### PR TITLE
No Validation for Allergies and Ingredient Lists

### DIFF
--- a/src/schemas/auth.py
+++ b/src/schemas/auth.py
@@ -14,7 +14,7 @@ from src.db.models.user import UserRole, DietaryProfile
 # Validation constants for ingredient/allergy lists
 MAX_LIST_ITEM_LENGTH = 100
 MAX_LIST_SIZE = 100
-# Allow letters (any language), numbers, spaces, and common punctuation used in food names
+# Allow ASCII letters, numbers, spaces, and common punctuation used in food names
 ALLOWED_CHARS_PATTERN = re.compile(r'^[a-zA-Z0-9\s\-\'\(\),./]+$')
 
 
@@ -79,6 +79,8 @@ class UserCreate(BaseModel):
     password: str = Field(..., description="Password (minimum 8 characters, maximum 128 characters)")
     dietary_profile: Optional[list[str]] = Field(default=None, description="Dietary preferences")
     allergies: Optional[list[str]] = Field(default=None, description="Food allergies")
+    disliked_ingredients: Optional[list[str]] = Field(default=None, description="Disliked ingredients (stored as JSON array)")
+    favorite_ingredients: Optional[list[str]] = Field(default=None, description="Favorite ingredients (stored as JSON array)")
     role: Optional[str] = Field(default=None, description="User role (coordinator or member)")
 
     @field_validator('password')
@@ -164,11 +166,17 @@ class UserCreate(BaseModel):
                     raise ValueError(f'Invalid dietary profile: {profile}. Must be one of: {", ".join(valid_profiles)}')
         return v
 
-    @field_validator('allergies')
+    @field_validator('allergies', 'disliked_ingredients', 'favorite_ingredients')
     @classmethod
-    def validate_allergies(cls, v: Optional[list[str]]) -> Optional[list[str]]:
-        """Validate allergies list for length and character constraints."""
-        return validate_string_list('allergies', v)
+    def validate_ingredient_lists(cls, v: Optional[list[str]], info) -> Optional[list[str]]:
+        """
+        Validate ingredient/allergy lists for length and character constraints.
+
+        Ensures data quality by enforcing maximum item length, maximum list size,
+        and allowed character constraints.
+        """
+        field_name = info.field_name
+        return validate_string_list(field_name, v)
 
 
 

--- a/src/schemas/auth.py
+++ b/src/schemas/auth.py
@@ -6,8 +6,69 @@ Defines request/response models for user registration and login.
 
 from uuid import UUID
 from typing import Optional, Any
+import re
 from pydantic import BaseModel, EmailStr, Field, field_validator, model_validator, ConfigDict
 from src.db.models.user import UserRole, DietaryProfile
+
+
+# Validation constants for ingredient/allergy lists
+MAX_LIST_ITEM_LENGTH = 100
+MAX_LIST_SIZE = 100
+# Allow letters (any language), numbers, spaces, and common punctuation used in food names
+ALLOWED_CHARS_PATTERN = re.compile(r'^[a-zA-Z0-9\s\-\'\(\),./]+$')
+
+
+def validate_string_list(
+    field_name: str,
+    values: Optional[list[str]],
+    max_item_length: int = MAX_LIST_ITEM_LENGTH,
+    max_list_size: int = MAX_LIST_SIZE,
+) -> Optional[list[str]]:
+    """
+    Validate a list of strings for ingredient/allergy fields.
+
+    Ensures items meet length constraints and contain only allowed characters.
+    Strips whitespace and filters out empty strings.
+
+    Args:
+        field_name: Name of the field being validated (for error messages)
+        values: List of strings to validate
+        max_item_length: Maximum allowed length per item
+        max_list_size: Maximum number of items in the list
+
+    Returns:
+        Validated and cleaned list of strings, or None if input was None
+
+    Raises:
+        ValueError: If validation fails
+    """
+    if values is None:
+        return None
+
+    # Strip whitespace and filter empty strings
+    cleaned = [item.strip() for item in values if item.strip()]
+
+    # Check list size
+    if len(cleaned) > max_list_size:
+        raise ValueError(f'{field_name} cannot contain more than {max_list_size} items')
+
+    # Validate each item
+    for item in cleaned:
+        # Check item length
+        if len(item) > max_item_length:
+            raise ValueError(
+                f'{field_name} items cannot exceed {max_item_length} characters. '
+                f'Item "{item[:20]}..." is {len(item)} characters long'
+            )
+
+        # Check allowed characters
+        if not ALLOWED_CHARS_PATTERN.match(item):
+            raise ValueError(
+                f'{field_name} items can only contain letters, numbers, spaces, '
+                f'and common punctuation (- \' ( ) , . /). Invalid item: "{item}"'
+            )
+
+    return cleaned
 
 
 class UserCreate(BaseModel):
@@ -90,14 +151,25 @@ class UserCreate(BaseModel):
         """Normalize email to lowercase for case-insensitive comparison."""
         return v.lower()
 
-    @field_validator('dietary_profile', 'allergies')
+    @field_validator('dietary_profile')
     @classmethod
