### PR TITLE
[Phase 1C] Add auth integration tests

### DIFF
--- a/alembic/versions/1bf9b813a278_rename_audit_log_metadata_to_event_.py
+++ b/alembic/versions/1bf9b813a278_rename_audit_log_metadata_to_event_.py
@@ -1,0 +1,28 @@
+"""rename_audit_log_metadata_to_event_metadata
+
+Revision ID: 1bf9b813a278
+Revises: 425f03cb4131
+Create Date: 2026-03-18 22:39:17.381625
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '1bf9b813a278'
+down_revision: Union[str, None] = '425f03cb4131'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Rename metadata column to event_metadata to avoid SQLAlchemy reserved word conflict
+    op.alter_column('auth_audit_logs', 'metadata', new_column_name='event_metadata')
+
+
+def downgrade() -> None:
+    # Revert the column name back to metadata
+    op.alter_column('auth_audit_logs', 'event_metadata', new_column_name='metadata')

--- a/src/db/models/auth_audit_log.py
+++ b/src/db/models/auth_audit_log.py
@@ -60,8 +60,9 @@ class AuthAuditLog(Base):
     ip_address: Mapped[Optional[str]] = mapped_column(String(45), nullable=True, index=True)
     user_agent: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 
-    # Additional metadata (flexible JSON field for future extensibility)
-    metadata: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
+    # Additional event_metadata (flexible JSON field for future extensibility)
+    # Note: renamed from 'metadata' to avoid conflict with SQLAlchemy reserved attribute
+    event_metadata: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
 
     # Timestamp
     created_at: Mapped[datetime] = mapped_column(DateTime, default=func.now(), nullable=False, index=True)

--- a/src/services/audit_service.py
+++ b/src/services/audit_service.py
@@ -97,7 +97,7 @@ def log_registration(
         failure_reason=failure_reason,
         ip_address=_extract_client_ip(request),
         user_agent=_extract_user_agent(request),
-        metadata=metadata
+        event_metadata=metadata
     )
     db.add(audit_log)
     db.commit()
@@ -137,7 +137,7 @@ def log_login_attempt(
         failure_reason=failure_reason,
         ip_address=_extract_client_ip(request),
         user_agent=_extract_user_agent(request),
-        metadata=metadata
+        event_metadata=metadata
     )
     db.add(audit_log)
     db.commit()
@@ -172,7 +172,7 @@ def log_logout(
         success=True,
         ip_address=_extract_client_ip(request),
         user_agent=_extract_user_agent(request),
-        metadata=metadata
+        event_metadata=metadata
     )
     db.add(audit_log)
     db.commit()
@@ -212,7 +212,7 @@ def log_profile_update(
         success=True,
         ip_address=_extract_client_ip(request),
         user_agent=_extract_user_agent(request),
-        metadata=audit_metadata
+        event_metadata=audit_metadata
     )
     db.add(audit_log)
     db.commit()

--- a/tests/routers/test_auth.py
+++ b/tests/routers/test_auth.py
@@ -792,7 +792,8 @@ class TestRegistrationDatabaseErrors:
     """Tests for database error handling in POST /auth/register endpoint."""
 
     def test_register_integrity_error_handling(self, client, db_session):
-        """POST /auth/register handles IntegrityError with appropriate response."""        registration_data = {
+        """POST /auth/register handles IntegrityError with appropriate response."""
+        registration_data = {
             "name": "New User",
             "email": "newuser@example.com",
             "password": "securepassword123",
@@ -1489,8 +1490,8 @@ class TestAuditLogging:
         log = audit_logs[0]
         assert log.success is True
         assert log.email == test_user.email
-        assert "name" in log.metadata["fields_updated"]
-        assert "dietary_profile" in log.metadata["fields_updated"]
+        assert "name" in log.event_metadata["fields_updated"]
+        assert "dietary_profile" in log.event_metadata["fields_updated"]
 
     def test_audit_log_captures_ip_and_user_agent(self, client, test_user, db_session):
         """Audit logs capture IP address and user agent."""


### PR DESCRIPTION
## Work in Progress

Closes #11

[Phase 1C] Add auth integration tests

## Labels
`phase-1`, `testing`, `priority-medium`

## Time Estimate
1.5hr

## Description
Create comprehensive integration tests for the full Phase 1C authentication and user management system. Covers registration, login, profile management, role-based authorization, user listing, device session switching, and substitution preference CRUD. Ensures the entire auth system works end-to-end before building dependent features in 1D-1G.

## Claude Context
Files to Read:
- `src/routers/auth.py` (auth endpoints)
- `src/routers/users.py` (users endpoint)
- `src/routers/substitutions.py` (substitution preference endpoints)
- `src/main.py` (app for TestClient)
- `Dockerfile` (Python 3.12 base image)
- `docker-compose.yml` (dev environment — all commands run via docker compose exec)

Files to Modify:
- `tests/test_auth.py` (create)
- `tests/test_substitutions.py` (create)
- `tests/conftest.py` (create — fixtures for test client and test database)
- `requirements.txt` (add pytest, httpx if not present)

Related Issues: #10, #13

## Acceptance Criteria
- [ ] Test fixtures create isolated test database: verify conftest.py
- [ ] Test registration happy path: creates user, returns profile
- [ ] Test first-user-becomes-coordinator: first registration gets coordinator role
- [ ] Test registration rejects duplicate email: returns 400
- [ ] Test login with valid credentials: returns token
- [ ] Test login with invalid credentials: returns 401 with generic message
- [ ] Test /auth/me requires authentication: returns 401 without token
- [ ] Test /auth/me returns profile with valid token
- [ ] Test profile update modifies dietary_profile, allergies, disliked_ingredients, favorite_ingredients
- [ ] Test profile update rejects email and role changes
- [ ] Test role-based authorization: coordinator allowed, member gets 403
- [ ] Test user listing returns all household members with safe fields only
- [ ] Test switch-user flow: login -> switch -> verify new identity
- [ ] Test substitution preference CRUD: create, list, update, delete
- [ ] Test substitution preference cross-user isolation: cannot access another user's preferences
- [ ] All tests pass: `docker compose exec api pytest tests/test_auth.py tests/test_substitutions.py -v`

## Verification Commands
```bash
docker compose build api
docker compose up -d
docker compose exec api pip install pytest httpx
docker compose exec api pytest tests/test_auth.py tests/test_substitutions.py -v
```

## Done Definition
Done when all integration tests pass inside Docker and cover the complete Phase 1C auth + user management surface including substitution preferences.

## Scope Boundary
- DO: create pytest fixtures with test database isolation
- DO: test all auth endpoints (register, login, me, switch-user, users)
- DO: test substitution preference CRUD endpoints
- DO: test both success and error cases
- DO: test first-user-becomes-coordinator logic
- DO: test cross-user isolation for substitution preferences
- DO NOT: test business logic for other features (Phase 1D-1G)
- DO NOT: add load testing or performance tests
- DO NOT: test frontend (no frontend in 1C)
- DO NOT: create a local .venv — all commands run inside Docker

## Dependencies
After: #10, #13

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**4** files, **2** commits (+1 added, ~3 modified, -0 deleted)
- `A` alembic/versions/1bf9b813a278_rename_audit_log_metadata_to_event_.py
- `M` src/db/models/auth_audit_log.py
- `M` src/services/audit_service.py
- `M` tests/routers/test_auth.py

### Commits
- 99ced7e test: [Phase 1C] Add auth integration tests
- a06e82a chore: initialize work on #11 [Phase 1C] Add auth integration tests
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-03-18T22:43:57Z:**
- Created: #61 
- Updated: none