### PR TITLE
[Phase 1D] Create inventory Pydantic schemas

### DIFF
--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -1,2 +1,16 @@
 # Pydantic schemas for request/response validation
 # Organized by domain to match routers structure
+
+from src.schemas.inventory import (
+    InventoryItemCreate,
+    InventoryItemUpdate,
+    InventoryItemResponse,
+    InventoryItemListResponse,
+)
+
+__all__ = [
+    "InventoryItemCreate",
+    "InventoryItemUpdate",
+    "InventoryItemResponse",
+    "InventoryItemListResponse",
+]

--- a/src/schemas/inventory.py
+++ b/src/schemas/inventory.py
@@ -1,0 +1,243 @@
+"""
+Pydantic schemas for inventory endpoints.
+
+Defines request/response models for inventory CRUD operations.
+"""
+
+from uuid import UUID
+from datetime import datetime
+from typing import Optional
+from pydantic import BaseModel, Field, field_validator, ConfigDict
+
+from src.db.models.inventory_item import Category, UnitType, StorageLocation, Shareability
+
+
+class InventoryItemCreate(BaseModel):
+    """Request schema for creating a new inventory item."""
+
+    name: str = Field(..., min_length=1, max_length=255, description="Item name")
+    quantity: float = Field(..., description="Quantity of the item")
+    unit: str = Field(..., description="Unit of measurement")
+    category: str = Field(..., description="Item category")
+    storage_location: str = Field(..., description="Storage location (pantry, fridge, freezer)")
+    added_by: UUID = Field(..., description="User ID who added the item")
+
+    # Optional fields
+    expiration_date: Optional[datetime] = Field(default=None, description="Expiration date")
+    frozen_date: Optional[datetime] = Field(default=None, description="Date when item was frozen")
+    is_staple: Optional[bool] = Field(default=False, description="Whether item is a staple")
+    minimum_threshold: Optional[float] = Field(default=None, description="Minimum quantity threshold for alerts")
+    shareability: Optional[str] = Field(default=Shareability.shared.value, description="Shareability status (shared, reserved, personal)")
+    reserved_note: Optional[str] = Field(default=None, max_length=500, description="Note for reserved items")
+    price: Optional[float] = Field(default=None, description="Price of the item")
+    brand: Optional[str] = Field(default=None, max_length=255, description="Brand name")
+    preferred_store: Optional[UUID] = Field(default=None, description="Preferred store ID")
+    vegan_friendly: Optional[bool] = Field(default=False, description="Whether item is vegan-friendly")
+
+    @field_validator('quantity')
+    @classmethod
+    def validate_quantity_non_negative(cls, v: float) -> float:
+        """Ensure quantity is non-negative."""
+        if v < 0:
+            raise ValueError('Quantity cannot be negative')
+        return v
+
+    @field_validator('minimum_threshold')
+    @classmethod
+    def validate_threshold_non_negative(cls, v: Optional[float]) -> Optional[float]:
+        """Ensure minimum threshold is non-negative if provided."""
+        if v is not None and v < 0:
+            raise ValueError('Minimum threshold cannot be negative')
+        return v
+
+    @field_validator('price')
+    @classmethod
+    def validate_price_non_negative(cls, v: Optional[float]) -> Optional[float]:
+        """Ensure price is non-negative if provided."""
+        if v is not None and v < 0:
+            raise ValueError('Price cannot be negative')
+        return v
+
+    @field_validator('unit')
+    @classmethod
+    def validate_unit(cls, v: str) -> str:
+        """Ensure unit is a valid UnitType enum value."""
+        valid_units = [unit.value for unit in UnitType]
+        if v not in valid_units:
+            raise ValueError(f'Unit must be one of: {", ".join(valid_units)}')
+        return v
+
+    @field_validator('category')
+    @classmethod
+    def validate_category(cls, v: str) -> str:
+        """Ensure category is a valid Category enum value."""
+        valid_categories = [cat.value for cat in Category]
+        if v not in valid_categories:
+            raise ValueError(f'Category must be one of: {", ".join(valid_categories)}')
+        return v
+
+    @field_validator('storage_location')
+    @classmethod
+    def validate_storage_location(cls, v: str) -> str:
+        """Ensure storage_location is a valid StorageLocation enum value."""
+        valid_locations = [loc.value for loc in StorageLocation]
+        if v not in valid_locations:
+            raise ValueError(f'Storage location must be one of: {", ".join(valid_locations)}')
+        return v
+
+    @field_validator('shareability')
+    @classmethod
+    def validate_shareability(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure shareability is a valid Shareability enum value."""
+        if v is not None:
+            valid_shareability = [share.value for share in Shareability]
+            if v not in valid_shareability:
+                raise ValueError(f'Shareability must be one of: {", ".join(valid_shareability)}')
+        return v
+
+    @field_validator('name')
+    @classmethod
+    def validate_name_not_empty(cls, v: str) -> str:
+        """Ensure name is not empty or whitespace only."""
+        if not v or not v.strip():
+            raise ValueError('Name cannot be empty')
+        return v.strip()
+
+
+class InventoryItemUpdate(BaseModel):
+    """Request schema for updating an inventory item (partial updates)."""
+
+    # Silently ignore unknown fields for forward compatibility
+    model_config = ConfigDict(extra="ignore")
+
+    name: Optional[str] = Field(default=None, min_length=1, max_length=255, description="Item name")
+    quantity: Optional[float] = Field(default=None, description="Quantity of the item")
+    unit: Optional[str] = Field(default=None, description="Unit of measurement")
+    category: Optional[str] = Field(default=None, description="Item category")
+    storage_location: Optional[str] = Field(default=None, description="Storage location (pantry, fridge, freezer)")
+    expiration_date: Optional[datetime] = Field(default=None, description="Expiration date")
+    frozen_date: Optional[datetime] = Field(default=None, description="Date when item was frozen")
+    is_staple: Optional[bool] = Field(default=None, description="Whether item is a staple")
+    minimum_threshold: Optional[float] = Field(default=None, description="Minimum quantity threshold for alerts")
+    shareability: Optional[str] = Field(default=None, description="Shareability status (shared, reserved, personal)")
+    reserved_note: Optional[str] = Field(default=None, max_length=500, description="Note for reserved items")
+    price: Optional[float] = Field(default=None, description="Price of the item")
+    brand: Optional[str] = Field(default=None, max_length=255, description="Brand name")
+    preferred_store: Optional[UUID] = Field(default=None, description="Preferred store ID")
+    vegan_friendly: Optional[bool] = Field(default=None, description="Whether item is vegan-friendly")
+
+    @field_validator('quantity')
+    @classmethod
+    def validate_quantity_non_negative(cls, v: Optional[float]) -> Optional[float]:
+        """Ensure quantity is non-negative if provided."""
+        if v is not None and v < 0:
+            raise ValueError('Quantity cannot be negative')
+        return v
+
+    @field_validator('minimum_threshold')
+    @classmethod
+    def validate_threshold_non_negative(cls, v: Optional[float]) -> Optional[float]:
+        """Ensure minimum threshold is non-negative if provided."""
+        if v is not None and v < 0:
+            raise ValueError('Minimum threshold cannot be negative')
+        return v
+
+    @field_validator('price')
+    @classmethod
+    def validate_price_non_negative(cls, v: Optional[float]) -> Optional[float]:
+        """Ensure price is non-negative if provided."""
+        if v is not None and v < 0:
+            raise ValueError('Price cannot be negative')
+        return v
+
+    @field_validator('unit')
+    @classmethod
+    def validate_unit(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure unit is a valid UnitType enum value if provided."""
+        if v is not None:
+            valid_units = [unit.value for unit in UnitType]
+            if v not in valid_units:
+                raise ValueError(f'Unit must be one of: {", ".join(valid_units)}')
+        return v
+
+    @field_validator('category')
+    @classmethod
+    def validate_category(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure category is a valid Category enum value if provided."""
+        if v is not None:
+            valid_categories = [cat.value for cat in Category]
+            if v not in valid_categories:
+                raise ValueError(f'Category must be one of: {", ".join(valid_categories)}')
+        return v
+
+    @field_validator('storage_location')
+    @classmethod
+    def validate_storage_location(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure storage_location is a valid StorageLocation enum value if provided."""
+        if v is not None:
+            valid_locations = [loc.value for loc in StorageLocation]
+            if v not in valid_locations:
+                raise ValueError(f'Storage location must be one of: {", ".join(valid_locations)}')
+        return v
+
+    @field_validator('shareability')
+    @classmethod
+    def validate_shareability(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure shareability is a valid Shareability enum value if provided."""
+        if v is not None:
+            valid_shareability = [share.value for share in Shareability]
+            if v not in valid_shareability:
+                raise ValueError(f'Shareability must be one of: {", ".join(valid_shareability)}')
+        return v
+
+    @field_validator('name')
+    @classmethod
+    def validate_name_not_empty(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure name is not empty or whitespace only if provided."""
+        if v is not None and (not v or not v.strip()):
+            raise ValueError('Name cannot be empty')
+        return v.strip() if v else None
+
+
+class InventoryItemResponse(BaseModel):
+    """Response schema for inventory item data (includes all fields)."""
+
+    id: UUID
+    name: str
+    quantity: float
+    unit: str
+    category: str
+    vegan_friendly: bool
+    storage_location: str
+    date_added: datetime
+    expiration_date: Optional[datetime]
+    frozen_date: Optional[datetime]
+    is_staple: bool
+    minimum_threshold: Optional[float]
+    shareability: str
+    reserved_for: Optional[UUID]
+    reserved_note: Optional[str]
+    added_by: UUID
+    price: Optional[float]
+    brand: Optional[str]
+    preferred_store: Optional[UUID]
+
+    class Config:
+        from_attributes = True
+
+
+class InventoryItemListResponse(BaseModel):
+    """Response schema for inventory item lists (summary fields only)."""
+
+    id: UUID
+    name: str
+    quantity: float
+    unit: str
+    category: str
+    storage_location: str
+    shareability: str
+    is_staple: bool
+    expiration_date: Optional[datetime]
+
+    class Config:
+        from_attributes = True

--- a/src/schemas/inventory.py
+++ b/src/schemas/inventory.py
@@ -202,6 +202,8 @@ class InventoryItemUpdate(BaseModel):
 class InventoryItemResponse(BaseModel):
     """Response schema for inventory item data (includes all fields)."""
 
+    model_config = ConfigDict(from_attributes=True)
+
     id: UUID
     name: str
     quantity: float
@@ -222,12 +224,11 @@ class InventoryItemResponse(BaseModel):
     brand: Optional[str]
     preferred_store: Optional[UUID]
 
-    class Config:
-        from_attributes = True
-
 
 class InventoryItemListResponse(BaseModel):
     """Response schema for inventory item lists (summary fields only)."""
+
+    model_config = ConfigDict(from_attributes=True)
 
     id: UUID
     name: str
@@ -238,6 +239,3 @@ class InventoryItemListResponse(BaseModel):
     shareability: str
     is_staple: bool
     expiration_date: Optional[datetime]
-
-    class Config:
-        from_attributes = True

--- a/tests/schemas/test_inventory.py
+++ b/tests/schemas/test_inventory.py
@@ -1,0 +1,456 @@
+"""
+Unit tests for inventory schemas.
+
+Tests cover validation for inventory item creation, updates, and enum constraints.
+"""
+
+import pytest
+from uuid import uuid4
+from datetime import datetime
+from pydantic import ValidationError
+
+from src.schemas.inventory import (
+    InventoryItemCreate,
+    InventoryItemUpdate,
+    InventoryItemResponse,
+    InventoryItemListResponse,
+)
+from src.db.models.inventory_item import Category, UnitType, StorageLocation, Shareability
+
+
+class TestInventoryItemCreate:
+    """Tests for InventoryItemCreate schema."""
+
+    def test_valid_create_with_required_fields(self):
+        """Test creation with all required fields."""
+        user_id = uuid4()
+        item_data = {
+            "name": "Tomatoes",
+            "quantity": 5.0,
+            "unit": "count",
+            "category": "produce",
+            "storage_location": "fridge",
+            "added_by": user_id,
+        }
+        item = InventoryItemCreate(**item_data)
+        assert item.name == "Tomatoes"
+        assert item.quantity == 5.0
+        assert item.unit == "count"
+        assert item.category == "produce"
+        assert item.storage_location == "fridge"
+        assert item.added_by == user_id
+
+    def test_valid_create_with_all_fields(self):
+        """Test creation with all fields including optional ones."""
+        user_id = uuid4()
+        store_id = uuid4()
+        expiration = datetime(2025, 12, 31)
+        frozen = datetime(2024, 1, 15)
+
+        item_data = {
+            "name": "Chicken Breast",
+            "quantity": 2.5,
+            "unit": "lb",
+            "category": "protein",
+            "storage_location": "freezer",
+            "added_by": user_id,
+            "expiration_date": expiration,
+            "frozen_date": frozen,
+            "is_staple": False,
+            "minimum_threshold": 1.0,
+            "shareability": "shared",
+            "reserved_note": "For dinner party",
+            "price": 12.99,
+            "brand": "Organic Farms",
+            "preferred_store": store_id,
+            "vegan_friendly": False,
+        }
+        item = InventoryItemCreate(**item_data)
+        assert item.name == "Chicken Breast"
+        assert item.quantity == 2.5
+        assert item.expiration_date == expiration
+        assert item.price == 12.99
+
+    def test_quantity_must_be_non_negative(self):
+        """Test that negative quantity is rejected."""
+        user_id = uuid4()
+        item_data = {
+            "name": "Test Item",
+            "quantity": -5.0,
+            "unit": "count",
+            "category": "produce",
+            "storage_location": "pantry",
+            "added_by": user_id,
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            InventoryItemCreate(**item_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("quantity",) for error in errors)
+        assert any("negative" in error["msg"].lower() for error in errors)
+
+    def test_minimum_threshold_must_be_non_negative(self):
+        """Test that negative minimum threshold is rejected."""
+        user_id = uuid4()
+        item_data = {
+            "name": "Test Item",
+            "quantity": 5.0,
+            "unit": "count",
+            "category": "produce",
+            "storage_location": "pantry",
+            "added_by": user_id,
+            "minimum_threshold": -2.0,
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            InventoryItemCreate(**item_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("minimum_threshold",) for error in errors)
+        assert any("negative" in error["msg"].lower() for error in errors)
+
+    def test_price_must_be_non_negative(self):
+        """Test that negative price is rejected."""
+        user_id = uuid4()
+        item_data = {
+            "name": "Test Item",
+            "quantity": 5.0,
+            "unit": "count",
+            "category": "produce",
+            "storage_location": "pantry",
+            "added_by": user_id,
+            "price": -10.50,
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            InventoryItemCreate(**item_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("price",) for error in errors)
+        assert any("negative" in error["msg"].lower() for error in errors)
+
+    def test_invalid_unit_is_rejected(self):
+        """Test that invalid unit value is rejected."""
+        user_id = uuid4()
+        item_data = {
+            "name": "Test Item",
+            "quantity": 5.0,
+            "unit": "invalid_unit",
+            "category": "produce",
+            "storage_location": "pantry",
+            "added_by": user_id,
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            InventoryItemCreate(**item_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("unit",) for error in errors)
+        assert any("must be one of" in error["msg"].lower() for error in errors)
+
+    def test_invalid_category_is_rejected(self):
+        """Test that invalid category value is rejected."""
+        user_id = uuid4()
+        item_data = {
+            "name": "Test Item",
+            "quantity": 5.0,
+            "unit": "count",
+            "category": "invalid_category",
+            "storage_location": "pantry",
+            "added_by": user_id,
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            InventoryItemCreate(**item_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("category",) for error in errors)
+        assert any("must be one of" in error["msg"].lower() for error in errors)
+
+    def test_invalid_storage_location_is_rejected(self):
+        """Test that invalid storage_location value is rejected."""
+        user_id = uuid4()
+        item_data = {
+            "name": "Test Item",
+            "quantity": 5.0,
+            "unit": "count",
+            "category": "produce",
+            "storage_location": "garage",
+            "added_by": user_id,
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            InventoryItemCreate(**item_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("storage_location",) for error in errors)
+        assert any("must be one of" in error["msg"].lower() for error in errors)
+
+    def test_invalid_shareability_is_rejected(self):
+        """Test that invalid shareability value is rejected."""
+        user_id = uuid4()
+        item_data = {
+            "name": "Test Item",
+            "quantity": 5.0,
+            "unit": "count",
+            "category": "produce",
+            "storage_location": "pantry",
+            "added_by": user_id,
+            "shareability": "invalid_shareability",
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            InventoryItemCreate(**item_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("shareability",) for error in errors)
+        assert any("must be one of" in error["msg"].lower() for error in errors)
+
+    def test_all_valid_units_are_accepted(self):
+        """Test that all valid UnitType enum values are accepted."""
+        user_id = uuid4()
+        for unit in UnitType:
+            item_data = {
+                "name": "Test Item",
+                "quantity": 1.0,
+                "unit": unit.value,
+                "category": "produce",
+                "storage_location": "pantry",
+                "added_by": user_id,
+            }
+            item = InventoryItemCreate(**item_data)
+            assert item.unit == unit.value
+
+    def test_all_valid_categories_are_accepted(self):
+        """Test that all valid Category enum values are accepted."""
+        user_id = uuid4()
+        for category in Category:
+            item_data = {
+                "name": "Test Item",
+                "quantity": 1.0,
+                "unit": "count",
+                "category": category.value,
+                "storage_location": "pantry",
+                "added_by": user_id,
+            }
+            item = InventoryItemCreate(**item_data)
+            assert item.category == category.value
+
+    def test_all_valid_storage_locations_are_accepted(self):
+        """Test that all valid StorageLocation enum values are accepted."""
+        user_id = uuid4()
+        for location in StorageLocation:
+            item_data = {
+                "name": "Test Item",
+                "quantity": 1.0,
+                "unit": "count",
+                "category": "produce",
+                "storage_location": location.value,
+                "added_by": user_id,
+            }
+            item = InventoryItemCreate(**item_data)
+            assert item.storage_location == location.value
+
+    def test_all_valid_shareability_values_are_accepted(self):
+        """Test that all valid Shareability enum values are accepted."""
+        user_id = uuid4()
+        for shareability in Shareability:
+            item_data = {
+                "name": "Test Item",
+                "quantity": 1.0,
+                "unit": "count",
+                "category": "produce",
+                "storage_location": "pantry",
+                "added_by": user_id,
+                "shareability": shareability.value,
+            }
+            item = InventoryItemCreate(**item_data)
+            assert item.shareability == shareability.value
+
+    def test_name_cannot_be_empty(self):
+        """Test that empty name is rejected."""
+        user_id = uuid4()
+        item_data = {
+            "name": "   ",
+            "quantity": 5.0,
+            "unit": "count",
+            "category": "produce",
+            "storage_location": "pantry",
+            "added_by": user_id,
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            InventoryItemCreate(**item_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("name",) for error in errors)
+        assert any("cannot be empty" in error["msg"].lower() for error in errors)
+
+    def test_name_whitespace_is_stripped(self):
+        """Test that whitespace in name is stripped."""
+        user_id = uuid4()
+        item_data = {
+            "name": "  Test Item  ",
+            "quantity": 5.0,
+            "unit": "count",
+            "category": "produce",
+            "storage_location": "pantry",
+            "added_by": user_id,
+        }
+        item = InventoryItemCreate(**item_data)
+        assert item.name == "Test Item"
+
+
+class TestInventoryItemUpdate:
+    """Tests for InventoryItemUpdate schema (partial updates)."""
+
+    def test_update_with_single_field(self):
+        """Test partial update with only one field."""
+        update_data = {"quantity": 10.0}
+        update = InventoryItemUpdate(**update_data)
+        assert update.quantity == 10.0
+        assert update.name is None
+        assert update.category is None
+
+    def test_update_with_multiple_fields(self):
+        """Test partial update with multiple fields."""
+        update_data = {
+            "quantity": 3.0,
+            "price": 15.99,
+            "is_staple": True,
+        }
+        update = InventoryItemUpdate(**update_data)
+        assert update.quantity == 3.0
+        assert update.price == 15.99
+        assert update.is_staple is True
+
+    def test_update_quantity_must_be_non_negative(self):
+        """Test that negative quantity is rejected in updates."""
+        update_data = {"quantity": -5.0}
+        with pytest.raises(ValidationError) as exc_info:
+            InventoryItemUpdate(**update_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("quantity",) for error in errors)
+        assert any("negative" in error["msg"].lower() for error in errors)
+
+    def test_update_invalid_unit_is_rejected(self):
+        """Test that invalid unit is rejected in updates."""
+        update_data = {"unit": "invalid_unit"}
+        with pytest.raises(ValidationError) as exc_info:
+            InventoryItemUpdate(**update_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("unit",) for error in errors)
+
+    def test_update_invalid_category_is_rejected(self):
+        """Test that invalid category is rejected in updates."""
+        update_data = {"category": "invalid_category"}
+        with pytest.raises(ValidationError) as exc_info:
+            InventoryItemUpdate(**update_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("category",) for error in errors)
+
+    def test_update_invalid_storage_location_is_rejected(self):
+        """Test that invalid storage_location is rejected in updates."""
+        update_data = {"storage_location": "garage"}
+        with pytest.raises(ValidationError) as exc_info:
+            InventoryItemUpdate(**update_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("storage_location",) for error in errors)
+
+    def test_update_invalid_shareability_is_rejected(self):
+        """Test that invalid shareability is rejected in updates."""
+        update_data = {"shareability": "invalid_value"}
+        with pytest.raises(ValidationError) as exc_info:
+            InventoryItemUpdate(**update_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("shareability",) for error in errors)
+
+    def test_update_name_cannot_be_empty(self):
+        """Test that empty name is rejected in updates."""
+        update_data = {"name": "   "}
+        with pytest.raises(ValidationError) as exc_info:
+            InventoryItemUpdate(**update_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("name",) for error in errors)
+        assert any("cannot be empty" in error["msg"].lower() for error in errors)
+
+    def test_update_name_whitespace_is_stripped(self):
+        """Test that whitespace in name is stripped during updates."""
+        update_data = {"name": "  Updated Name  "}
+        update = InventoryItemUpdate(**update_data)
+        assert update.name == "Updated Name"
+
+    def test_update_ignores_unknown_fields(self):
+        """Test that unknown fields are silently ignored."""
+        update_data = {
+            "quantity": 5.0,
+            "unknown_field": "should be ignored",
+        }
+        update = InventoryItemUpdate(**update_data)
+        assert update.quantity == 5.0
+        assert not hasattr(update, "unknown_field")
+
+    def test_empty_update_is_valid(self):
+        """Test that an empty update object is valid."""
+        update = InventoryItemUpdate()
+        assert update.name is None
+        assert update.quantity is None
+
+
+class TestInventoryItemResponse:
+    """Tests for InventoryItemResponse schema."""
+
+    def test_response_schema_has_all_fields(self):
+        """Test that response schema includes all expected fields."""
+        item_id = uuid4()
+        user_id = uuid4()
+        now = datetime.now()
+
+        response_data = {
+            "id": item_id,
+            "name": "Test Item",
+            "quantity": 5.0,
+            "unit": "count",
+            "category": "produce",
+            "vegan_friendly": True,
+            "storage_location": "fridge",
+            "date_added": now,
+            "expiration_date": None,
+            "frozen_date": None,
+            "is_staple": False,
+            "minimum_threshold": None,
+            "shareability": "shared",
+            "reserved_for": None,
+            "reserved_note": None,
+            "added_by": user_id,
+            "price": None,
+            "brand": None,
+            "preferred_store": None,
+        }
+        response = InventoryItemResponse(**response_data)
+        assert response.id == item_id
+        assert response.name == "Test Item"
+        assert response.date_added == now
+
+
+class TestInventoryItemListResponse:
+    """Tests for InventoryItemListResponse schema (summary fields)."""
+
+    def test_list_response_has_summary_fields(self):
+        """Test that list response includes summary fields only."""
+        item_id = uuid4()
+
+        response_data = {
+            "id": item_id,
+            "name": "Test Item",
+            "quantity": 5.0,
+            "unit": "count",
+            "category": "produce",
+            "storage_location": "fridge",
+            "shareability": "shared",
+            "is_staple": False,
+            "expiration_date": None,
+        }
+        response = InventoryItemListResponse(**response_data)
+        assert response.id == item_id
+        assert response.name == "Test Item"
+        assert response.quantity == 5.0


### PR DESCRIPTION
## Work in Progress

Closes #75

[Phase 1D] Create inventory Pydantic schemas

**Time Estimate**: 45min

**Description**:
Define Pydantic request/response schemas for inventory CRUD operations. Required before implementing inventory endpoints to ensure consistent validation and serialization.

**Claude Context**:
Files to Read:
- src/db/models/inventory_item.py (model definition with enums)
- src/schemas/auth.py (existing schema patterns in this codebase)

Files to Modify:
- src/schemas/inventory.py (create)
- src/schemas/__init__.py (export new schemas)

Related Issues: None

**Acceptance Criteria**:
- [ ] InventoryItemCreate schema with required fields (name, quantity, unit, category, storage_location, added_by) and optional fields (expiration_date, frozen_date, is_staple, minimum_threshold, shareability, reserved_note, price, brand, preferred_store): `python -c "from src.schemas.inventory import InventoryItemCreate; print('OK')"`
- [ ] InventoryItemUpdate schema with all fields optional for partial updates
- [ ] InventoryItemResponse schema matching the model
- [ ] InventoryItemListResponse schema for list endpoints with summary fields
- [ ] Enum validation for category, unit, storage_location, shareability matching model enums
- [ ] Quantity validation ensuring non-negative values
- [ ] Unit tests pass: `pytest tests/schemas/test_inventory.py -v`

**Verification Commands**:
```bash
pytest tests/schemas/test_inventory.py -v
python -c "from src.schemas.inventory import InventoryItemCreate, InventoryItemUpdate, InventoryItemResponse; print('All schemas imported')"
```

**Done Definition**: Done when all inventory schemas import cleanly, enum validation works, and unit tests pass.

**Scope Boundary**:
- DO: Create Pydantic schemas for inventory CRUD
- DO: Add validation for enums and quantity constraints
- DO: Add unit tests for schema validation
- DO NOT: Implement API endpoints (next issue)
- DO NOT: Add filtering/search schemas (separate issue)

**Dependencies**: None

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**7** files, **2** commits (+2 added, ~5 modified, -0 deleted)
- `M` .env.example
- `M` src/config.py
- `M` src/schemas/__init__.py
- `A` src/schemas/inventory.py
- `M` src/services/audit_service.py
- `A` tests/schemas/test_inventory.py
- `M` tests/services/test_audit_service.py

### Commits
- 27fbd8b feat: [Phase 1D] Create inventory Pydantic schemas
- 2042839 chore: initialize work on #75 [Phase 1D] Create inventory Pydantic schemas
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues
 Updated: #86 
**From assessment on 2026-03-19T05:40:03Z:**
- Created: #86 
- Updated: none