### PR TITLE
Enable X-Forwarded-For trust enforcement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,16 @@ MINIO_USE_SSL=false
 # JWT_SECRET_KEY=<paste-generated-key-here>
 JWT_ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=43200
+
+# Proxy Trust Configuration
+# Enable X-Forwarded-For header trust (default: false for security)
+# Only enable if behind a trusted reverse proxy (nginx, Apache, AWS ALB, etc.)
+TRUST_X_FORWARDED_FOR=false
+
+# Trusted proxy IPs/CIDR ranges (comma-separated)
+# Examples:
+#   Single IP: TRUSTED_PROXIES=10.0.0.1
+#   Multiple IPs: TRUSTED_PROXIES=10.0.0.1,192.168.1.1
+#   CIDR range: TRUSTED_PROXIES=10.0.0.0/24,192.168.1.0/24
+# Empty = trust all proxies when TRUST_X_FORWARDED_FOR=true (NOT recommended)
+TRUSTED_PROXIES=

--- a/.env.example
+++ b/.env.example
@@ -36,5 +36,6 @@ TRUST_X_FORWARDED_FOR=false
 #   Single IP: TRUSTED_PROXIES=10.0.0.1
 #   Multiple IPs: TRUSTED_PROXIES=10.0.0.1,192.168.1.1
 #   CIDR range: TRUSTED_PROXIES=10.0.0.0/24,192.168.1.0/24
-# Empty = trust all proxies when TRUST_X_FORWARDED_FOR=true (NOT recommended)
+# Empty = trust NO proxies (fail-secure default - X-Forwarded-For will be ignored)
+# You MUST explicitly list your proxy IPs to enable X-Forwarded-For trust
 TRUSTED_PROXIES=

--- a/src/config.py
+++ b/src/config.py
@@ -22,6 +22,13 @@ class Settings(BaseSettings):
     jwt_algorithm: str = "HS256"
     access_token_expire_minutes: int = 43200  # 30 days (household use case)
 
+    # Proxy Trust Configuration
+    # Controls whether to trust X-Forwarded-For headers for client IP extraction
+    trust_x_forwarded_for: bool = False  # Secure by default
+    # Comma-separated list of trusted proxy IPs/CIDR ranges (e.g., "10.0.0.1,192.168.1.0/24")
+    # Empty string = trust all proxies when trust_x_forwarded_for=true (NOT recommended)
+    trusted_proxies: str = ""
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/src/config.py
+++ b/src/config.py
@@ -26,7 +26,7 @@ class Settings(BaseSettings):
     # Controls whether to trust X-Forwarded-For headers for client IP extraction
     trust_x_forwarded_for: bool = False  # Secure by default
     # Comma-separated list of trusted proxy IPs/CIDR ranges (e.g., "10.0.0.1,192.168.1.0/24")
-    # Empty string = trust all proxies when trust_x_forwarded_for=true (NOT recommended)
+    # Empty string = trust NO proxies (fail-secure default, X-Forwarded-For will be ignored)
     trusted_proxies: str = ""
 
 

--- a/src/services/audit_service.py
+++ b/src/services/audit_service.py
@@ -46,7 +46,8 @@ def _is_trusted_proxy(ip: str, trusted_proxies: str) -> bool:
         True if IP is trusted, False otherwise
     """
     if not trusted_proxies.strip():
-        # Empty list means trust none (fail-secure)
+        # Empty/whitespace-only list means trust NO proxies (fail-secure default)
+        # This prevents X-Forwarded-For header spoofing when misconfigured
         return False
 
     try:

--- a/src/services/audit_service.py
+++ b/src/services/audit_service.py
@@ -26,9 +26,12 @@ from uuid import UUID
 from sqlalchemy.orm import Session
 from fastapi import Request
 import ipaddress
+import logging
 
 from src.db.models.auth_audit_log import AuthAuditLog, AuthEventType
 from src.config import get_settings
+
+logger = logging.getLogger(__name__)
 
 
 def _is_trusted_proxy(ip: str, trusted_proxies: str) -> bool:
@@ -43,8 +46,8 @@ def _is_trusted_proxy(ip: str, trusted_proxies: str) -> bool:
         True if IP is trusted, False otherwise
     """
     if not trusted_proxies.strip():
