### PR TITLE
[Phase 1C] Add authentication middleware

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy source code and Alembic config
+# Copy source code, tests, and Alembic config
 COPY src/ ./src/
+COPY tests/ ./tests/
 COPY alembic/ ./alembic/
 COPY alembic.ini .
 

--- a/src/middleware/__init__.py
+++ b/src/middleware/__init__.py
@@ -1,0 +1,10 @@
+"""
+Authentication middleware for FreshUp.
+
+Provides FastAPI dependencies for extracting and validating JWT tokens
+from request headers.
+"""
+
+from src.middleware.auth import get_current_user, get_current_user_optional
+
+__all__ = ["get_current_user", "get_current_user_optional"]

--- a/src/middleware/auth.py
+++ b/src/middleware/auth.py
@@ -1,0 +1,156 @@
+"""
+Authentication middleware for FreshUp.
+
+FastAPI dependencies for extracting and validating JWT tokens from request headers.
+Used by protected endpoints to identify the current user.
+"""
+
+from typing import Optional
+from uuid import UUID
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from sqlalchemy.orm import Session
+
+from src.db.database import get_db
+from src.db.models.user import User
+from src.services.auth_service import decode_token, TokenError
+
+
+# Bearer token scheme for extracting Authorization header
+security = HTTPBearer(auto_error=False)
+
+
+def get_current_user(
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+    db: Session = Depends(get_db),
+) -> User:
+    """
+    FastAPI dependency that extracts and validates JWT from Authorization header.
+
+    This dependency is used by protected endpoints to authenticate requests and
+    retrieve the current user. It fails closed: any authentication error returns 401.
+
+    Args:
+        credentials: Bearer token from Authorization header (injected by HTTPBearer)
+        db: Database session (injected by get_db)
+
+    Returns:
+        User object for the authenticated user
+
+    Raises:
+        HTTPException(401): If Authorization header is missing, token is invalid/expired,
+                           or user is not found in database
+
+    Example:
+        @app.get("/protected")
+        def protected_route(current_user: User = Depends(get_current_user)):
+            return {"user_id": str(current_user.id)}
+    """
+    # Check if Authorization header is present
+    if credentials is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    token = credentials.credentials
+
+    try:
+        # Decode and validate the JWT token
+        payload = decode_token(token)
+        user_id_str: str = payload.get("sub")
+
+        if user_id_str is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Not authenticated",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+        # Convert string user ID to UUID
+        try:
+            user_id = UUID(user_id_str)
+        except (ValueError, AttributeError):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Not authenticated",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+    except TokenError:
+        # TokenExpiredError or TokenInvalidError from decode_token
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    # Query database for user
+    user = db.query(User).filter(User.id == user_id).first()
+
+    if user is None:
+        # User ID in token is valid but user doesn't exist in database
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    return user
+
+
+def get_current_user_optional(
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+    db: Session = Depends(get_db),
+) -> Optional[User]:
+    """
+    FastAPI dependency that extracts and validates JWT, but returns None on failure.
+
+    This dependency is used by endpoints that enhance behavior when authenticated
+    but don't require authentication. For example, a public feed that shows
+    personalized content if the user is logged in.
+
+    Args:
+        credentials: Bearer token from Authorization header (injected by HTTPBearer)
+        db: Database session (injected by get_db)
+
+    Returns:
+        User object if authenticated, None otherwise
+
+    Example:
+        @app.get("/feed")
+        def feed(current_user: Optional[User] = Depends(get_current_user_optional)):
+            if current_user:
+                return {"message": f"Hello, {current_user.name}"}
+            return {"message": "Hello, guest"}
+    """
+    # If no credentials provided, return None (not authenticated)
+    if credentials is None:
+        return None
+
+    token = credentials.credentials
+
+    try:
+        # Decode and validate the JWT token
+        payload = decode_token(token)
+        user_id_str: str = payload.get("sub")
+
+        if user_id_str is None:
+            return None
+
+        # Convert string user ID to UUID
+        try:
+            user_id = UUID(user_id_str)
+        except (ValueError, AttributeError):
+            return None
+
+    except TokenError:
+        # TokenExpiredError or TokenInvalidError from decode_token
+        return None
+
+    # Query database for user
+    user = db.query(User).filter(User.id == user_id).first()
+
+    # Return user if found, None otherwise
+    return user

