### PR TITLE
Skip unknown fields in Pydantic update models

### DIFF
--- a/src/schemas/auth.py
+++ b/src/schemas/auth.py
@@ -6,7 +6,7 @@ Defines request/response models for user registration and login.
 
 from uuid import UUID
 from typing import Optional, Any
-from pydantic import BaseModel, EmailStr, Field, field_validator, model_validator
+from pydantic import BaseModel, EmailStr, Field, field_validator, model_validator, ConfigDict
 from src.db.models.user import UserRole, DietaryProfile
 
 
@@ -84,6 +84,9 @@ class UserResponse(BaseModel):
 
 class UserUpdate(BaseModel):
     """Request schema for updating user profile via PUT /auth/me."""
+
+    # Silently ignore unknown fields for forward compatibility and robustness
+    model_config = ConfigDict(extra="ignore")
 
     name: Optional[str] = Field(default=None, min_length=1, max_length=255, description="User's display name")
     dietary_profile: Optional[list[str]] = Field(default=None, description="Dietary preferences")

--- a/tests/routers/test_auth.py
+++ b/tests/routers/test_auth.py
@@ -141,6 +141,18 @@ class TestGetProfile:
         assert response.status_code == 401
         assert "detail" in response.json()
 
+    def test_get_profile_expired_token(self, client):
+        """GET /auth/me returns 401 with expired JWT token."""
+        from datetime import timedelta
+        user_id = uuid4()
+        token = create_access_token({"sub": str(user_id)}, expires_delta=timedelta(seconds=-1))
+        headers = {"Authorization": f"Bearer {token}"}
+
+        response = client.get("/auth/me", headers=headers)
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Not authenticated"
+
     def test_get_profile_nonexistent_user(self, client):
         """GET /auth/me returns 401 when token references deleted/non-existent user."""
         # Create a token for a user ID that doesn't exist in the database
@@ -273,6 +285,19 @@ class TestUpdateProfile:
         update_data = {"name": "Should Fail"}
 
         response = client.put("/auth/me", json=update_data)
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Not authenticated"
+
+    def test_update_profile_expired_token(self, client):
+        """PUT /auth/me returns 401 with expired JWT token."""
+        from datetime import timedelta
+        user_id = uuid4()
+        token = create_access_token({"sub": str(user_id)}, expires_delta=timedelta(seconds=-1))
+        headers = {"Authorization": f"Bearer {token}"}
+        update_data = {"name": "Should Fail"}
+
+        response = client.put("/auth/me", json=update_data, headers=headers)
 
         assert response.status_code == 401
         assert response.json()["detail"] == "Not authenticated"

--- a/tests/routers/test_auth.py
+++ b/tests/routers/test_auth.py
@@ -393,3 +393,121 @@ class TestUpdateProfile:
         assert test_user.email == original_email
         assert test_user.role == original_role
         assert test_user.name == original_name  # Name should also be unchanged since the request was rejected
