### PR TITLE
[Phase 1C] Implement user listing for household

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ from sqlalchemy import inspect, text
 
 from src.config import get_settings
 from src.db.database import Base, init_engine, get_engine, get_session_factory
-from src.routers import auth_router
+from src.routers import auth_router, users_router
 
 settings = get_settings()
 
@@ -65,6 +65,7 @@ app = FastAPI(
 
 # Register routers
 app.include_router(auth_router)
+app.include_router(users_router)
 
 
 @app.get("/health")

--- a/src/routers/__init__.py
+++ b/src/routers/__init__.py
@@ -1,10 +1,12 @@
 # API route handlers will be organized here by domain:
 # - auth.py (1C - authentication endpoints)
+# - users.py (1C - user management endpoints)
 # - inventory.py (1D)
 # - recipes.py (1E)
 # - grocery.py (1F)
 # - prepared_foods.py (1G)
 
 from src.routers.auth import router as auth_router
+from src.routers.users import router as users_router
 
-__all__ = ["auth_router"]
+__all__ = ["auth_router", "users_router"]

--- a/src/routers/users.py
+++ b/src/routers/users.py
@@ -1,0 +1,47 @@
+"""
+User management endpoints for FreshUp.
+
+Provides endpoints for listing household members. Used by the iPad "who are you?"
+selector and meal plan opt-in flows.
+"""
+
+import logging
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from src.db.database import get_db
+from src.db.models.user import User
+from src.schemas.auth import UserListResponse
+from src.middleware.auth import get_current_user
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+@router.get("", response_model=list[UserListResponse])
+def list_users(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    List all household members.
+
+    Returns a list of all users in the household with their basic profile information.
+    Used by the iPad "who are you?" selector and meal plan opt-in flows.
+    Any authenticated user can view the household roster.
+
+    Args:
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        list[UserListResponse]: List of all users with id, name, role, dietary_profile,
+                                allergies, disliked_ingredients, favorite_ingredients
+                                (excludes email and hashed_password for privacy)
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+    """
+    users = db.query(User).all()
+    return users

--- a/src/routers/users.py
+++ b/src/routers/users.py
@@ -43,5 +43,5 @@ def list_users(
     Raises:
         HTTPException(401): If Authorization header is missing or token is invalid
     """
-    users = db.query(User).all()
+    users = db.query(User).order_by(User.name).all()
     return users

--- a/src/schemas/auth.py
+++ b/src/schemas/auth.py
@@ -142,6 +142,21 @@ class UserUpdate(BaseModel):
         return data
 
 
+class UserListResponse(BaseModel):
+    """Response schema for user list (excludes email and password for privacy)."""
+
+    id: UUID
+    name: str
+    role: str
+    dietary_profile: list
+    allergies: list
+    disliked_ingredients: list
+    favorite_ingredients: list
+
+    class Config:
+        from_attributes = True
+
+
 class TokenResponse(BaseModel):
     """Response schema for JWT token."""
 

--- a/src/schemas/auth.py
+++ b/src/schemas/auth.py
@@ -73,10 +73,10 @@ class UserResponse(BaseModel):
     name: str
     email: str
     role: str
-    dietary_profile: list
-    allergies: list
-    disliked_ingredients: list
-    favorite_ingredients: list
+    dietary_profile: list[str]
+    allergies: list[str]
+    disliked_ingredients: list[str]
+    favorite_ingredients: list[str]
 
     class Config:
         from_attributes = True
@@ -148,10 +148,10 @@ class UserListResponse(BaseModel):
     id: UUID
     name: str
     role: str
-    dietary_profile: list
-    allergies: list
-    disliked_ingredients: list
-    favorite_ingredients: list
+    dietary_profile: list[str]
+    allergies: list[str]
+    disliked_ingredients: list[str]
+    favorite_ingredients: list[str]
 
     class Config:
         from_attributes = True

--- a/tests/routers/test_auth.py
+++ b/tests/routers/test_auth.py
@@ -141,6 +141,18 @@ class TestGetProfile:
         assert response.status_code == 401
         assert "detail" in response.json()
 
+    def test_get_profile_expired_token(self, client):
+        """GET /auth/me returns 401 with expired JWT token."""
+        from datetime import timedelta
+        user_id = uuid4()
+        token = create_access_token({"sub": str(user_id)}, expires_delta=timedelta(seconds=-1))
+        headers = {"Authorization": f"Bearer {token}"}
+
+        response = client.get("/auth/me", headers=headers)
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Not authenticated"
+
     def test_get_profile_nonexistent_user(self, client):
         """GET /auth/me returns 401 when token references deleted/non-existent user."""
         # Create a token for a user ID that doesn't exist in the database
@@ -273,6 +285,19 @@ class TestUpdateProfile:
         update_data = {"name": "Should Fail"}
 
         response = client.put("/auth/me", json=update_data)
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Not authenticated"
+
+    def test_update_profile_expired_token(self, client):
+        """PUT /auth/me returns 401 with expired JWT token."""
+        from datetime import timedelta
+        user_id = uuid4()
+        token = create_access_token({"sub": str(user_id)}, expires_delta=timedelta(seconds=-1))
+        headers = {"Authorization": f"Bearer {token}"}
+        update_data = {"name": "Should Fail"}
+
+        response = client.put("/auth/me", json=update_data, headers=headers)
 
         assert response.status_code == 401
         assert response.json()["detail"] == "Not authenticated"

--- a/tests/routers/test_users.py
+++ b/tests/routers/test_users.py
@@ -1,0 +1,281 @@
+"""
+Integration tests for user management endpoints.
+
+Tests cover:
+- GET /users: unauthorized access and successful user listing
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from uuid import uuid4
+
+from src.db.database import Base, get_db
+from src.db import models  # Import all models to ensure Base.metadata has all tables
+from src.db.models.user import User, UserRole
+from src.services.auth_service import hash_password, create_access_token
+
+# Import router directly and create a test app without lifespan
+from fastapi import FastAPI
+from src.routers import users_router
+
+# Create a test app without lifespan
+app = FastAPI(
+    title="FreshUp",
+    description="Privacy-first kitchen management system",
+    version="0.1.0",
+)
+
+# Register the users router
+app.include_router(users_router)
+
+
+# Create an in-memory SQLite database for testing
+TEST_DATABASE_URL = "sqlite:///:memory:"
+
+
+@pytest.fixture(autouse=True)
+def setup_test_env(monkeypatch):
+    """
+    Set up test environment variables.
+
+    Uses monkeypatch to ensure clean setup/teardown and prevent test pollution.
+    autouse=True means this fixture runs automatically for all tests in this module.
+    """
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars")
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+    monkeypatch.setenv("ENVIRONMENT", "test")
+
+
+@pytest.fixture
+def db_session():
+    """Create a fresh database session for each test."""
+    from sqlalchemy.pool import StaticPool
+
+    # Ensure all models are imported by accessing them
+    _ = models  # This forces the import of all models
+
+    # Create a new engine with StaticPool to ensure all connections share the same in-memory database
+    engine = create_engine(
+        TEST_DATABASE_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,  # Critical for SQLite :memory: to work correctly
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+@pytest.fixture
+def client(db_session):
+    """Create a test client with database dependency override."""
+    # FastAPI caches dependency results within a single request
+    # We need to ensure get_db returns the same session for the entire request
+    def override_get_db():
+        try:
+            # Important: yield the same session for all dependencies in one request
+            yield db_session
+        finally:
+            # Don't close here - the fixture will handle it
+            pass
+
+    app.dependency_overrides[get_db] = override_get_db
+    # Create test client
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def test_users(db_session):
+    """Create multiple test users in the database."""
+    users = [
+        User(
+            id=uuid4(),
+            name="Alice Coordinator",
+            email="alice@example.com",
+            hashed_password=hash_password("password123"),
+            role=UserRole.coordinator.value,
+            dietary_profile=["vegetarian", "keto"],
+            allergies=["peanuts"],
+            disliked_ingredients=["cilantro"],
+            favorite_ingredients=["tomatoes"],
+        ),
+        User(
+            id=uuid4(),
+            name="Bob Member",
+            email="bob@example.com",
+            hashed_password=hash_password("password123"),
+            role=UserRole.member.value,
+            dietary_profile=["vegan"],
+            allergies=["shellfish", "dairy"],
+            disliked_ingredients=["onions"],
+            favorite_ingredients=["avocado"],
+        ),
+        User(
+            id=uuid4(),
+            name="Charlie Member",
+            email="charlie@example.com",
+            hashed_password=hash_password("password123"),
+            role=UserRole.member.value,
+            dietary_profile=[],
+            allergies=[],
+            disliked_ingredients=[],
+            favorite_ingredients=[],
+        ),
+    ]
+    for user in users:
+        db_session.add(user)
+    db_session.commit()
+    for user in users:
+        db_session.refresh(user)
+    return users
+
+
+@pytest.fixture
+def auth_headers(test_users):
+    """Create authentication headers with a valid JWT token for the first test user."""
+    token = create_access_token(data={"sub": str(test_users[0].id)})
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestListUsers:
+    """Tests for GET /users endpoint."""
+
+    def test_list_users_unauthorized(self, client, test_users):
+        """GET /users returns 401 without auth token."""
+        response = client.get("/users")
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Not authenticated"
+
+    def test_list_users_invalid_token(self, client, test_users):
+        """GET /users returns 401 with invalid/malformed JWT token."""
+        invalid_headers = {"Authorization": "Bearer invalid.token.here"}
+        response = client.get("/users", headers=invalid_headers)
+
+        assert response.status_code == 401
+        assert "detail" in response.json()
+
+    def test_list_users_success(self, client, test_users, auth_headers):
+        """GET /users returns list of all household members with valid token."""
+        response = client.get("/users", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify response is a list
+        assert isinstance(data, list)
+        assert len(data) == 3
+
+        # Verify all expected fields are present in each user
+        for user_data in data:
+            assert "id" in user_data
+            assert "name" in user_data
+            assert "role" in user_data
+            assert "dietary_profile" in user_data
+            assert "allergies" in user_data
+            assert "disliked_ingredients" in user_data
+            assert "favorite_ingredients" in user_data
+
+            # Verify email and password are NOT included for privacy
+            assert "email" not in user_data
+            assert "password" not in user_data
+            assert "hashed_password" not in user_data
+
+        # Verify specific user data
+        user_names = {user["name"] for user in data}
+        assert "Alice Coordinator" in user_names
+        assert "Bob Member" in user_names
+        assert "Charlie Member" in user_names
+
+        # Verify roles are present
+        user_roles = {user["role"] for user in data}
+        assert "coordinator" in user_roles
+        assert "member" in user_roles
+
+    def test_list_users_fields_verification(self, client, test_users, auth_headers):
+        """GET /users returns correct field values for each user."""
+        response = client.get("/users", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Find Alice in the response
+        alice = next((u for u in data if u["name"] == "Alice Coordinator"), None)
+        assert alice is not None
+        assert alice["role"] == "coordinator"
+        assert alice["dietary_profile"] == ["vegetarian", "keto"]
+        assert alice["allergies"] == ["peanuts"]
+        assert alice["disliked_ingredients"] == ["cilantro"]
+        assert alice["favorite_ingredients"] == ["tomatoes"]
+
+        # Find Bob in the response
+        bob = next((u for u in data if u["name"] == "Bob Member"), None)
+        assert bob is not None
+        assert bob["role"] == "member"
+        assert bob["dietary_profile"] == ["vegan"]
+        assert bob["allergies"] == ["shellfish", "dairy"]
+        assert bob["disliked_ingredients"] == ["onions"]
+        assert bob["favorite_ingredients"] == ["avocado"]
+
+        # Find Charlie in the response (user with empty lists)
+        charlie = next((u for u in data if u["name"] == "Charlie Member"), None)
+        assert charlie is not None
+        assert charlie["role"] == "member"
+        assert charlie["dietary_profile"] == []
+        assert charlie["allergies"] == []
+        assert charlie["disliked_ingredients"] == []
+        assert charlie["favorite_ingredients"] == []
+
+    def test_list_users_empty_household(self, client, db_session):
+        """GET /users returns empty list when no users exist."""
+        # Create a token for a non-existent user (simulate edge case)
+        user_id = uuid4()
+        user = User(
+            id=user_id,
+            name="Solo User",
+            email="solo@example.com",
+            hashed_password=hash_password("password123"),
+            role=UserRole.member.value,
+            dietary_profile=[],
+            allergies=[],
+            disliked_ingredients=[],
+            favorite_ingredients=[],
+        )
+        db_session.add(user)
+        db_session.commit()
+
+        token = create_access_token(data={"sub": str(user_id)})
+        headers = {"Authorization": f"Bearer {token}"}
+
+        # Delete the user to simulate empty household (edge case)
+        db_session.delete(user)
+        db_session.commit()
+
+        response = client.get("/users", headers=headers)
+
+        # Should return 401 because the token's user no longer exists
+        assert response.status_code == 401
+
+    def test_list_users_member_can_access(self, client, test_users):
+        """GET /users allows member role to access user list."""
+        # Create token for Bob (a member, not coordinator)
+        bob = test_users[1]
+        token = create_access_token(data={"sub": str(bob.id)})
+        headers = {"Authorization": f"Bearer {token}"}
+
+        response = client.get("/users", headers=headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) == 3

--- a/tests/routers/test_users.py
+++ b/tests/routers/test_users.py
@@ -165,6 +165,18 @@ class TestListUsers:
         assert response.status_code == 401
         assert "detail" in response.json()
 
+    def test_list_users_expired_token(self, client, test_users):
+        """GET /users returns 401 with expired JWT token."""
+        from datetime import timedelta
+        user_id = uuid4()
+        token = create_access_token({"sub": str(user_id)}, expires_delta=timedelta(seconds=-1))
+        headers = {"Authorization": f"Bearer {token}"}
+
+        response = client.get("/users", headers=headers)
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Not authenticated"
+
     def test_list_users_success(self, client, test_users, auth_headers):
         """GET /users returns list of all household members with valid token."""
         response = client.get("/users", headers=auth_headers)


### PR DESCRIPTION
## Work in Progress

Closes #9

[Phase 1C] Implement user listing for household

## Labels
`phase-1`, `backend`, `priority-medium`

## Time Estimate
30min

## Description
Create GET /users endpoint that lists all household members. Required for the iPad "who are you?" selector and for meal plan opt-in flows. Any authenticated user can view the household roster.

## Claude Context
Files to Read:
- `src/routers/auth.py` (existing auth router)
- `src/middleware/auth.py` (get_current_user)
- `src/schemas/auth.py` (UserResponse schema)
- `docker-compose.yml` (dev environment — all commands run via docker compose exec)

Files to Modify:
- `src/routers/users.py` (create)
- `src/routers/__init__.py` (export users router)
- `src/main.py` (register users router)

Related Issues: #8

## Acceptance Criteria
- [ ] GET /users returns list of all users: test endpoint
- [ ] Response includes id, name, role, dietary_profile for each user: verify fields
- [ ] Response excludes email and hashed_password: verify excluded
- [ ] Requires authentication: test without token returns 401
- [ ] Router registered at /users prefix: verify in main.py

## Verification Commands
```bash
docker compose build api
docker compose up -d

TOKEN=$(curl -s -X POST http://localhost:8000/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"coord@example.com","password":"SecurePass123!"}' | jq -r .access_token)

curl -H "Authorization: Bearer $TOKEN" http://localhost:8000/users
```

## Done Definition
Done when authenticated users can retrieve a list of all household members with their basic profile info.

## Scope Boundary
- DO: create GET /users endpoint in new users router
- DO: return UserResponse list (safe fields only)
- DO: require authentication
- DO NOT: implement user deletion or admin user management
- DO NOT: implement pagination (household is small)
- DO NOT: create a local .venv — all commands run inside Docker

## Dependencies
After: #8

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**5** files, **3** commits (+1 added, ~4 modified, -0 deleted)
- `M` src/main.py
- `M` src/routers/__init__.py
- `A` src/routers/users.py
- `M` src/schemas/auth.py
- `M` tests/routers/test_auth.py

### Commits
- d1a8941 feat: [Phase 1C] Implement user listing for household
- 616e47c chore: initialize work on #9 [Phase 1C] Implement user listing for household
- d86d5fd Add expired token integration tests for GET/PUT /auth/me
<!-- /sharkrite-changes-summary -->