-    def strip_whitespace_from_list_items(cls, v: Optional[list[str]]) -> Optional[list[str]]:
-        """Strip whitespace from list items to ensure data consistency."""
+    def validate_dietary_profile(cls, v: Optional[list[str]]) -> Optional[list[str]]:
+        """Ensure dietary_profile contains valid DietaryProfile enum values and strip whitespace."""
         if v is not None:
-            # Strip whitespace from each item and filter out empty strings
+            # Strip whitespace from each item
             v = [item.strip() for item in v if item.strip()]
+            valid_profiles = [profile.value for profile in DietaryProfile]
+            for profile in v:
+                if profile not in valid_profiles:
+                    raise ValueError(f'Invalid dietary profile: {profile}. Must be one of: {", ".join(valid_profiles)}')
         return v
+
+    @field_validator('allergies')
+    @classmethod
+    def validate_allergies(cls, v: Optional[list[str]]) -> Optional[list[str]]:
+        """Validate allergies list for length and character constraints."""
+        return validate_string_list('allergies', v)
+
 
 
 class LoginRequest(BaseModel):
@@ -164,12 +236,15 @@ class UserUpdate(BaseModel):
 
     @field_validator('allergies', 'disliked_ingredients', 'favorite_ingredients')
     @classmethod
-    def strip_whitespace_from_list_items(cls, v: Optional[list[str]]) -> Optional[list[str]]:
-        """Strip whitespace from list items to ensure data consistency."""
-        if v is not None:
-            # Strip whitespace from each item and filter out empty strings
-            v = [item.strip() for item in v if item.strip()]
-        return v
+    def validate_ingredient_lists(cls, v: Optional[list[str]], info) -> Optional[list[str]]:
+        """
+        Validate ingredient/allergy lists for length and character constraints.
+
+        Ensures data quality by enforcing maximum item length, maximum list size,
+        and allowed character constraints.
+        """
+        field_name = info.field_name
+        return validate_string_list(field_name, v)
 
     @model_validator(mode='before')
     @classmethod

--- a/tests/routers/test_auth.py
+++ b/tests/routers/test_auth.py
@@ -523,6 +523,62 @@ class TestUpdateProfile:
         assert test_user.email == original_email
         assert test_user.role == original_role
         assert test_user.name == original_name  # Name should be unchanged since request was rejected
+    def test_update_profile_rejects_too_long_allergy_items(self, client, test_user, auth_headers):
+        """PUT /auth/me rejects allergy items exceeding max length."""
+        # Create an item that's 101 characters (exceeds the 100 char limit)
+        too_long_item = "a" * 101
+
+        update_data = {"allergies": [too_long_item]}
+
+        response = client.put("/auth/me", json=update_data, headers=auth_headers)
+
+        assert response.status_code == 422
+        error_detail = response.json()["detail"]
+        assert any("allergies" in str(err).lower() and "100 characters" in str(err).lower() for err in error_detail)
+
+    def test_update_profile_rejects_too_many_items(self, client, test_user, auth_headers):
+        """PUT /auth/me rejects lists with more than max items."""
+        # Create 101 items (exceeds the 100 item limit)
+        too_many_items = [f"ingredient{i}" for i in range(101)]
+
+        update_data = {"disliked_ingredients": too_many_items}
+
+        response = client.put("/auth/me", json=update_data, headers=auth_headers)
+
+        assert response.status_code == 422
+        error_detail = response.json()["detail"]
+        assert any("disliked_ingredients" in str(err).lower() and "100 items" in str(err).lower() for err in error_detail)
+
+    def test_update_profile_rejects_invalid_characters(self, client, test_user, auth_headers):
+        """PUT /auth/me rejects items with invalid characters."""
+        update_data = {"favorite_ingredients": ["tomatoes", "invalid@item#here", "carrots"]}
+
+        response = client.put("/auth/me", json=update_data, headers=auth_headers)
+
+        assert response.status_code == 422
+        error_detail = response.json()["detail"]
+        assert any("favorite_ingredients" in str(err).lower() and "punctuation" in str(err).lower() for err in error_detail)
+
+    def test_update_profile_accepts_valid_special_chars(self, client, test_user, auth_headers, db_session):
+        """PUT /auth/me accepts items with valid special characters."""
+        update_data = {
+            "allergies": ["tree nuts", "low-fat milk", "peanut butter (smooth)", "Trader Joe's sauce"],
+            "disliked_ingredients": ["cilantro/coriander", "onions, raw"],
+        }
+
+        response = client.put("/auth/me", json=update_data, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify all items were accepted
+        assert data["allergies"] == ["tree nuts", "low-fat milk", "peanut butter (smooth)", "Trader Joe's sauce"]
+        assert data["disliked_ingredients"] == ["cilantro/coriander", "onions, raw"]
+
+        # Verify database state
+        db_session.refresh(test_user)
+        assert test_user.allergies == ["tree nuts", "low-fat milk", "peanut butter (smooth)", "Trader Joe's sauce"]
+        assert test_user.disliked_ingredients == ["cilantro/coriander", "onions, raw"]
 
 
 class TestSwitchUser:
@@ -848,7 +904,6 @@ class TestRegister:
         }
 
         response = client.post("/auth/register", json=register_data)