-        # Empty list means trust all when trust_x_forwarded_for is enabled
-        return True
+        # Empty list means trust none (fail-secure)
+        return False
 
     try:
         ip_addr = ipaddress.ip_address(ip)
@@ -67,7 +70,11 @@ def _is_trusted_proxy(ip: str, trusted_proxies: str) -> bool:
                 if ip_addr == ipaddress.ip_address(trusted):
                     return True
         except ValueError:
-            # Invalid IP/network in config, skip it
+            # Invalid IP/network in config, log and skip it
+            logger.warning(
+                "Invalid proxy configuration entry '%s' in TRUSTED_PROXIES - skipping",
+                trusted
+            )
             continue
 
     return False

--- a/src/services/audit_service.py
+++ b/src/services/audit_service.py
@@ -25,26 +25,70 @@ from typing import Optional
 from uuid import UUID
 from sqlalchemy.orm import Session
 from fastapi import Request
+import ipaddress
 
 from src.db.models.auth_audit_log import AuthAuditLog, AuthEventType
+from src.config import get_settings
+
+
+def _is_trusted_proxy(ip: str, trusted_proxies: str) -> bool:
+    """
+    Check if an IP address is in the trusted proxy list.
+
+    Args:
+        ip: IP address to check
+        trusted_proxies: Comma-separated list of IPs/CIDR ranges
+
+    Returns:
+        True if IP is trusted, False otherwise
+    """
+    if not trusted_proxies.strip():
+        # Empty list means trust all when trust_x_forwarded_for is enabled
+        return True
+
+    try:
+        ip_addr = ipaddress.ip_address(ip)
+    except ValueError:
+        return False
+
+    for trusted in trusted_proxies.split(","):
+        trusted = trusted.strip()
+        if not trusted:
+            continue
+
+        try:
+            # Try as network (CIDR notation)
+            if "/" in trusted:
+                network = ipaddress.ip_network(trusted, strict=False)
+                if ip_addr in network:
+                    return True
+            else:
+                # Try as individual IP
+                if ip_addr == ipaddress.ip_address(trusted):
+                    return True
+        except ValueError:
+            # Invalid IP/network in config, skip it
+            continue
+
+    return False
 
 
 def _extract_client_ip(request: Request) -> Optional[str]:
     """
-    Extract client IP address from request, handling proxy headers.
+    Extract client IP address from request with proxy trust enforcement.
 
-    Checks X-Forwarded-For header first (for reverse proxy setups),
-    then falls back to direct client host.
+    This function implements secure X-Forwarded-For header handling. By default,
+    X-Forwarded-For headers are NOT trusted (secure by default). They are only
+    used when:
+    1. TRUST_X_FORWARDED_FOR=true in configuration, AND
+    2. The request comes from a trusted proxy IP (configured via TRUSTED_PROXIES)
 
-    SECURITY WARNING: X-Forwarded-For can be spoofed by malicious clients.
-    This function should ONLY be used behind a trusted reverse proxy (e.g., nginx,
-    Apache, AWS ALB) that is configured to:
-    1. Strip/replace X-Forwarded-For from incoming client requests
-    2. Set X-Forwarded-For to the actual client IP
+    When trust conditions are not met, falls back to the direct connection IP
+    (request.client.host), which cannot be spoofed.
 
-    If deployed without a properly configured proxy, clients can forge IP addresses
-    in audit logs. For production deployments, ensure your reverse proxy is configured
-    to sanitize these headers, or modify this function to only trust request.client.host.
+    Configuration:
+        TRUST_X_FORWARDED_FOR: Enable X-Forwarded-For trust (default: false)
+        TRUSTED_PROXIES: Comma-separated IPs/CIDR ranges (e.g., "10.0.0.1,192.168.1.0/24")
 
     Args:
         request: FastAPI request object
@@ -52,19 +96,23 @@ def _extract_client_ip(request: Request) -> Optional[str]:
     Returns:
         Client IP address as string, or None if unavailable
     """
-    # Check for proxy headers (X-Forwarded-For takes precedence)
-    # SECURITY: Only safe when behind a trusted proxy that sanitizes this header
-    forwarded_for = request.headers.get("X-Forwarded-For")
-    if forwarded_for:
-        # X-Forwarded-For can contain multiple IPs (client, proxy1, proxy2)
-        # The first IP is the original client
-        return forwarded_for.split(",")[0].strip()
+    settings = get_settings()
 
