### PR TITLE
[Phase 1C] Add role-based authorization

### DIFF
--- a/src/middleware/auth.py
+++ b/src/middleware/auth.py
@@ -12,7 +12,7 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from sqlalchemy.orm import Session
 
 from src.db.database import get_db
-from src.db.models.user import User
+from src.db.models.user import User, UserRole
 from src.services.auth_service import decode_token, TokenError
 
 
@@ -154,3 +154,48 @@ def get_current_user_optional(
 
     # Return user if found, None otherwise
     return user
+
+
+def require_coordinator(
+    current_user: User = Depends(get_current_user),
+) -> User:
+    """
+    FastAPI dependency that requires the authenticated user to have coordinator role.
+
+    This dependency is used by coordinator-only endpoints to enforce role-based
+    authorization. It chains with get_current_user, so authentication is verified
+    first, then role authorization is checked. Returns 403 if authenticated user
+    is not a coordinator.
+
+    Args:
+        current_user: Authenticated user (injected by get_current_user dependency)
+
+    Returns:
+        User object if user is a coordinator
+
+    Raises:
+        HTTPException(403): If authenticated user does not have coordinator role
+
+    Example:
+        @app.post("/meal-plans/approve")
+        def approve_meal_plan(
+            plan_id: UUID,
+            coordinator: User = Depends(require_coordinator)
+        ):
+            # Only coordinators can access this endpoint
+            return approve_plan(plan_id, coordinator)
+
+        # Can also be combined with route dependencies:
+        @app.post("/admin/settings", dependencies=[Depends(require_coordinator)])
+        def update_settings(settings: Settings):
+            # Coordinator check happens before handler is called
+            return update(settings)
+    """
+    # Check if user has coordinator role
+    if current_user.role != UserRole.coordinator.value:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Insufficient permissions. Coordinator role required.",
+        )
+
+    return current_user

--- a/tests/middleware/test_auth.py
+++ b/tests/middleware/test_auth.py
@@ -13,7 +13,7 @@ from unittest.mock import Mock
 from fastapi import HTTPException
 from fastapi.security import HTTPAuthorizationCredentials
 
-from src.middleware.auth import get_current_user, get_current_user_optional
+from src.middleware.auth import get_current_user, get_current_user_optional, require_coordinator
 from src.services.auth_service import create_access_token
 from src.db.models.user import User, UserRole
 
