### PR TITLE
Implement user profile endpoints GET/PUT /auth/me

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ passlib[bcrypt]==1.7.4
 # bcrypt pinned to 4.2.1 for passlib 1.7.4 compatibility (passlib has known issues with bcrypt 5.x)
 bcrypt==4.2.1
 pytest==8.3.4
+httpx==0.28.1

--- a/src/routers/auth.py
+++ b/src/routers/auth.py
@@ -10,8 +10,9 @@ from sqlalchemy import func
 
 from src.db.database import get_db
 from src.db.models.user import User, UserRole
-from src.schemas.auth import UserCreate, LoginRequest, UserResponse, TokenResponse
+from src.schemas.auth import UserCreate, LoginRequest, UserResponse, TokenResponse, UserUpdate
 from src.services.auth_service import hash_password, verify_password, create_access_token
+from src.middleware.auth import get_current_user
 
 
 # Pre-computed valid bcrypt hash for timing attack mitigation
@@ -121,3 +122,60 @@ def login(login_data: LoginRequest, db: Session = Depends(get_db)):
     access_token = create_access_token(data={"sub": str(user.id)})
 
     return TokenResponse(access_token=access_token, token_type="bearer")
+
+
+@router.get("/me", response_model=UserResponse)
+def get_current_user_profile(current_user: User = Depends(get_current_user)):
+    """
+    Get the authenticated user's profile.
+
+    Returns the full user profile for the authenticated user. Requires a valid
+    JWT token in the Authorization header.
+
+    Args:
+        current_user: Authenticated user (injected by get_current_user dependency)
+
+    Returns:
+        UserResponse: User profile data (excluding password)
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+    """
+    return current_user
+
+
+@router.put("/me", response_model=UserResponse)
+def update_current_user_profile(
+    update_data: UserUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    Update the authenticated user's profile.
+
+    Allows users to update their own profile information including name, dietary
+    preferences, allergies, and ingredient preferences. Email and role updates
+    are not permitted through this endpoint.
+
+    Args:
+        update_data: Profile fields to update (all fields optional)
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        UserResponse: Updated user profile data (excluding password)
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(422): If validation fails (invalid dietary profile, empty name, etc.)
+    """
+    # Update only the fields that were provided (partial updates)
+    update_dict = update_data.model_dump(exclude_unset=True)
+
+    for field, value in update_dict.items():
+        setattr(current_user, field, value)
+
+    db.commit()
+    db.refresh(current_user)
+
+    return current_user

--- a/src/routers/auth.py
+++ b/src/routers/auth.py
@@ -4,6 +4,7 @@ Authentication endpoints for FreshUp.
 Provides user registration and login endpoints with JWT token generation.
 """
 
+import logging
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 from sqlalchemy import func
@@ -13,6 +14,8 @@ from src.db.models.user import User, UserRole
 from src.schemas.auth import UserCreate, LoginRequest, UserResponse, TokenResponse, UserUpdate
 from src.services.auth_service import hash_password, verify_password, create_access_token
 from src.middleware.auth import get_current_user
+
+logger = logging.getLogger(__name__)
 
 
 # Pre-computed valid bcrypt hash for timing attack mitigation
@@ -179,11 +182,22 @@ def update_current_user_profile(
         "favorite_ingredients"
     }
 
+    PROTECTED_FIELDS = {"email", "role"}
+
     # Update only the fields that were provided (partial updates)
     update_dict = update_data.model_dump(exclude_unset=True)
 
     for field, value in update_dict.items():
         if field not in ALLOWED_UPDATE_FIELDS:
+            # Log attempts to modify protected fields for security monitoring
+            if field in PROTECTED_FIELDS:
+                logger.warning(
+                    "Attempted modification of protected field '%s' by user %s (email: %s). "
+                    "This may indicate a privilege escalation attempt.",
+                    field,
+                    current_user.id,
+                    current_user.email
+                )
             # Silently skip disallowed fields for defense-in-depth
             continue
         setattr(current_user, field, value)

--- a/src/routers/auth.py
+++ b/src/routers/auth.py
@@ -169,10 +169,23 @@ def update_current_user_profile(
         HTTPException(401): If Authorization header is missing or token is invalid
         HTTPException(422): If validation fails (invalid dietary profile, empty name, etc.)
     """
+    # Explicit allowlist of fields that can be updated via this endpoint
+    # Security: role and email can NEVER be updated here to prevent privilege escalation
+    ALLOWED_UPDATE_FIELDS = {
+        "name",
+        "dietary_profile",
+        "allergies",
+        "disliked_ingredients",
+        "favorite_ingredients"
+    }
+
     # Update only the fields that were provided (partial updates)
     update_dict = update_data.model_dump(exclude_unset=True)
 
     for field, value in update_dict.items():
+        if field not in ALLOWED_UPDATE_FIELDS:
+            # Silently skip disallowed fields for defense-in-depth
+            continue
         setattr(current_user, field, value)
 
     db.commit()

--- a/src/schemas/auth.py
+++ b/src/schemas/auth.py
@@ -7,7 +7,7 @@ Defines request/response models for user registration and login.
 from uuid import UUID
 from typing import Optional
 from pydantic import BaseModel, EmailStr, Field, field_validator
-from src.db.models.user import UserRole
+from src.db.models.user import UserRole, DietaryProfile
 
 
 class UserCreate(BaseModel):
@@ -80,6 +80,35 @@ class UserResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class UserUpdate(BaseModel):
+    """Request schema for updating user profile via PUT /auth/me."""
+
+    name: Optional[str] = Field(default=None, min_length=1, max_length=255, description="User's display name")
+    dietary_profile: Optional[list[str]] = Field(default=None, description="Dietary preferences")
+    allergies: Optional[list[str]] = Field(default=None, description="Food allergies")
+    disliked_ingredients: Optional[list[str]] = Field(default=None, description="Disliked ingredients (stored as JSON array)")
+    favorite_ingredients: Optional[list[str]] = Field(default=None, description="Favorite ingredients (stored as JSON array)")
+
+    @field_validator('name')
+    @classmethod
+    def validate_name_not_empty(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure name is not empty or whitespace only if provided."""
+        if v is not None and (not v or not v.strip()):
+            raise ValueError('Name cannot be empty')
+        return v.strip() if v else None
+
+    @field_validator('dietary_profile')
+    @classmethod
+    def validate_dietary_profile(cls, v: Optional[list[str]]) -> Optional[list[str]]:
+        """Ensure dietary_profile contains valid DietaryProfile enum values."""
+        if v is not None:
+            valid_profiles = [profile.value for profile in DietaryProfile]
+            for profile in v:
+                if profile not in valid_profiles:
+                    raise ValueError(f'Invalid dietary profile: {profile}. Must be one of: {", ".join(valid_profiles)}')
+        return v
 
 
 class TokenResponse(BaseModel):

--- a/src/schemas/auth.py
+++ b/src/schemas/auth.py
@@ -5,8 +5,8 @@ Defines request/response models for user registration and login.
 """
 
 from uuid import UUID
-from typing import Optional
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from typing import Optional, Any
+from pydantic import BaseModel, EmailStr, Field, field_validator, model_validator
 from src.db.models.user import UserRole, DietaryProfile
 
 
@@ -109,6 +109,26 @@ class UserUpdate(BaseModel):
                 if profile not in valid_profiles:
                     raise ValueError(f'Invalid dietary profile: {profile}. Must be one of: {", ".join(valid_profiles)}')
         return v
+
+    @model_validator(mode='before')
+    @classmethod
+    def reject_protected_fields(cls, data: Any) -> Any:
+        """
+        Explicitly reject attempts to modify protected fields.
+
+        Protected fields (email, role) can only be modified through dedicated
+        administrative endpoints, not through the user profile update endpoint.
+        This provides defense-in-depth and clear error messages for API consumers.
+        """
+        if isinstance(data, dict):
+            protected_fields = {'email', 'role'}
+            submitted_protected = protected_fields.intersection(data.keys())
+            if submitted_protected:
+                raise ValueError(
+                    f"Cannot modify protected fields: {', '.join(sorted(submitted_protected))}. "
+                    f"These fields cannot be updated through this endpoint."
+                )
+        return data
 
 
 class TokenResponse(BaseModel):

--- a/src/schemas/auth.py
+++ b/src/schemas/auth.py
@@ -102,12 +102,23 @@ class UserUpdate(BaseModel):
     @field_validator('dietary_profile')
     @classmethod
     def validate_dietary_profile(cls, v: Optional[list[str]]) -> Optional[list[str]]:
-        """Ensure dietary_profile contains valid DietaryProfile enum values."""
+        """Ensure dietary_profile contains valid DietaryProfile enum values and strip whitespace."""
         if v is not None:
+            # Strip whitespace from each item
+            v = [item.strip() for item in v if item.strip()]
             valid_profiles = [profile.value for profile in DietaryProfile]
             for profile in v:
                 if profile not in valid_profiles:
                     raise ValueError(f'Invalid dietary profile: {profile}. Must be one of: {", ".join(valid_profiles)}')
+        return v
+
+    @field_validator('allergies', 'disliked_ingredients', 'favorite_ingredients')
+    @classmethod
+    def strip_whitespace_from_list_items(cls, v: Optional[list[str]]) -> Optional[list[str]]:
+        """Strip whitespace from list items to ensure data consistency."""
+        if v is not None:
+            # Strip whitespace from each item and filter out empty strings
+            v = [item.strip() for item in v if item.strip()]
         return v
 
     @model_validator(mode='before')

--- a/tests/routers/__init__.py
+++ b/tests/routers/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for API routers."""

--- a/tests/routers/test_auth.py
+++ b/tests/routers/test_auth.py
@@ -141,6 +141,18 @@ class TestGetProfile:
         assert response.status_code == 401
         assert "detail" in response.json()
 
+    def test_get_profile_nonexistent_user(self, client):
+        """GET /auth/me returns 401 when token references deleted/non-existent user."""
+        # Create a token for a user ID that doesn't exist in the database
+        nonexistent_user_id = uuid4()
+        token = create_access_token(data={"sub": str(nonexistent_user_id)})
+        headers = {"Authorization": f"Bearer {token}"}
+
+        response = client.get("/auth/me", headers=headers)
+
+        assert response.status_code == 401
+        assert "detail" in response.json()
+
     def test_get_profile_success(self, client, test_user, auth_headers):
         """GET /auth/me returns profile with valid token."""
         response = client.get("/auth/me", headers=auth_headers)
@@ -328,33 +340,31 @@ class TestUpdateProfile:
         db_session.refresh(test_user)
         assert test_user.dietary_profile == valid_profiles
 
-    def test_update_profile_ignores_protected_fields(self, client, test_user, auth_headers, db_session):
-        """PUT /auth/me ignores attempts to modify email or role (protected fields)."""
+    def test_update_profile_rejects_protected_fields(self, client, test_user, auth_headers, db_session):
+        """PUT /auth/me returns 422 when attempting to modify email or role (protected fields)."""
         original_email = test_user.email
         original_role = test_user.role
+        original_name = test_user.name
 
         # Attempt to update protected fields along with allowed fields
         update_data = {
             "name": "Updated Name",
-            "email": "hacker@evil.com",  # Should be ignored
-            "role": "admin",  # Should be ignored
+            "email": "hacker@evil.com",  # Should be rejected
+            "role": "admin",  # Should be rejected
         }
 
         response = client.put("/auth/me", json=update_data, headers=auth_headers)
 
-        # Request should succeed but protected fields should be unchanged
-        assert response.status_code == 200
-        data = response.json()
+        # Request should fail with validation error
+        assert response.status_code == 422
+        error_data = response.json()
+        assert "detail" in error_data
+        # Verify error message mentions protected fields
+        error_msg = str(error_data["detail"])
+        assert "protected" in error_msg.lower() or "email" in error_msg.lower() or "role" in error_msg.lower()
 
-        # Verify allowed field was updated
-        assert data["name"] == "Updated Name"
-
-        # Verify protected fields remain unchanged in response
-        assert data["email"] == original_email
-        assert data["role"] == original_role
-
-        # Verify database state - protected fields remain unchanged
+        # Verify database state - nothing should have changed (including the name field)
         db_session.refresh(test_user)
         assert test_user.email == original_email
         assert test_user.role == original_role
-        assert test_user.name == "Updated Name"
+        assert test_user.name == original_name  # Name should also be unchanged since the request was rejected

--- a/tests/routers/test_auth.py
+++ b/tests/routers/test_auth.py
@@ -308,3 +308,34 @@ class TestUpdateProfile:
         # Verify database state
         db_session.refresh(test_user)
         assert test_user.dietary_profile == valid_profiles
+
+    def test_update_profile_ignores_protected_fields(self, client, test_user, auth_headers, db_session):
+        """PUT /auth/me ignores attempts to modify email or role (protected fields)."""
+        original_email = test_user.email
+        original_role = test_user.role
+
+        # Attempt to update protected fields along with allowed fields
+        update_data = {
+            "name": "Updated Name",
+            "email": "hacker@evil.com",  # Should be ignored
+            "role": "admin",  # Should be ignored
+        }
+
+        response = client.put("/auth/me", json=update_data, headers=auth_headers)
+
+        # Request should succeed but protected fields should be unchanged
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify allowed field was updated
+        assert data["name"] == "Updated Name"
+
+        # Verify protected fields remain unchanged in response
+        assert data["email"] == original_email
+        assert data["role"] == original_role
+
+        # Verify database state - protected fields remain unchanged
+        db_session.refresh(test_user)
+        assert test_user.email == original_email
+        assert test_user.role == original_role
+        assert test_user.name == "Updated Name"

--- a/tests/routers/test_auth.py
+++ b/tests/routers/test_auth.py
@@ -1,0 +1,310 @@
+"""
+Integration tests for authentication endpoints.
+
+Tests cover:
+- GET /auth/me: unauthorized access and successful profile retrieval
+- PUT /auth/me: partial updates and validation errors
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from uuid import uuid4
+
+from src.db.database import Base, get_db
+from src.db import models  # Import all models to ensure Base.metadata has all tables
+from src.db.models.user import User, UserRole
+from src.services.auth_service import hash_password, create_access_token
+
+# Import router directly and create a test app without lifespan
+from fastapi import FastAPI
+from src.routers import auth_router
+
+# Create a test app without lifespan
+app = FastAPI(
+    title="FreshUp",
+    description="Privacy-first kitchen management system",
+    version="0.1.0",
+)
+
+# Register the auth router
+app.include_router(auth_router)
+
+
+# Create an in-memory SQLite database for testing
+TEST_DATABASE_URL = "sqlite:///:memory:"
+
+
+@pytest.fixture(autouse=True)
+def setup_test_env(monkeypatch):
+    """
+    Set up test environment variables.
+
+    Uses monkeypatch to ensure clean setup/teardown and prevent test pollution.
+    autouse=True means this fixture runs automatically for all tests in this module.
+    """
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars")
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+    monkeypatch.setenv("ENVIRONMENT", "test")
+
+
+@pytest.fixture
+def db_session():
+    """Create a fresh database session for each test."""
+    from sqlalchemy.pool import StaticPool
+
+    # Ensure all models are imported by accessing them
+    _ = models  # This forces the import of all models
+
+    # Create a new engine with StaticPool to ensure all connections share the same in-memory database
+    engine = create_engine(
+        TEST_DATABASE_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,  # Critical for SQLite :memory: to work correctly
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+@pytest.fixture
+def client(db_session):
+    """Create a test client with database dependency override."""
+    # FastAPI caches dependency results within a single request
+    # We need to ensure get_db returns the same session for the entire request
+    def override_get_db():
+        try:
+            # Important: yield the same session for all dependencies in one request
+            yield db_session
+        finally:
+            # Don't close here - the fixture will handle it
+            pass
+
+    app.dependency_overrides[get_db] = override_get_db
+    # Create test client
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def test_user(db_session):
+    """Create a test user in the database."""
+    user = User(
+        id=uuid4(),
+        name="Test User",
+        email="test@example.com",
+        hashed_password=hash_password("testpassword123"),
+        role=UserRole.member.value,
+        dietary_profile=["vegetarian"],
+        allergies=["peanuts"],
+        disliked_ingredients=["cilantro"],
+        favorite_ingredients=["tomatoes"],
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def auth_headers(test_user):
+    """Create authentication headers with a valid JWT token."""
+    token = create_access_token(data={"sub": str(test_user.id)})
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestGetProfile:
+    """Tests for GET /auth/me endpoint."""
+
+    def test_get_profile_unauthorized(self, client):
+        """GET /auth/me returns 401 without auth."""
+        response = client.get("/auth/me")
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Not authenticated"
+
+    def test_get_profile_success(self, client, test_user, auth_headers):
+        """GET /auth/me returns profile with valid token."""
+        response = client.get("/auth/me", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify response schema
+        assert "id" in data
+        assert "name" in data
+        assert "email" in data
+        assert "role" in data
+        assert "dietary_profile" in data
+        assert "allergies" in data
+        assert "disliked_ingredients" in data
+        assert "favorite_ingredients" in data
+
+        # Verify response data matches test user
+        assert data["id"] == str(test_user.id)
+        assert data["name"] == "Test User"
+        assert data["email"] == "test@example.com"
+        assert data["role"] == "member"
+        assert data["dietary_profile"] == ["vegetarian"]
+        assert data["allergies"] == ["peanuts"]
+        assert data["disliked_ingredients"] == ["cilantro"]
+        assert data["favorite_ingredients"] == ["tomatoes"]
+
+        # Verify password is not included in response
+        assert "password" not in data
+        assert "hashed_password" not in data
+
+
+class TestUpdateProfile:
+    """Tests for PUT /auth/me endpoint."""
+
+    def test_update_profile_partial(self, client, test_user, auth_headers, db_session):
+        """PUT /auth/me updates allowed fields."""
+        update_data = {
+            "name": "Updated Name",
+            "dietary_profile": ["vegan", "keto"],
+            "allergies": ["shellfish", "dairy"],
+            "disliked_ingredients": ["onions", "garlic"],
+            "favorite_ingredients": ["avocado", "spinach"],
+        }
+
+        response = client.put("/auth/me", json=update_data, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify updated fields in response
+        assert data["name"] == "Updated Name"
+        assert data["dietary_profile"] == ["vegan", "keto"]
+        assert data["allergies"] == ["shellfish", "dairy"]
+        assert data["disliked_ingredients"] == ["onions", "garlic"]
+        assert data["favorite_ingredients"] == ["avocado", "spinach"]
+
+        # Verify unchanged fields
+        assert data["id"] == str(test_user.id)
+        assert data["email"] == "test@example.com"
+        assert data["role"] == "member"
+
+        # Verify database state was updated
+        db_session.refresh(test_user)
+        assert test_user.name == "Updated Name"
+        assert test_user.dietary_profile == ["vegan", "keto"]
+        assert test_user.allergies == ["shellfish", "dairy"]
+        assert test_user.disliked_ingredients == ["onions", "garlic"]
+        assert test_user.favorite_ingredients == ["avocado", "spinach"]
+
+    def test_update_profile_invalid_dietary(self, client, test_user, auth_headers):
+        """PUT /auth/me rejects invalid dietary profiles."""
+        update_data = {
+            "dietary_profile": ["invalid_diet", "another_invalid"],
+        }
+
+        response = client.put("/auth/me", json=update_data, headers=auth_headers)
+
+        assert response.status_code == 422
+        error_detail = response.json()["detail"]
+
+        # Verify error message mentions invalid dietary profile
+        assert any("dietary_profile" in str(err).lower() for err in error_detail)
+
+    def test_update_profile_partial_name_only(self, client, test_user, auth_headers, db_session):
+        """PUT /auth/me supports partial updates (name only)."""
+        update_data = {"name": "Just Name Update"}
+
+        response = client.put("/auth/me", json=update_data, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify only name was updated
+        assert data["name"] == "Just Name Update"
+        assert data["dietary_profile"] == ["vegetarian"]  # unchanged
+        assert data["allergies"] == ["peanuts"]  # unchanged
+
+        # Verify database state
+        db_session.refresh(test_user)
+        assert test_user.name == "Just Name Update"
+        assert test_user.dietary_profile == ["vegetarian"]
+
+    def test_update_profile_empty_name_rejected(self, client, test_user, auth_headers):
+        """PUT /auth/me rejects empty name."""
+        update_data = {"name": "   "}
+
+        response = client.put("/auth/me", json=update_data, headers=auth_headers)
+
+        assert response.status_code == 422
+        error_detail = response.json()["detail"]
+
+        # Verify error message mentions name validation
+        assert any("name" in str(err).lower() for err in error_detail)
+
+    def test_update_profile_unauthorized(self, client):
+        """PUT /auth/me returns 401 without auth."""
+        update_data = {"name": "Should Fail"}
+
+        response = client.put("/auth/me", json=update_data)
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Not authenticated"
+
+    def test_update_profile_empty_lists(self, client, test_user, auth_headers, db_session):
+        """PUT /auth/me allows clearing lists with empty arrays."""
+        update_data = {
+            "dietary_profile": [],
+            "allergies": [],
+            "disliked_ingredients": [],
+            "favorite_ingredients": [],
+        }
+
+        response = client.put("/auth/me", json=update_data, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify lists were cleared
+        assert data["dietary_profile"] == []
+        assert data["allergies"] == []
+        assert data["disliked_ingredients"] == []
+        assert data["favorite_ingredients"] == []
+
+        # Verify database state
+        db_session.refresh(test_user)
+        assert test_user.dietary_profile == []
+        assert test_user.allergies == []
+        assert test_user.disliked_ingredients == []
+        assert test_user.favorite_ingredients == []
+
+    def test_update_profile_valid_dietary_profiles(self, client, test_user, auth_headers, db_session):
+        """PUT /auth/me accepts all valid dietary profiles."""
+        valid_profiles = [
+            "omnivore",
+            "vegetarian",
+            "vegan",
+            "pescatarian",
+            "keto",
+            "low_carb",
+            "low_sugar",
+        ]
+
+        update_data = {"dietary_profile": valid_profiles}
+
+        response = client.put("/auth/me", json=update_data, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify all profiles were accepted
+        assert data["dietary_profile"] == valid_profiles
+
+        # Verify database state
+        db_session.refresh(test_user)
+        assert test_user.dietary_profile == valid_profiles

--- a/tests/routers/test_auth.py
+++ b/tests/routers/test_auth.py
@@ -132,6 +132,15 @@ class TestGetProfile:
         assert response.status_code == 401
         assert response.json()["detail"] == "Not authenticated"
 
+    def test_get_profile_invalid_token(self, client):
+        """GET /auth/me returns 401 with invalid/malformed JWT token."""
+        # Test with malformed token
+        invalid_headers = {"Authorization": "Bearer invalid.token.here"}
+        response = client.get("/auth/me", headers=invalid_headers)
+
+        assert response.status_code == 401
+        assert "detail" in response.json()
+
     def test_get_profile_success(self, client, test_user, auth_headers):
         """GET /auth/me returns profile with valid token."""
         response = client.get("/auth/me", headers=auth_headers)
@@ -255,6 +264,16 @@ class TestUpdateProfile:
 
         assert response.status_code == 401
         assert response.json()["detail"] == "Not authenticated"
+
+    def test_update_profile_invalid_token(self, client):
+        """PUT /auth/me returns 401 with invalid/malformed JWT token."""
+        update_data = {"name": "Should Fail"}
+        invalid_headers = {"Authorization": "Bearer invalid.token.here"}
+
+        response = client.put("/auth/me", json=update_data, headers=invalid_headers)
+
+        assert response.status_code == 401
+        assert "detail" in response.json()
 
     def test_update_profile_empty_lists(self, client, test_user, auth_headers, db_session):
         """PUT /auth/me allows clearing lists with empty arrays."""


### PR DESCRIPTION
## Work in Progress

Closes #7

Implement user profile endpoints GET/PUT /auth/me

## Labels
`phase-1`, `backend`, `priority-medium`

## Time Estimate
1hr

## Description
Create GET /auth/me and PUT /auth/me endpoints. GET returns the authenticated user's full profile. PUT allows updating profile fields including dietary preferences, allergies, and ingredient preferences.

**Storage strategy for disliked_ingredients and favorite_ingredients:** The ADR defines these as FK[] to Ingredient entities, but Ingredient entities won't exist until Phase 1E (Recipe Management). For Phase 1C, store these as JSON arrays of strings (e.g., `["broccoli", "cilantro"]`). When 1E introduces the Ingredient model, a migration will formalize these into proper FK relationships. The issue implementing that migration should live in 1E's issue set. The PUT endpoint schema should accept string arrays now, and the field names should match the ADR (`disliked_ingredients`, `favorite_ingredients`) so the API contract doesn't change later — only the storage backing changes.

**preferred_substitutions is out of scope** for this issue — it has its own entity (SubstitutionPreference) with separate CRUD needs. See #13.

**Backend-only scope:** No frontend UI in this issue.

## Claude Context
Files to Read:
- `src/routers/auth.py` (existing auth endpoints from #5)
- `src/middleware/auth.py` (get_current_user dependency from #4)
- `src/schemas/auth.py` (existing schemas from #5)
- `src/db/models/user.py` (User model — check current field types)
- `docs/FreshUp-ADR.md` (Section 4.1 User fields)
- `docker-compose.yml` (dev environment — all commands run via docker compose exec)

Files to Modify:
- `src/routers/auth.py` (add /me endpoints)
- `src/schemas/auth.py` (add UserUpdate schema)

Related Issues: #5, #13

## Acceptance Criteria
- [ ] GET /auth/me returns current user profile with valid token: test with Bearer token
- [ ] GET /auth/me returns 401 without token: test without auth header
- [ ] Response excludes hashed_password: verify response schema
- [ ] PUT /auth/me updates name: test update
- [ ] PUT /auth/me updates dietary_profile (enum array): test update
- [ ] PUT /auth/me updates allergies (string array): test update
- [ ] PUT /auth/me updates disliked_ingredients (string array, stored as JSON): test update
- [ ] PUT /auth/me updates favorite_ingredients (string array, stored as JSON): test update
- [ ] PUT /auth/me rejects attempts to update email: verify excluded from UserUpdate schema
- [ ] PUT /auth/me rejects attempts to self-promote role: verify excluded from UserUpdate schema
- [ ] All updated fields persist and appear in subsequent GET /auth/me: round-trip test

## Verification Commands
```bash
docker compose build api
docker compose up -d

# Get token
TOKEN=$(curl -s -X POST http://localhost:8000/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"first@example.com","password":"SecurePass123!"}' | jq -r .access_token)

# Get profile
curl -H "Authorization: Bearer $TOKEN" http://localhost:8000/auth/me

# Update dietary preferences
curl -X PUT -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  http://localhost:8000/auth/me \
  -d '{"dietary_profile":["vegan","low_sugar"],"allergies":["gluten","tree nuts"],"disliked_ingredients":["cilantro","olives"],"favorite_ingredients":["garlic","sweet potato"]}'

# Verify round-trip
curl -H "Authorization: Bearer $TOKEN" http://localhost:8000/auth/me
```

## Done Definition
Done when authenticated users can view and update their dietary preferences, allergies, and ingredient likes/dislikes via /auth/me endpoints, with string-array storage for ingredient fields.

## Scope Boundary
- DO: create GET /auth/me and PUT /auth/me endpoints
- DO: allow updating name, dietary_profile, allergies, disliked_ingredients, favorite_ingredients
- DO: store disliked_ingredients and favorite_ingredients as JSON string arrays (FK migration deferred to 1E)
- DO: return full user profile in response (excluding hashed_password)
- DO NOT: allow updating email (requires verification flow)
- DO NOT: allow self-promotion to coordinator role
- DO NOT: implement preferred_substitutions management (see #13)
- DO NOT: implement favorite_recipes management (deferred to 1E)
- DO NOT: implement frontend UI
- DO NOT: create a local .venv — all commands run inside Docker

## Dependencies
After: #5

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+0 added, ~2 modified, -0 deleted)
- `M` src/routers/auth.py
- `M` src/schemas/auth.py

### Commits
- 9884354 feat: Implement user profile endpoints GET/PUT /auth/me
- 1e1abf5 chore: initialize work on #7 Implement user profile endpoints GET/PUT /auth/me
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues
Created: #28 Created: #27 Created: #25 #26  Updated: #24 
**From assessment on 2026-03-17T18:34:03Z:**
- Created: #24 
- Updated: none