-    # Fall back to direct client host
-    if request.client:
-        return request.client.host
+    # Get the direct connection IP (always available, cannot be spoofed)
+    direct_ip = request.client.host if request.client else None
 
-    return None
+    # Only check X-Forwarded-For if trust is explicitly enabled
+    if settings.trust_x_forwarded_for:
+        forwarded_for = request.headers.get("X-Forwarded-For")
+        if forwarded_for and direct_ip:
+            # Verify the request comes from a trusted proxy
+            if _is_trusted_proxy(direct_ip, settings.trusted_proxies):
+                # X-Forwarded-For can contain multiple IPs (client, proxy1, proxy2)
+                # The first IP is the original client
+                return forwarded_for.split(",")[0].strip()
+
+    # Fall back to direct client IP (secure default)
+    return direct_ip
 
 
 def _extract_user_agent(request: Request) -> Optional[str]:

--- a/tests/services/test_audit_service.py
+++ b/tests/services/test_audit_service.py
@@ -23,7 +23,8 @@ from src.services.audit_service import (
     log_login_attempt,
     log_profile_update,
     _extract_client_ip,
-    _extract_user_agent
+    _extract_user_agent,
+    _is_trusted_proxy
 )
 
 
@@ -73,11 +74,71 @@ def mock_request():
     return request
 
 
+class TestTrustedProxyValidation:
+    """Tests for trusted proxy IP validation."""
+
+    def test_trusted_proxy_single_ip_match(self):
+        """Match against single trusted IP."""
+        assert _is_trusted_proxy("10.0.0.1", "10.0.0.1") is True
+
+    def test_trusted_proxy_single_ip_no_match(self):
+        """No match against single trusted IP."""
+        assert _is_trusted_proxy("10.0.0.2", "10.0.0.1") is False
+
+    def test_trusted_proxy_multiple_ips(self):
+        """Match against multiple trusted IPs."""
+        trusted = "10.0.0.1, 192.168.1.1, 172.16.0.1"
+        assert _is_trusted_proxy("192.168.1.1", trusted) is True
+        assert _is_trusted_proxy("10.0.0.99", trusted) is False
+
+    def test_trusted_proxy_cidr_range(self):
+        """Match against CIDR range."""
+        assert _is_trusted_proxy("10.0.0.50", "10.0.0.0/24") is True
+        assert _is_trusted_proxy("10.0.1.50", "10.0.0.0/24") is False
+
+    def test_trusted_proxy_multiple_cidr_ranges(self):
+        """Match against multiple CIDR ranges."""
+        trusted = "10.0.0.0/24, 192.168.1.0/24"
+        assert _is_trusted_proxy("10.0.0.100", trusted) is True
+        assert _is_trusted_proxy("192.168.1.50", trusted) is True
+        assert _is_trusted_proxy("172.16.0.1", trusted) is False
+
+    def test_trusted_proxy_mixed_ip_and_cidr(self):
+        """Match against mixed IPs and CIDR ranges."""
+        trusted = "10.0.0.1, 192.168.1.0/24, 172.16.0.5"
+        assert _is_trusted_proxy("10.0.0.1", trusted) is True
+        assert _is_trusted_proxy("192.168.1.100", trusted) is True
+        assert _is_trusted_proxy("172.16.0.5", trusted) is True
+        assert _is_trusted_proxy("172.16.0.6", trusted) is False
+
+    def test_trusted_proxy_empty_list_trusts_all(self):
+        """Empty trusted list means trust all proxies."""
+        assert _is_trusted_proxy("1.2.3.4", "") is True
+        assert _is_trusted_proxy("10.0.0.1", "  ") is True
+
+    def test_trusted_proxy_invalid_ip(self):
+        """Invalid IP address returns False."""
+        assert _is_trusted_proxy("not-an-ip", "10.0.0.0/24") is False
+
+    def test_trusted_proxy_invalid_config(self):
+        """Invalid entries in config are skipped."""
+        trusted = "10.0.0.1, invalid-ip, 192.168.1.0/24"
+        assert _is_trusted_proxy("10.0.0.1", trusted) is True
+        assert _is_trusted_proxy("192.168.1.50", trusted) is True
+
+
 class TestIPExtraction:
     """Tests for IP address extraction from request."""
 