-
         assert response.status_code == 201
         data = response.json()
 
@@ -1069,3 +1124,73 @@ class TestRegister:
         assert response.status_code == 201
         data = response.json()
         assert data["email"] == "newuser@example.com"
+
+class TestRegistrationValidation:
+    """Tests for registration endpoint validation."""
+
+    def test_registration_rejects_invalid_dietary_profile(self, client):
+        """POST /auth/register rejects invalid dietary profiles."""
+        registration_data = {
+            "name": "Test User",
+            "email": "test@example.com",
+            "password": "testpassword123",
+            "dietary_profile": ["invalid_diet"],
+        }
+
+        response = client.post("/auth/register", json=registration_data)
+
+        assert response.status_code == 422
+        error_detail = response.json()["detail"]
+        assert any("dietary_profile" in str(err).lower() for err in error_detail)
+
+    def test_registration_rejects_too_long_allergy(self, client):
+        """POST /auth/register rejects allergies exceeding max length."""
+        too_long_allergy = "a" * 101
+
+        registration_data = {
+            "name": "Test User",
+            "email": "test@example.com",
+            "password": "testpassword123",
+            "allergies": [too_long_allergy],
+        }
+
+        response = client.post("/auth/register", json=registration_data)
+
+        assert response.status_code == 422
+        error_detail = response.json()["detail"]
+        assert any("allergies" in str(err).lower() and "100 characters" in str(err).lower() for err in error_detail)
+
+    def test_registration_rejects_invalid_characters_in_allergies(self, client):
+        """POST /auth/register rejects allergies with invalid characters."""
+        registration_data = {
+            "name": "Test User",
+            "email": "test@example.com",
+            "password": "testpassword123",
+            "allergies": ["invalid@allergy#here"],
+        }
+
+        response = client.post("/auth/register", json=registration_data)
+
+        assert response.status_code == 422
+        error_detail = response.json()["detail"]
+        assert any("allergies" in str(err).lower() and "punctuation" in str(err).lower() for err in error_detail)
+
+    def test_registration_accepts_valid_allergies_and_dietary_profile(self, client, db_session):
+        """POST /auth/register accepts valid allergies and dietary profiles."""
+        registration_data = {
+            "name": "Test User",
+            "email": "newuser@example.com",
+            "password": "testpassword123",
+            "dietary_profile": ["vegan", "keto"],
+            "allergies": ["tree nuts", "shellfish", "low-fat milk"],
+        }
+
+        response = client.post("/auth/register", json=registration_data)
+        assert response.status_code == 201
+        data = response.json()
+
+        # Verify response includes expected fields
+        assert data["name"] == "Test User"
+        assert data["email"] == "newuser@example.com"
+        assert data["dietary_profile"] == ["vegan", "keto"]
+        assert data["allergies"] == ["tree nuts", "shellfish", "low-fat milk"]


### PR DESCRIPTION
## Work in Progress

Closes #24

No Validation for Allergies and Ingredient Lists

<!-- sharkrite-source-issue:7 -->## From PR #23 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
The issue scope specifies storing these as "string arrays" without defining validation constraints. While malformed data is a real concern, adding validation rules wasn't part of the acceptance criteria and could introduce scope creep around defining what "valid" ingredient strings look like.

## Context
The ADR and issue describe storage format (JSON arrays of strings) but don't specify validation rules. This is a legitimate data quality concern that should be addressed with a defined specification.

## Defer Reason
Needs design discussion to define what constitutes valid ingredient names (max length, allowed characters, normalization rules)

---
_Created by Sharkrite assessment on 2026-03-17T18:34:03Z_
_Parent PR: #23_

---

## Additional Assessment (PR #23)

**Severity:** MEDIUM
**Reasoning:** This was previously classified as ACTIONABLE_LATER. The files changed since (requirements.txt, tests/routers/__init__.py, tests/routers/test_auth.py) do not address the validation logic in src/schemas/auth.py. The prior reasoning remains valid: validation constraints were not defined in the issue scope.
**Context:** Per prior assessment, this is a valid concern but was explicitly not part of acceptance criteria. No code changes since prior assessment affect the schema validation logic.
**Defer Reason:** Scope exceeds time budget - needs definition of what "valid" ingredient strings look like

_Added by Sharkrite on 2026-03-17T18:45:02Z_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **3** commits (+0 added, ~2 modified, -0 deleted)
- `M` src/schemas/auth.py
- `M` tests/routers/test_auth.py

### Commits
- 715ddc3 feat: No Validation for Allergies and Ingredient Lists
- fdc46b4 chore: initialize work on #24 No Validation for Allergies and Ingredient Lists
- d86d5fd Add expired token integration tests for GET/PUT /auth/me
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-03-18T02:40:55Z:**
- Created: #39 
- Updated: none