+
+    def test_update_profile_ignores_unknown_fields(self, client, test_user, auth_headers, db_session):
+        """PUT /auth/me silently ignores unknown fields (extra='ignore')."""
+        update_data = {
+            "name": "Updated Name",
+            "unknown_field": "should be ignored",
+            "another_unknown": 12345,
+            "nested_unknown": {"key": "value"},
+        }
+
+        response = client.put("/auth/me", json=update_data, headers=auth_headers)
+
+        # Request should succeed despite unknown fields
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify known field was updated
+        assert data["name"] == "Updated Name"
+
+        # Verify unknown fields are not in response
+        assert "unknown_field" not in data
+        assert "another_unknown" not in data
+        assert "nested_unknown" not in data
+
+        # Verify database state - only known field was updated
+        db_session.refresh(test_user)
+        assert test_user.name == "Updated Name"
+        assert not hasattr(test_user, "unknown_field")
+
+    def test_update_profile_unknown_fields_with_valid_fields(self, client, test_user, auth_headers, db_session):
+        """PUT /auth/me ignores unknown fields while processing valid fields."""
+        update_data = {
+            "name": "New Name",
+            "dietary_profile": ["vegan"],
+            "allergies": ["soy"],
+            "invalid_field_1": "ignored",
+            "disliked_ingredients": ["cilantro"],
+            "invalid_field_2": 999,
+            "favorite_ingredients": ["mango"],
+        }
+
+        response = client.put("/auth/me", json=update_data, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify all valid fields were updated correctly
+        assert data["name"] == "New Name"
+        assert data["dietary_profile"] == ["vegan"]
+        assert data["allergies"] == ["soy"]
+        assert data["disliked_ingredients"] == ["cilantro"]
+        assert data["favorite_ingredients"] == ["mango"]
+
+        # Verify invalid fields are not in response
+        assert "invalid_field_1" not in data
+        assert "invalid_field_2" not in data
+
+        # Verify database state matches
+        db_session.refresh(test_user)
+        assert test_user.name == "New Name"
+        assert test_user.dietary_profile == ["vegan"]
+        assert test_user.allergies == ["soy"]
+        assert test_user.disliked_ingredients == ["cilantro"]
+        assert test_user.favorite_ingredients == ["mango"]
+
+    def test_update_profile_only_unknown_fields(self, client, test_user, auth_headers, db_session):
+        """PUT /auth/me with only unknown fields succeeds but changes nothing."""
+        original_name = test_user.name
+        original_dietary = test_user.dietary_profile
+
+        update_data = {
+            "completely_unknown": "value",
+            "another_unknown": 123,
+        }
+
+        response = client.put("/auth/me", json=update_data, headers=auth_headers)
+
+        # Request should succeed (unknown fields are silently ignored)
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify no fields were changed
+        assert data["name"] == original_name
+        assert data["dietary_profile"] == original_dietary
+
+        # Verify database state unchanged
+        db_session.refresh(test_user)
+        assert test_user.name == original_name
+        assert test_user.dietary_profile == original_dietary
+
+    def test_update_profile_protected_fields_still_rejected_with_unknown_fields(self, client, test_user, auth_headers, db_session):
+        """PUT /auth/me still rejects protected fields even when unknown fields are present."""
+        original_email = test_user.email
+        original_role = test_user.role
+        original_name = test_user.name
+
+        update_data = {
+            "name": "Updated Name",
+            "email": "hacker@evil.com",  # Protected - should be rejected
+            "unknown_field": "ignored",
+            "role": "admin",  # Protected - should be rejected
+        }
+
+        response = client.put("/auth/me", json=update_data, headers=auth_headers)
+
+        # Request should fail due to protected fields
+        assert response.status_code == 422
+        error_data = response.json()
+        assert "detail" in error_data
+        # Verify error message mentions protected fields
+        error_msg = str(error_data["detail"])
+        assert "protected" in error_msg.lower() or "email" in error_msg.lower() or "role" in error_msg.lower()
+
+        # Verify database state - nothing changed
+        db_session.refresh(test_user)
+        assert test_user.email == original_email
+        assert test_user.role == original_role
+        assert test_user.name == original_name  # Name should be unchanged since request was rejected


### PR DESCRIPTION
## Work in Progress

Closes #28

Skip unknown fields in Pydantic update models

<!-- sharkrite-source-issue:26 -->## From PR #23 Assessment

**Severity:** MEDIUM
**Category:** Security

## Issue
This finding is functionally identical to the previously classified "No Logging for Security-Relevant Profile Update Attempts" from 2026-03-17T18:49:08Z. The changes since (src/schemas/auth.py, tests/routers/test_auth.py) do not address logging in the router. The defense-in-depth mechanism works; logging is an observability enhancement.

## Context
Logging infrastructure is not part of this issue's scope. The dual-layer validation already prevents privilege escalation; this is about visibility into attempted attacks.

## Defer Reason
Scope exceeds time budget - logging patterns should be consistent across all endpoints

---
_Created by Sharkrite assessment on 2026-03-17T19:00:01Z_
_Parent PR: #23_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **3** commits (+0 added, ~2 modified, -0 deleted)
- `M` src/schemas/auth.py
- `M` tests/routers/test_auth.py

### Commits
- 0911756 feat: Skip unknown fields in Pydantic update models
- abcab90 chore: initialize work on #28 Skip unknown fields in Pydantic update models
- d86d5fd Add expired token integration tests for GET/PUT /auth/me
<!-- /sharkrite-changes-summary -->