-    def test_extract_ip_from_client(self):
-        """Extract IP from request.client when no proxy headers."""
+    def test_extract_ip_from_client_no_trust(self, monkeypatch):
+        """Extract IP from request.client when trust is disabled (default)."""
+        monkeypatch.setenv("TRUST_X_FORWARDED_FOR", "false")
+        monkeypatch.delenv("TRUSTED_PROXIES", raising=False)
+
+        # Clear the settings cache
+        from src.config import get_settings
+        get_settings.cache_clear()
+
         request = Mock()
         request.client = Mock()
         request.client.host = "192.168.1.100"
@@ -86,8 +147,13 @@ class TestIPExtraction:
         ip = _extract_client_ip(request)
         assert ip == "192.168.1.100"
 
-    def test_extract_ip_from_forwarded_for(self):
-        """Extract IP from X-Forwarded-For header (proxy)."""
+    def test_extract_ip_ignores_forwarded_for_when_trust_disabled(self, monkeypatch):
+        """Ignore X-Forwarded-For when trust is disabled (secure by default)."""
+        monkeypatch.setenv("TRUST_X_FORWARDED_FOR", "false")
+
+        from src.config import get_settings
+        get_settings.cache_clear()
+
         request = Mock()
         request.client = Mock()
         request.client.host = "10.0.0.1"  # Proxy IP
@@ -96,7 +162,81 @@ class TestIPExtraction:
         }
 
         ip = _extract_client_ip(request)
+        # Should return proxy IP, not forwarded IP
+        assert ip == "10.0.0.1"
+
+    def test_extract_ip_from_forwarded_for_with_trust_enabled(self, monkeypatch):
+        """Extract IP from X-Forwarded-For when trust is enabled and proxy is trusted."""
+        monkeypatch.setenv("TRUST_X_FORWARDED_FOR", "true")
+        monkeypatch.setenv("TRUSTED_PROXIES", "10.0.0.1")
+
+        from src.config import get_settings
+        get_settings.cache_clear()
+
+        request = Mock()
+        request.client = Mock()
+        request.client.host = "10.0.0.1"  # Trusted proxy IP
+        request.headers = {
+            "X-Forwarded-For": "203.0.113.42, 10.0.0.1"
+        }
+
+        ip = _extract_client_ip(request)
         assert ip == "203.0.113.42"  # First IP is original client
+
+    def test_extract_ip_ignores_forwarded_for_from_untrusted_proxy(self, monkeypatch):
+        """Ignore X-Forwarded-For from untrusted proxy even when trust is enabled."""
+        monkeypatch.setenv("TRUST_X_FORWARDED_FOR", "true")
+        monkeypatch.setenv("TRUSTED_PROXIES", "10.0.0.1")  # Only trust this IP
+
+        from src.config import get_settings
+        get_settings.cache_clear()
+
+        request = Mock()
+        request.client = Mock()
+        request.client.host = "10.0.0.99"  # Untrusted proxy IP
+        request.headers = {
+            "X-Forwarded-For": "203.0.113.42, 10.0.0.99"
+        }
+
+        ip = _extract_client_ip(request)
+        # Should return direct connection IP, not forwarded IP
+        assert ip == "10.0.0.99"
+
+    def test_extract_ip_from_forwarded_for_with_cidr_trust(self, monkeypatch):
+        """Extract IP from X-Forwarded-For when proxy is in trusted CIDR range."""
+        monkeypatch.setenv("TRUST_X_FORWARDED_FOR", "true")
+        monkeypatch.setenv("TRUSTED_PROXIES", "10.0.0.0/24")
+
+        from src.config import get_settings
+        get_settings.cache_clear()
+
+        request = Mock()
+        request.client = Mock()
+        request.client.host = "10.0.0.50"  # In trusted CIDR range
+        request.headers = {
+            "X-Forwarded-For": "203.0.113.42"
+        }
+
+        ip = _extract_client_ip(request)
+        assert ip == "203.0.113.42"
+
+    def test_extract_ip_with_trust_enabled_empty_proxy_list(self, monkeypatch):
+        """Trust all proxies when trust enabled with empty proxy list."""
+        monkeypatch.setenv("TRUST_X_FORWARDED_FOR", "true")
+        monkeypatch.setenv("TRUSTED_PROXIES", "")
+
+        from src.config import get_settings
+        get_settings.cache_clear()
+
+        request = Mock()
+        request.client = Mock()
+        request.client.host = "1.2.3.4"  # Any proxy IP
+        request.headers = {
+            "X-Forwarded-For": "203.0.113.42"
+        }
+
+        ip = _extract_client_ip(request)
+        assert ip == "203.0.113.42"
 
     def test_extract_ip_no_client(self):
         """Handle request with no client."""

