### PR TITLE
Add logging for profile update attempts

### DIFF
--- a/src/routers/auth.py
+++ b/src/routers/auth.py
@@ -187,6 +187,17 @@ def update_current_user_profile(
     # Update only the fields that were provided (partial updates)
     update_dict = update_data.model_dump(exclude_unset=True)
 
+    # Log the profile update attempt with requested fields
+    logger.debug(
+        "Profile update attempt by user %s (email: %s) with fields: %s",
+        current_user.id,
+        current_user.email,
+        list(update_dict.keys())
+    )
+
+    # Track which fields are actually applied (for success logging)
+    applied_fields = []
+
     for field, value in update_dict.items():
         if field not in ALLOWED_UPDATE_FIELDS:
             # Log attempts to modify protected fields for security monitoring
@@ -201,8 +212,17 @@ def update_current_user_profile(
             # Silently skip disallowed fields for defense-in-depth
             continue
         setattr(current_user, field, value)
+        applied_fields.append(field)
 
     db.commit()
     db.refresh(current_user)
+
+    # Log successful profile update with applied fields
+    logger.info(
+        "Profile updated successfully for user %s (email: %s). Updated fields: %s",
+        current_user.id,
+        current_user.email,
+        applied_fields
+    )
 
     return current_user


### PR DESCRIPTION
## Work in Progress

Closes #25

Add logging for profile update attempts

<!-- sharkrite-source-issue:7 -->## From PR #23 Assessment

**Severity:** MEDIUM
**Category:** Security

## Issue
While this is a valid security observability improvement, logging infrastructure and audit patterns are not part of this issue's scope. The defense-in-depth mechanism already prevents the attack; logging is an enhancement for visibility.

## Context
The issue scope focuses on implementing the GET/PUT endpoints with proper field protection. Audit logging is a cross-cutting concern that should be addressed consistently across all endpoints, not just this one.

## Defer Reason
Needs separate focused PR - audit logging should be designed holistically for the entire API, not added piecemeal.

---
_Created by Sharkrite assessment on 2026-03-17T18:49:07Z_
_Parent PR: #23_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**1** files, **2** commits (+0 added, ~1 modified, -0 deleted)
- `M` src/routers/auth.py

### Commits
- 565370f feat: Add logging for profile update attempts
- bbc71f0 chore: initialize work on #25 Add logging for profile update attempts
<!-- /sharkrite-changes-summary -->