@@ -27,7 +27,9 @@ def setup_test_env(monkeypatch):
     autouse=True means this fixture runs automatically for all tests in this module.
     """
     monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars")
+    monkeypatch.setenv("JWT_ALGORITHM", "HS256")
     monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+    monkeypatch.setenv("ACCESS_TOKEN_EXPIRE_MINUTES", "43200")
 
 
 class TestGetCurrentUser:
@@ -349,3 +351,114 @@ class TestAuthMiddlewareIntegration:
         # get_current_user_optional should return None
         result = get_current_user_optional(credentials=None, db=mock_db)
         assert result is None
+
+
+class TestRequireCoordinator:
+    """Tests for the require_coordinator dependency."""
+
+    def test_require_coordinator_allows_coordinator_user(self):
+        """Coordinator user should pass authorization and be returned."""
+        coordinator_user = User(
+            id=uuid4(),
+            name="Coordinator User",
+            email="coordinator@example.com",
+            role=UserRole.coordinator.value,
+        )
+
+        # Call the dependency with a coordinator user
+        result = require_coordinator(current_user=coordinator_user)
+
+        # Should return the same user
+        assert result == coordinator_user
+        assert result.role == UserRole.coordinator.value
+
+    def test_require_coordinator_rejects_member_user_with_403(self):
+        """Member user should be rejected with 403 Forbidden."""
+        member_user = User(
+            id=uuid4(),
+            name="Member User",
+            email="member@example.com",
+            role=UserRole.member.value,
+        )
+
+        # Call the dependency with a member user
+        with pytest.raises(HTTPException) as exc_info:
+            require_coordinator(current_user=member_user)
+
+        # Should raise 403, not 401 (user is authenticated but not authorized)
+        assert exc_info.value.status_code == 403
+        assert "Insufficient permissions" in exc_info.value.detail
+        assert "Coordinator role required" in exc_info.value.detail
+
+    def test_require_coordinator_error_message_is_descriptive(self):
+        """Error message should clearly indicate the authorization failure."""
+        member_user = User(
+            id=uuid4(),
+            name="Member User",
+            email="member@example.com",
+            role=UserRole.member.value,
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            require_coordinator(current_user=member_user)
+
+        # Verify the error message is helpful
+        detail = exc_info.value.detail
+        assert "permissions" in detail.lower() or "coordinator" in detail.lower()
+        assert exc_info.value.status_code == 403
+
+    def test_require_coordinator_can_be_chained_with_get_current_user(self):
+        """
+        Integration test: verify require_coordinator can be used with get_current_user.
+
+        This simulates the pattern:
+            def endpoint(coordinator: User = Depends(require_coordinator)):
+                ...
+
+        Where require_coordinator internally depends on get_current_user.
+        """
+        user_id = uuid4()
+        coordinator_user = User(
+            id=user_id,
+            name="Coordinator",
+            email="coord@example.com",
+            role=UserRole.coordinator.value,
+        )
+
+        # Create valid token
+        token = create_access_token({"sub": str(user_id)})
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+        # Mock database
+        mock_db = Mock()
+        mock_query = mock_db.query.return_value
+        mock_filter = mock_query.filter.return_value
+        mock_filter.first.return_value = coordinator_user
+
+        # Simulate the full dependency chain:
+        # 1. get_current_user extracts and validates token
+        current_user = get_current_user(credentials=credentials, db=mock_db)
+
+        # 2. require_coordinator checks role
+        result = require_coordinator(current_user=current_user)
+
+        # Both should return the same coordinator
+        assert result == coordinator_user
+        assert result.role == UserRole.coordinator.value
+
+    def test_require_coordinator_preserves_user_object(self):
+        """The returned User object should be identical to the input."""
+        coordinator_user = User(
+            id=uuid4(),
+            name="Test Coordinator",
+            email="test@example.com",
+            role=UserRole.coordinator.value,
+        )
+
+        result = require_coordinator(current_user=coordinator_user)
+
+        # Should return the exact same object
+        assert result is coordinator_user
+        assert result.id == coordinator_user.id
+        assert result.name == coordinator_user.name
+        assert result.email == coordinator_user.email

--- a/tests/routers/test_auth.py
+++ b/tests/routers/test_auth.py
@@ -141,6 +141,18 @@ class TestGetProfile:
         assert response.status_code == 401
         assert "detail" in response.json()
 
+    def test_get_profile_expired_token(self, client):
+        """GET /auth/me returns 401 with expired JWT token."""
+        from datetime import timedelta
+        user_id = uuid4()
+        token = create_access_token({"sub": str(user_id)}, expires_delta=timedelta(seconds=-1))
+        headers = {"Authorization": f"Bearer {token}"}
+
+        response = client.get("/auth/me", headers=headers)
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Not authenticated"
+
     def test_get_profile_nonexistent_user(self, client):
         """GET /auth/me returns 401 when token references deleted/non-existent user."""
         # Create a token for a user ID that doesn't exist in the database
@@ -273,6 +285,19 @@ class TestUpdateProfile:
         update_data = {"name": "Should Fail"}
 
         response = client.put("/auth/me", json=update_data)
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Not authenticated"
+
+    def test_update_profile_expired_token(self, client):
+        """PUT /auth/me returns 401 with expired JWT token."""
+        from datetime import timedelta
+        user_id = uuid4()
+        token = create_access_token({"sub": str(user_id)}, expires_delta=timedelta(seconds=-1))
+        headers = {"Authorization": f"Bearer {token}"}
+        update_data = {"name": "Should Fail"}
+
+        response = client.put("/auth/me", json=update_data, headers=headers)
 
         assert response.status_code == 401
         assert response.json()["detail"] == "Not authenticated"


### PR DESCRIPTION
## Work in Progress

Closes #8

[Phase 1C] Add role-based authorization

## Labels
`phase-1`, `backend`, `priority-medium`

## Time Estimate
45min

## Description
Create authorization utilities for coordinator-only actions. Coordinators have meal plan approval authority per the ADR. This middleware enables protecting admin actions while allowing members normal access.

## Claude Context
Files to Read:
- `src/middleware/auth.py` (existing auth middleware)
- `src/db/models/user.py` (UserRole enum)
- `docs/FreshUp-ADR.md` (Section 4.1 User roles, Section 5.6 coordinator approval)
- `docker-compose.yml` (dev environment — all commands run via docker compose exec)

Files to Modify:
- `src/middleware/auth.py` (add require_coordinator dependency)

Related Issues: #7

## Acceptance Criteria
- [ ] require_coordinator dependency allows coordinator users: test with coordinator
- [ ] require_coordinator returns 403 for member users: test with member
- [ ] Error message indicates insufficient permissions: verify response body
- [ ] Can be combined with get_current_user in endpoint dependencies: verify pattern

## Verification Commands
```bash
docker compose build api
docker compose up -d

# Register coordinator (first user auto-becomes coordinator)
curl -X POST http://localhost:8000/auth/register \
  -H "Content-Type: application/json" \
  -d '{"name":"Coordinator","email":"coord@example.com","password":"SecurePass123!"}'

# Register member
curl -X POST http://localhost:8000/auth/register \
  -H "Content-Type: application/json" \
  -d '{"name":"Member","email":"member@example.com","password":"SecurePass123!"}'

# Verify import
docker compose exec api python -c "
from src.middleware.auth import require_coordinator
print('require_coordinator dependency exists')
"
```

## Done Definition
Done when require_coordinator dependency correctly allows coordinators and returns 403 for members.

## Scope Boundary
- DO: create require_coordinator FastAPI dependency
- DO: return 403 Forbidden with clear error message
- DO: design for easy extension to other roles if needed
- DO NOT: implement specific coordinator-only endpoints yet (meal plan approval is Phase 3)
- DO NOT: add role management endpoints
- DO NOT: create a local .venv — all commands run inside Docker

## Dependencies
After: #7

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **3** commits (+0 added, ~3 modified, -0 deleted)
- `M` src/middleware/auth.py
- `M` tests/middleware/test_auth.py
- `M` tests/routers/test_auth.py

### Commits
- 9ebeef4 feat: [Phase 1C] Add role-based authorization
- ef5eaa8 chore: initialize work on #8 [Phase 1C] Add role-based authorization
- d86d5fd Add expired token integration tests for GET/PUT /auth/me
<!-- /sharkrite-changes-summary -->