--- a/tests/services/test_audit_service.py
+++ b/tests/services/test_audit_service.py
@@ -111,10 +111,10 @@ class TestTrustedProxyValidation:
         assert _is_trusted_proxy("172.16.0.5", trusted) is True
         assert _is_trusted_proxy("172.16.0.6", trusted) is False
 
-    def test_trusted_proxy_empty_list_trusts_all(self):
-        """Empty trusted list means trust all proxies."""
-        assert _is_trusted_proxy("1.2.3.4", "") is True
-        assert _is_trusted_proxy("10.0.0.1", "  ") is True
+    def test_trusted_proxy_empty_list_trusts_none(self):
+        """Empty trusted list means trust NO proxies (fail-secure)."""
+        assert _is_trusted_proxy("1.2.3.4", "") is False
+        assert _is_trusted_proxy("10.0.0.1", "  ") is False
 
     def test_trusted_proxy_invalid_ip(self):
         """Invalid IP address returns False."""
@@ -221,7 +221,7 @@ class TestIPExtraction:
         assert ip == "203.0.113.42"
 
     def test_extract_ip_with_trust_enabled_empty_proxy_list(self, monkeypatch):
-        """Trust all proxies when trust enabled with empty proxy list."""
+        """Empty proxy list trusts NO proxies (fail-secure), falls back to direct IP."""
         monkeypatch.setenv("TRUST_X_FORWARDED_FOR", "true")
         monkeypatch.setenv("TRUSTED_PROXIES", "")
 
@@ -230,13 +230,15 @@ class TestIPExtraction:
 
         request = Mock()
         request.client = Mock()
-        request.client.host = "1.2.3.4"  # Any proxy IP
+        request.client.host = "1.2.3.4"  # Untrusted proxy IP
         request.headers = {
             "X-Forwarded-For": "203.0.113.42"
         }
 
         ip = _extract_client_ip(request)
-        assert ip == "203.0.113.42"
+        # Empty TRUSTED_PROXIES means no proxy is trusted (fail-secure)
+        # Should ignore X-Forwarded-For and return direct connection IP
+        assert ip == "1.2.3.4"
 
     def test_extract_ip_no_client(self):
         """Handle request with no client."""


### PR DESCRIPTION
## Work in Progress

Closes #47

Enable X-Forwarded-For trust enforcement

<!-- sharkrite-source-issue:21 -->## From PR #43 Assessment

**Severity:** MEDIUM
**Category:** Security

## Issue
This is a real security concern - the code documents the risk but doesn't enforce safe behavior. However, adding configuration infrastructure for proxy trust settings is beyond the scope of basic audit logging implementation.

## Context
The security warning is documented, which is better than silently trusting headers. Adding a configuration flag requires changes to the application configuration system and deployment documentation.

## Defer Reason
Needs separate focused PR - requires configuration infrastructure changes

---
_Created by Sharkrite assessment on 2026-03-18T03:11:43Z_
_Parent PR: #43_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**4** files, **2** commits (+0 added, ~4 modified, -0 deleted)
- `M` .env.example
- `M` src/config.py
- `M` src/services/audit_service.py
- `M` tests/services/test_audit_service.py

### Commits
- b34c0ac feat: Enable X-Forwarded-For trust enforcement
- 5f1f964 chore: initialize work on #47 Enable X-Forwarded-For trust enforcement
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues
 Updated: #74  Updated: #74 
**From assessment on 2026-03-19T05:26:29Z:**
- Created: #74 
- Updated: none