--- a/src/middleware/auth.py
+++ b/src/middleware/auth.py
@@ -59,7 +59,7 @@ def get_current_user(
     try:
         # Decode and validate the JWT token
         payload = decode_token(token)
-        user_id_str: str = payload.get("sub")
+        user_id_str: Optional[str] = payload.get("sub")
 
         if user_id_str is None:
             raise HTTPException(
@@ -134,7 +134,7 @@ def get_current_user_optional(
     try:
         # Decode and validate the JWT token
         payload = decode_token(token)
-        user_id_str: str = payload.get("sub")
+        user_id_str: Optional[str] = payload.get("sub")
 
         if user_id_str is None:
             return None

--- a/tests/middleware/__init__.py
+++ b/tests/middleware/__init__.py
@@ -1,0 +1,1 @@
+# Tests for authentication middleware

--- a/tests/middleware/test_auth.py
+++ b/tests/middleware/test_auth.py
@@ -1,0 +1,344 @@
+"""
+Unit tests for authentication middleware.
+
+Tests cover:
+- get_current_user: valid JWT, missing header, invalid/expired tokens, user not found
+- get_current_user_optional: same scenarios but returns None instead of 401
+"""
+
+import pytest
+import os
+from datetime import timedelta
+from uuid import uuid4, UUID
+from unittest.mock import Mock
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+
+# Set required environment variables for testing
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars")
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
+
+from src.middleware.auth import get_current_user, get_current_user_optional
+from src.services.auth_service import create_access_token
+from src.db.models.user import User, UserRole
+
+
+class TestGetCurrentUser:
+    """Tests for the get_current_user dependency."""
+
+    def test_get_current_user_with_valid_token_returns_user(self):
+        """Valid JWT should return User object from database."""
+        # Create a test user
+        user_id = uuid4()
+        test_user = User(
+            id=user_id,
+            name="Test User",
+            email="test@example.com",
+            role=UserRole.member.value,
+        )
+
+        # Create a valid token for this user
+        token = create_access_token({"sub": str(user_id)})
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+        # Mock database session
+        mock_db = Mock()
+        mock_query = mock_db.query.return_value
+        mock_filter = mock_query.filter.return_value
+        mock_filter.first.return_value = test_user
+
+        # Call the dependency
+        result = get_current_user(credentials=credentials, db=mock_db)
+
+        # Verify the user is returned
+        assert result == test_user
+        assert result.id == user_id
+        assert result.name == "Test User"
+
+        # Verify database query was called correctly
+        mock_db.query.assert_called_once_with(User)
+
+    def test_get_current_user_without_credentials_raises_401(self):
+        """Missing Authorization header should raise 401."""
+        mock_db = Mock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            get_current_user(credentials=None, db=mock_db)
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "Not authenticated"
+        assert exc_info.value.headers == {"WWW-Authenticate": "Bearer"}
+
+    def test_get_current_user_with_expired_token_raises_401(self):
+        """Expired JWT should raise 401."""
+        user_id = uuid4()
+        # Create an expired token (expired 1 second ago)
+        token = create_access_token(
+            {"sub": str(user_id)}, expires_delta=timedelta(seconds=-1)
+        )
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+        mock_db = Mock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            get_current_user(credentials=credentials, db=mock_db)
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "Not authenticated"
+        assert exc_info.value.headers == {"WWW-Authenticate": "Bearer"}
+
+    def test_get_current_user_with_invalid_token_raises_401(self):
+        """Invalid/malformed JWT should raise 401."""
+        credentials = HTTPAuthorizationCredentials(
+            scheme="Bearer", credentials="invalid.token.here"
+        )
+
+        mock_db = Mock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            get_current_user(credentials=credentials, db=mock_db)
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "Not authenticated"
+
+    def test_get_current_user_with_tampered_token_raises_401(self):
+        """JWT with invalid signature should raise 401."""
+        user_id = uuid4()
+        token = create_access_token({"sub": str(user_id)})
+
+        # Tamper with the signature
+        parts = token.split(".")
+        parts[-1] = parts[-1][:-4] + "XXXX"
+        tampered_token = ".".join(parts)
+
+        credentials = HTTPAuthorizationCredentials(
+            scheme="Bearer", credentials=tampered_token
+        )
+
+        mock_db = Mock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            get_current_user(credentials=credentials, db=mock_db)
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "Not authenticated"
+
+    def test_get_current_user_when_user_not_found_raises_401(self):
+        """Valid JWT but user not in database should raise 401."""
+        user_id = uuid4()
+        token = create_access_token({"sub": str(user_id)})
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+        # Mock database to return None (user not found)
+        mock_db = Mock()
+        mock_query = mock_db.query.return_value
+        mock_filter = mock_query.filter.return_value
+        mock_filter.first.return_value = None
+
+        with pytest.raises(HTTPException) as exc_info:
+            get_current_user(credentials=credentials, db=mock_db)
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "Not authenticated"
+        assert exc_info.value.headers == {"WWW-Authenticate": "Bearer"}
+
+    def test_get_current_user_with_invalid_uuid_in_token_raises_401(self):
+        """JWT with invalid UUID in 'sub' claim should raise 401."""
+        token = create_access_token({"sub": "not-a-valid-uuid"})
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+        mock_db = Mock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            get_current_user(credentials=credentials, db=mock_db)
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "Not authenticated"
+
+    def test_get_current_user_with_missing_sub_claim_raises_401(self):
+        """JWT missing 'sub' claim should raise 401."""
+        # This should be caught by decode_token, but testing defense in depth
+        # We can't easily create a token without 'sub' using create_access_token,
+        # but we test that the middleware handles it
+        user_id = uuid4()
+        token = create_access_token({"sub": str(user_id)})
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+        mock_db = Mock()
+        mock_query = mock_db.query.return_value
+        mock_filter = mock_query.filter.return_value
+        mock_filter.first.return_value = None
+
+        # Simulate the user not found scenario (closest we can get to missing sub)
+        with pytest.raises(HTTPException) as exc_info:
+            get_current_user(credentials=credentials, db=mock_db)
+
+        assert exc_info.value.status_code == 401
+
+
+class TestGetCurrentUserOptional:
+    """Tests for the get_current_user_optional dependency."""
+
+    def test_get_current_user_optional_with_valid_token_returns_user(self):
+        """Valid JWT should return User object."""
+        user_id = uuid4()
+        test_user = User(
+            id=user_id,
+            name="Test User",
+            email="test@example.com",
+            role=UserRole.member.value,
+        )
+
+        token = create_access_token({"sub": str(user_id)})
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+        # Mock database session
+        mock_db = Mock()
+        mock_query = mock_db.query.return_value
+        mock_filter = mock_query.filter.return_value
+        mock_filter.first.return_value = test_user
+
+        result = get_current_user_optional(credentials=credentials, db=mock_db)
+
+        assert result == test_user
+        assert result.id == user_id
+
+    def test_get_current_user_optional_without_credentials_returns_none(self):
+        """Missing Authorization header should return None."""
+        mock_db = Mock()
+
+        result = get_current_user_optional(credentials=None, db=mock_db)
+
+        assert result is None
+
+    def test_get_current_user_optional_with_expired_token_returns_none(self):
+        """Expired JWT should return None."""
+        user_id = uuid4()
+        token = create_access_token(
+            {"sub": str(user_id)}, expires_delta=timedelta(seconds=-1)
+        )
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+        mock_db = Mock()
+
+        result = get_current_user_optional(credentials=credentials, db=mock_db)
+
+        assert result is None
+
+    def test_get_current_user_optional_with_invalid_token_returns_none(self):
+        """Invalid/malformed JWT should return None."""
+        credentials = HTTPAuthorizationCredentials(
+            scheme="Bearer", credentials="invalid.token.here"
+        )
+
+        mock_db = Mock()
+
+        result = get_current_user_optional(credentials=credentials, db=mock_db)
+
+        assert result is None
+
+    def test_get_current_user_optional_with_tampered_token_returns_none(self):
+        """JWT with invalid signature should return None."""
+        user_id = uuid4()
+        token = create_access_token({"sub": str(user_id)})
+
+        # Tamper with the signature
+        parts = token.split(".")
+        parts[-1] = parts[-1][:-4] + "XXXX"
+        tampered_token = ".".join(parts)
+
+        credentials = HTTPAuthorizationCredentials(
+            scheme="Bearer", credentials=tampered_token
+        )
+
+        mock_db = Mock()
+
+        result = get_current_user_optional(credentials=credentials, db=mock_db)
+
+        assert result is None
+
+    def test_get_current_user_optional_when_user_not_found_returns_none(self):
+        """Valid JWT but user not in database should return None."""
+        user_id = uuid4()
+        token = create_access_token({"sub": str(user_id)})
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+        # Mock database to return None (user not found)
+        mock_db = Mock()
+        mock_query = mock_db.query.return_value
+        mock_filter = mock_query.filter.return_value
+        mock_filter.first.return_value = None
+
+        result = get_current_user_optional(credentials=credentials, db=mock_db)
+
+        assert result is None
+
+    def test_get_current_user_optional_with_invalid_uuid_returns_none(self):
+        """JWT with invalid UUID in 'sub' claim should return None."""
+        token = create_access_token({"sub": "not-a-valid-uuid"})
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+        mock_db = Mock()
+
+        result = get_current_user_optional(credentials=credentials, db=mock_db)
+
+        assert result is None
+
+
+class TestAuthMiddlewareIntegration:
+    """Integration tests comparing behavior of both dependencies."""
+
+    def test_same_token_both_dependencies_consistent(self):
+        """Both dependencies should handle the same valid token consistently."""
+        user_id = uuid4()
+        test_user = User(
+            id=user_id,
+            name="Integration Test User",
+            email="integration@example.com",
+            role=UserRole.coordinator.value,
+        )
+
+        token = create_access_token({"sub": str(user_id)})
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+        # Mock database
+        mock_db = Mock()
+        mock_query = mock_db.query.return_value
+        mock_filter = mock_query.filter.return_value
+        mock_filter.first.return_value = test_user
+
+        # Both should return the same user
+        result1 = get_current_user(credentials=credentials, db=mock_db)
+        result2 = get_current_user_optional(credentials=credentials, db=mock_db)
+
+        assert result1 == result2
+        assert result1.id == user_id
+
+    def test_error_handling_differs_between_dependencies(self):
+        """get_current_user raises 401, get_current_user_optional returns None."""
+        credentials = HTTPAuthorizationCredentials(
+            scheme="Bearer", credentials="invalid.token"
+        )
+        mock_db = Mock()
+
+        # get_current_user should raise
+        with pytest.raises(HTTPException) as exc_info:
+            get_current_user(credentials=credentials, db=mock_db)
+        assert exc_info.value.status_code == 401
+
+        # get_current_user_optional should return None
+        result = get_current_user_optional(credentials=credentials, db=mock_db)
+        assert result is None
+
+    def test_no_credentials_differs_between_dependencies(self):
+        """get_current_user raises 401, get_current_user_optional returns None."""
+        mock_db = Mock()
+
+        # get_current_user should raise
+        with pytest.raises(HTTPException) as exc_info:
+            get_current_user(credentials=None, db=mock_db)
+        assert exc_info.value.status_code == 401
+
+        # get_current_user_optional should return None
+        result = get_current_user_optional(credentials=None, db=mock_db)
+        assert result is None

--- a/tests/middleware/test_auth.py
+++ b/tests/middleware/test_auth.py
@@ -7,20 +7,27 @@ Tests cover:
 """
 
 import pytest
-import os
 from datetime import timedelta
 from uuid import uuid4, UUID
 from unittest.mock import Mock
 from fastapi import HTTPException
 from fastapi.security import HTTPAuthorizationCredentials
 
-# Set required environment variables for testing
-os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars")
-os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
-
 from src.middleware.auth import get_current_user, get_current_user_optional
 from src.services.auth_service import create_access_token
 from src.db.models.user import User, UserRole
+
+
+@pytest.fixture(autouse=True)
+def setup_test_env(monkeypatch):
+    """
+    Pytest fixture to set up test environment variables.
+
+    Uses monkeypatch to ensure clean setup/teardown and prevent test pollution.
+    autouse=True means this fixture runs automatically for all tests in this module.
+    """
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars")
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///./test.db")
 
 
 class TestGetCurrentUser:

--- a/tests/middleware/test_auth.py
+++ b/tests/middleware/test_auth.py
@@ -27,7 +27,7 @@ def setup_test_env(monkeypatch):
     autouse=True means this fixture runs automatically for all tests in this module.
     """
     monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars")
-    monkeypatch.setenv("DATABASE_URL", "sqlite:///./test.db")
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
 
 
 class TestGetCurrentUser:


### PR DESCRIPTION
## Work in Progress

Closes #4

[Phase 1C] Add authentication middleware

## Labels
`phase-1`, `backend`, `priority-high`

## Time Estimate
45min

## Description
Create FastAPI dependency for extracting and validating JWT from request headers. This middleware will be used by all protected endpoints to identify the current user. Returns 401 for missing/invalid tokens.

## Claude Context
Files to Read:
- `src/services/auth_service.py` (JWT utilities)
- `src/db/models/user.py` (User model)
- `src/db/database.py` (get_db dependency)
- `src/main.py` (existing app structure)
- `docker-compose.yml` (dev environment — all commands run via docker compose exec)

Files to Modify:
- `src/middleware/auth.py` (create)
- `src/middleware/__init__.py` (create)

Related Issues: #3

## Acceptance Criteria
- [ ] get_current_user dependency extracts user from valid JWT: unit test
- [ ] Returns 401 HTTPException for missing Authorization header: unit test
- [ ] Returns 401 HTTPException for invalid/expired token: unit test
- [ ] Returns 401 HTTPException if user not found in database: unit test
- [ ] Optional get_current_user_optional returns None instead of 401: unit test

## Verification Commands
```bash
docker compose build api
docker compose up -d api
docker compose exec api python -c "
from src.middleware.auth import get_current_user, get_current_user_optional
print('Auth middleware imports OK')
"
```

## Done Definition
Done when get_current_user dependency correctly validates JWT and returns User object or raises 401.

## Scope Boundary
- DO: create get_current_user FastAPI dependency
- DO: create get_current_user_optional for endpoints that work with or without auth
- DO: use Bearer token scheme in Authorization header
- DO NOT: implement role-based authorization yet (separate issue)
- DO NOT: add endpoints yet
- DO NOT: create a local .venv — all commands run inside Docker

## Dependencies
After: #3

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**5** files, **2** commits (+4 added, ~1 modified, -0 deleted)
- `M` Dockerfile
- `A` src/middleware/__init__.py
- `A` src/middleware/auth.py
- `A` tests/middleware/__init__.py
- `A` tests/middleware/test_auth.py

### Commits
- 59793b1 feat: [Phase 1C] Add authentication middleware
- f80dbde chore: initialize work on #4 [Phase 1C] Add authentication middleware
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues
 Updated: #17 Created: #18 
**From assessment on 2026-03-17T04:06:29Z:**
- Created: #17 
- Updated: none