### PR TITLE
[Phase 1D] Add inventory CRUD endpoints

### DIFF
--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -1,5 +1,0 @@
-# Sharkrite Scratchpad
-
-## Encountered Issues (Needs Triage)
-
-- **2026-03-18** | `tests/routers/test_auth.py:test_register_password_exactly_128_characters` | test-failure | Password validation test expects 128-char passwords to be accepted but hash_password rejects passwords >72 bytes | Affects: User registration with long passwords | Fix: Either update test to expect 422 validation error or update password validation to truncate/reject at Pydantic level before hashing | Done: Test passes or validation is consistent across all layers

--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -1,0 +1,5 @@
+# Sharkrite Scratchpad
+
+## Encountered Issues (Needs Triage)
+
+- **2026-03-18** | `tests/routers/test_auth.py:test_register_password_exactly_128_characters` | test-failure | Password validation test expects 128-char passwords to be accepted but hash_password rejects passwords >72 bytes | Affects: User registration with long passwords | Fix: Either update test to expect 422 validation error or update password validation to truncate/reject at Pydantic level before hashing | Done: Test passes or validation is consistent across all layers

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ from sqlalchemy import inspect, text
 
 from src.config import get_settings
 from src.db.database import Base, init_engine, get_engine, get_session_factory
-from src.routers import auth_router, users_router, substitutions_router
+from src.routers import auth_router, users_router, substitutions_router, inventory_router
 
 settings = get_settings()
 
@@ -67,6 +67,7 @@ app = FastAPI(
 app.include_router(auth_router)
 app.include_router(users_router)
 app.include_router(substitutions_router)
+app.include_router(inventory_router)
 
 
 @app.get("/health")

--- a/src/routers/__init__.py
+++ b/src/routers/__init__.py
@@ -9,5 +9,6 @@
 from src.routers.auth import router as auth_router
 from src.routers.users import router as users_router
 from src.routers.substitutions import router as substitutions_router
+from src.routers.inventory import router as inventory_router
 
-__all__ = ["auth_router", "users_router", "substitutions_router"]
+__all__ = ["auth_router", "users_router", "substitutions_router", "inventory_router"]

--- a/src/routers/inventory.py
+++ b/src/routers/inventory.py
@@ -1,0 +1,308 @@
+"""
+InventoryItem CRUD endpoints for FreshUp.
+
+Provides endpoints for users to manage their kitchen inventory items.
+All endpoints are scoped to the authenticated user's inventory.
+"""
+
+import logging
+from uuid import UUID
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError, IntegrityError
+
+from src.db.database import get_db
+from src.db.models.user import User
+from src.db.models.inventory_item import InventoryItem
+from src.schemas.inventory import (
+    InventoryItemCreate,
+    InventoryItemUpdate,
+    InventoryItemResponse,
+    InventoryItemListResponse,
+)
+from src.middleware.auth import get_current_user
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/inventory", tags=["inventory"])
+
+
+@router.post("", response_model=InventoryItemResponse, status_code=status.HTTP_201_CREATED)
+def create_inventory_item(
+    item_data: InventoryItemCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Create a new inventory item for the authenticated user.
+
+    The added_by field is automatically set to the current user's ID,
+    ignoring any value provided in the request body.
+
+    Args:
+        item_data: Inventory item data (name, quantity, unit, category, etc.)
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        InventoryItemResponse: Created inventory item
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(400): If data integrity violation occurs
+        HTTPException(422): If validation fails (invalid unit, category, etc.)
+    """
+    # Create new inventory item with added_by set to current user
+    # Ignore any added_by value from request body for security
+    item_dict = item_data.model_dump(exclude={'added_by'})
+    new_item = InventoryItem(
+        **item_dict,
+        added_by=current_user.id,
+    )
+
+    db.add(new_item)
+
+    try:
+        db.commit()
+        db.refresh(new_item)
+    except IntegrityError as e:
+        db.rollback()
+        logger.error(f"Integrity error during inventory item creation for user {current_user.id}")
+        logger.debug(f"Integrity error details: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Inventory item creation failed due to data integrity violation"
+        )
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during inventory item creation for user {current_user.id}")
+        logger.debug(f"Database error details: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while creating the inventory item"
+        )
+
+    logger.info(
+        f"Inventory item created: user_id={current_user.id}, "
+        f"item_name={item_data.name}, "
+        f"item_id={new_item.id}"
+    )
+
+    return new_item
+
+
+@router.get("", response_model=list[InventoryItemListResponse])
+def list_inventory_items(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+    limit: int = Query(default=50, ge=1, le=100, description="Maximum number of items to return"),
+    offset: int = Query(default=0, ge=0, description="Number of items to skip"),
+):
+    """
+    List inventory items for the authenticated user with pagination.
+
+    Returns items owned by the current user, ordered by most recently added first.
+    Supports pagination via limit and offset query parameters.
+
+    Args:
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+        limit: Maximum number of items to return (1-100, default 50)
+        offset: Number of items to skip (default 0)
+
+    Returns:
+        list[InventoryItemListResponse]: List of user's inventory items
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+    """
+    items = (
+        db.query(InventoryItem)
+        .filter(InventoryItem.added_by == current_user.id)
+        .order_by(InventoryItem.date_added.desc())
+        .limit(limit)
+        .offset(offset)
+        .all()
+    )
+
+    return items
+
+
+@router.get("/{item_id}", response_model=InventoryItemResponse)
+def get_inventory_item(
+    item_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Get a single inventory item by ID.
+
+    Retrieves a specific inventory item. Returns 404 if the item doesn't exist
+    or belongs to a different user (preventing cross-user access).
+
+    Args:
+        item_id: UUID of the inventory item to retrieve
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        InventoryItemResponse: Requested inventory item
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If item doesn't exist or belongs to another user
+    """
+    item = (
+        db.query(InventoryItem)
+        .filter(
+            InventoryItem.id == item_id,
+            InventoryItem.added_by == current_user.id,
+        )
+        .first()
+    )
+
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Inventory item not found"
+        )
+
+    return item
+
+
+@router.put("/{item_id}", response_model=InventoryItemResponse)
+def update_inventory_item(
+    item_id: UUID,
+    update_data: InventoryItemUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Update an inventory item with partial data.
+
+    Allows partial updates - only provided fields will be updated. Returns 404
+    if the item doesn't exist or belongs to a different user.
+
+    Args:
+        item_id: UUID of the inventory item to update
+        update_data: Fields to update (all optional)
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        InventoryItemResponse: Updated inventory item
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If item doesn't exist or belongs to another user
+        HTTPException(422): If validation fails (invalid unit, category, etc.)
+    """
+    # Query item with user ownership check
+    item = (
+        db.query(InventoryItem)
+        .filter(
+            InventoryItem.id == item_id,
+            InventoryItem.added_by == current_user.id,
+        )
+        .first()
+    )
+
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Inventory item not found"
+        )
+
+    # Update only the fields that were provided
+    update_dict = update_data.model_dump(exclude_unset=True)
+
+    # Apply updates
+    for field, value in update_dict.items():
+        setattr(item, field, value)
+
+    try:
+        db.commit()
+        db.refresh(item)
+    except IntegrityError as e:
+        db.rollback()
+        logger.error(f"Integrity error during inventory item update for user {current_user.id}")
+        logger.debug(f"Integrity error details: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Inventory item update failed due to data integrity violation"
+        )
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during inventory item update for user {current_user.id}")
+        logger.debug(f"Database error details: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while updating the inventory item"
+        )
+
+    logger.info(
+        f"Inventory item updated: user_id={current_user.id}, "
+        f"item_id={item_id}"
+    )
+
+    return item
+
+
+@router.delete("/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_inventory_item(
+    item_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Delete an inventory item.
+
+    Removes the specified inventory item. Returns 404 if the item doesn't exist
+    or belongs to a different user.
+
+    Args:
+        item_id: UUID of the inventory item to delete
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        None (204 No Content on success)
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If item doesn't exist or belongs to another user
+    """
+    # Query item with user ownership check
+    item = (
+        db.query(InventoryItem)
+        .filter(
+            InventoryItem.id == item_id,
+            InventoryItem.added_by == current_user.id,
+        )
+        .first()
+    )
+
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Inventory item not found"
+        )
+
+    try:
+        db.delete(item)
+        db.commit()
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during inventory item deletion for user {current_user.id}")
+        logger.debug(f"Database error details: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while deleting the inventory item"
+        )
+
+    logger.info(
+        f"Inventory item deleted: user_id={current_user.id}, "
+        f"item_id={item_id}"
+    )
+
+    return None

--- a/src/routers/inventory.py
+++ b/src/routers/inventory.py
@@ -68,7 +68,7 @@ def create_inventory_item(
     except IntegrityError as e:
         db.rollback()
         logger.error(f"Integrity error during inventory item creation for user {current_user.id}")
-        logger.debug(f"Integrity error details: {str(e)}")
+        logger.debug("Integrity error occurred during inventory item creation")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Inventory item creation failed due to data integrity violation"
@@ -76,7 +76,7 @@ def create_inventory_item(
     except SQLAlchemyError as e:
         db.rollback()
         logger.error(f"Database error during inventory item creation for user {current_user.id}")
-        logger.debug(f"Database error details: {str(e)}")
+        logger.debug("Database error occurred during inventory item creation")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An error occurred while creating the inventory item"
@@ -226,7 +226,7 @@ def update_inventory_item(
     except IntegrityError as e:
         db.rollback()
         logger.error(f"Integrity error during inventory item update for user {current_user.id}")
-        logger.debug(f"Integrity error details: {str(e)}")
+        logger.debug("Integrity error occurred during inventory item update")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Inventory item update failed due to data integrity violation"
@@ -234,7 +234,7 @@ def update_inventory_item(
     except SQLAlchemyError as e:
         db.rollback()
         logger.error(f"Database error during inventory item update for user {current_user.id}")
-        logger.debug(f"Database error details: {str(e)}")
+        logger.debug("Database error occurred during inventory item update")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An error occurred while updating the inventory item"
@@ -294,7 +294,7 @@ def delete_inventory_item(
     except SQLAlchemyError as e:
         db.rollback()
         logger.error(f"Database error during inventory item deletion for user {current_user.id}")
-        logger.debug(f"Database error details: {str(e)}")
+        logger.debug("Database error occurred during inventory item deletion")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An error occurred while deleting the inventory item"

--- a/src/routers/inventory.py
+++ b/src/routers/inventory.py
@@ -68,7 +68,7 @@ def create_inventory_item(
     except IntegrityError as e:
         db.rollback()
         logger.error(f"Integrity error during inventory item creation for user {current_user.id}")
-        logger.debug("Integrity error occurred during inventory item creation")
+        logger.debug(f"Integrity error occurred during inventory item creation: {e}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Inventory item creation failed due to data integrity violation"
@@ -76,7 +76,7 @@ def create_inventory_item(
     except SQLAlchemyError as e:
         db.rollback()
         logger.error(f"Database error during inventory item creation for user {current_user.id}")
-        logger.debug("Database error occurred during inventory item creation")
+        logger.debug(f"Database error occurred during inventory item creation: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An error occurred while creating the inventory item"
@@ -226,7 +226,7 @@ def update_inventory_item(
     except IntegrityError as e:
         db.rollback()
         logger.error(f"Integrity error during inventory item update for user {current_user.id}")
-        logger.debug("Integrity error occurred during inventory item update")
+        logger.debug(f"Integrity error occurred during inventory item update: {e}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Inventory item update failed due to data integrity violation"
@@ -234,7 +234,7 @@ def update_inventory_item(
     except SQLAlchemyError as e:
         db.rollback()
         logger.error(f"Database error during inventory item update for user {current_user.id}")
-        logger.debug("Database error occurred during inventory item update")
+        logger.debug(f"Database error occurred during inventory item update: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An error occurred while updating the inventory item"
@@ -294,7 +294,7 @@ def delete_inventory_item(
     except SQLAlchemyError as e:
         db.rollback()
         logger.error(f"Database error during inventory item deletion for user {current_user.id}")
-        logger.debug("Database error occurred during inventory item deletion")
+        logger.debug(f"Database error occurred during inventory item deletion: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An error occurred while deleting the inventory item"

--- a/tests/routers/test_inventory.py
+++ b/tests/routers/test_inventory.py
@@ -17,7 +17,6 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from uuid import uuid4
-from datetime import datetime
 
 from src.db.database import Base, get_db
 from src.db import models

--- a/tests/routers/test_inventory.py
+++ b/tests/routers/test_inventory.py
@@ -1,0 +1,668 @@
+"""
+Integration tests for inventory item endpoints.
+
+Tests cover:
+- POST /inventory: create items with validation
+- GET /inventory: list all user items with pagination
+- GET /inventory/{id}: get single item
+- PUT /inventory/{id}: update items with partial data
+- DELETE /inventory/{id}: delete item
+- Cross-user access prevention
+- Authentication requirements
+- Validation (quantity, unit, category, etc.)
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from uuid import uuid4
+from datetime import datetime
+
+from src.db.database import Base, get_db
+from src.db import models
+from src.db.models.user import User, UserRole
+from src.db.models.inventory_item import InventoryItem
+from src.services.auth_service import hash_password, create_access_token
+
+from fastapi import FastAPI
+from src.routers import inventory_router
+
+# Create a test app without lifespan
+app = FastAPI(
+    title="FreshUp",
+    description="Privacy-first kitchen management system",
+    version="0.1.0",
+)
+
+# Register the inventory router
+app.include_router(inventory_router)
+
+
+# Create an in-memory SQLite database for testing
+TEST_DATABASE_URL = "sqlite:///:memory:"
+
+
+@pytest.fixture(autouse=True)
+def setup_test_env(monkeypatch):
+    """Set up test environment variables."""
+    from src.config import get_settings
+    get_settings.cache_clear()
+
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars")
+    monkeypatch.setenv("JWT_ALGORITHM", "HS256")
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    monkeypatch.setenv("ACCESS_TOKEN_EXPIRE_MINUTES", "43200")
+
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def db_session():
+    """Create a fresh database session for each test."""
+    from sqlalchemy.pool import StaticPool
+
+    # Import models to ensure all SQLAlchemy model classes are registered
+    # with Base.metadata before create_all() is called
+    _ = models
+
+    engine = create_engine(
+        TEST_DATABASE_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+@pytest.fixture
+def client(db_session):
+    """Create a test client with database dependency override."""
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def test_user(db_session):
+    """Create a test user."""
+    user = User(
+        id=uuid4(),
+        email="test@example.com",
+        hashed_password=hash_password("testpassword123"),
+        name="Test User",
+        role=UserRole.member.value,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def test_user2(db_session):
+    """Create a second test user for cross-user access tests."""
+    user = User(
+        id=uuid4(),
+        email="test2@example.com",
+        hashed_password=hash_password("testpassword123"),
+        name="Test User 2",
+        role=UserRole.member.value,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def auth_headers(test_user):
+    """Generate authorization headers for test user."""
+    access_token = create_access_token({"sub": str(test_user.id)})
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+@pytest.fixture
+def auth_headers2(test_user2):
+    """Generate authorization headers for test user 2."""
+    access_token = create_access_token({"sub": str(test_user2.id)})
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+class TestCreateInventoryItem:
+    """Tests for POST /inventory (create inventory item)."""
+
+    def test_create_item_success(self, client, auth_headers, test_user, db_session):
+        """Should create inventory item and auto-set added_by to current user."""
+        payload = {
+            "name": "Milk",
+            "quantity": 1.0,
+            "unit": "gallon",
+            "category": "dairy",
+            "storage_location": "fridge",
+            "added_by": str(uuid4()),  # Should be ignored
+        }
+
+        response = client.post("/inventory", json=payload, headers=auth_headers)
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["name"] == "Milk"
+        assert data["quantity"] == 1.0
+        assert data["unit"] == "gallon"
+        assert data["category"] == "dairy"
+        assert data["storage_location"] == "fridge"
+        assert data["added_by"] == str(test_user.id)  # Should be current user, not from payload
+        assert "id" in data
+        assert "date_added" in data
+
+    def test_create_item_with_optional_fields(self, client, auth_headers, test_user):
+        """Should create item with optional fields."""
+        payload = {
+            "name": "Organic Eggs",
+            "quantity": 12,
+            "unit": "count",
+            "category": "protein",
+            "storage_location": "fridge",
+            "added_by": str(test_user.id),
+            "is_staple": True,
+            "minimum_threshold": 6.0,
+            "price": 4.99,
+            "brand": "Happy Hens",
+            "vegan_friendly": False,
+        }
+
+        response = client.post("/inventory", json=payload, headers=auth_headers)
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["is_staple"] is True
+        assert data["minimum_threshold"] == 6.0
+        assert data["price"] == 4.99
+        assert data["brand"] == "Happy Hens"
+        assert data["vegan_friendly"] is False
+
+    def test_create_item_requires_auth(self, client):
+        """Should return 401 if no auth token provided."""
+        payload = {
+            "name": "Milk",
+            "quantity": 1.0,
+            "unit": "gallon",
+            "category": "dairy",
+            "storage_location": "fridge",
+            "added_by": str(uuid4()),
+        }
+
+        response = client.post("/inventory", json=payload)
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Not authenticated"
+
+    def test_create_item_invalid_unit(self, client, auth_headers, test_user):
+        """Should return 422 if unit is invalid."""
+        payload = {
+            "name": "Milk",
+            "quantity": 1.0,
+            "unit": "invalid_unit",
+            "category": "dairy",
+            "storage_location": "fridge",
+            "added_by": str(test_user.id),
+        }
+
+        response = client.post("/inventory", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+
+    def test_create_item_invalid_category(self, client, auth_headers, test_user):
+        """Should return 422 if category is invalid."""
+        payload = {
+            "name": "Milk",
+            "quantity": 1.0,
+            "unit": "gallon",
+            "category": "invalid_category",
+            "storage_location": "fridge",
+            "added_by": str(test_user.id),
+        }
+
+        response = client.post("/inventory", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+
+    def test_create_item_negative_quantity(self, client, auth_headers, test_user):
+        """Should return 422 if quantity is negative."""
+        payload = {
+            "name": "Milk",
+            "quantity": -1.0,
+            "unit": "gallon",
+            "category": "dairy",
+            "storage_location": "fridge",
+            "added_by": str(test_user.id),
+        }
+
+        response = client.post("/inventory", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+
+    def test_create_item_empty_name(self, client, auth_headers, test_user):
+        """Should return 422 if name is empty."""
+        payload = {
+            "name": "   ",
+            "quantity": 1.0,
+            "unit": "gallon",
+            "category": "dairy",
+            "storage_location": "fridge",
+            "added_by": str(test_user.id),
+        }
+
+        response = client.post("/inventory", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+
+
+class TestListInventoryItems:
+    """Tests for GET /inventory (list inventory items)."""
+
+    def test_list_items_empty(self, client, auth_headers):
+        """Should return empty list if user has no items."""
+        response = client.get("/inventory", headers=auth_headers)
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_list_items_success(self, client, auth_headers, test_user, db_session):
+        """Should return user's inventory items ordered by date_added DESC."""
+        # Create multiple items
+        item1 = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        item2 = InventoryItem(
+            name="Bread",
+            quantity=2.0,
+            unit="count",
+            category="grain",
+            storage_location="pantry",
+            added_by=test_user.id,
+        )
+        db_session.add_all([item1, item2])
+        db_session.commit()
+
+        response = client.get("/inventory", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        # Verify both items are present (order may vary if created at same time)
+        item_names = {item["name"] for item in data}
+        assert item_names == {"Milk", "Bread"}
+
+    def test_list_items_multi_tenant_isolation(self, client, auth_headers, auth_headers2, test_user, test_user2, db_session):
+        """Should only return items owned by current user."""
+        # Create items for both users
+        item1 = InventoryItem(
+            name="User 1 Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        item2 = InventoryItem(
+            name="User 2 Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user2.id,
+        )
+        db_session.add_all([item1, item2])
+        db_session.commit()
+
+        # User 1 should only see their item
+        response = client.get("/inventory", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "User 1 Milk"
+
+        # User 2 should only see their item
+        response = client.get("/inventory", headers=auth_headers2)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "User 2 Milk"
+
+    def test_list_items_pagination(self, client, auth_headers, test_user, db_session):
+        """Should support pagination with limit and offset."""
+        # Create 5 items
+        for i in range(5):
+            item = InventoryItem(
+                name=f"Item {i}",
+                quantity=1.0,
+                unit="count",
+                category="other",
+                storage_location="pantry",
+                added_by=test_user.id,
+            )
+            db_session.add(item)
+        db_session.commit()
+
+        # Get first 2 items
+        response = client.get("/inventory?limit=2&offset=0", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+
+        # Get next 2 items
+        response = client.get("/inventory?limit=2&offset=2", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+
+        # Get last item
+        response = client.get("/inventory?limit=2&offset=4", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+
+    def test_list_items_requires_auth(self, client):
+        """Should return 401 if no auth token provided."""
+        response = client.get("/inventory")
+
+        assert response.status_code == 401
+
+
+class TestGetInventoryItem:
+    """Tests for GET /inventory/{id} (get single item)."""
+
+    def test_get_item_success(self, client, auth_headers, test_user, db_session):
+        """Should return single inventory item."""
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        response = client.get(f"/inventory/{item.id}", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == str(item.id)
+        assert data["name"] == "Milk"
+        assert data["quantity"] == 1.0
+
+    def test_get_item_not_found(self, client, auth_headers):
+        """Should return 404 if item doesn't exist."""
+        fake_id = uuid4()
+        response = client.get(f"/inventory/{fake_id}", headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Inventory item not found"
+
+    def test_get_item_cross_user_access_denied(self, client, auth_headers, test_user2, db_session):
+        """Should return 404 if item belongs to another user."""
+        # Create item for user 2
+        item = InventoryItem(
+            name="User 2 Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user2.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # User 1 tries to access user 2's item
+        response = client.get(f"/inventory/{item.id}", headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Inventory item not found"
+
+    def test_get_item_requires_auth(self, client, test_user, db_session):
+        """Should return 401 if no auth token provided."""
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        response = client.get(f"/inventory/{item.id}")
+
+        assert response.status_code == 401
+
+
+class TestUpdateInventoryItem:
+    """Tests for PUT /inventory/{id} (update item)."""
+
+    def test_update_item_partial(self, client, auth_headers, test_user, db_session):
+        """Should update only provided fields."""
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Update only quantity
+        payload = {"quantity": 0.5}
+        response = client.put(f"/inventory/{item.id}", json=payload, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["quantity"] == 0.5
+        assert data["name"] == "Milk"  # Unchanged
+        assert data["unit"] == "gallon"  # Unchanged
+
+    def test_update_item_multiple_fields(self, client, auth_headers, test_user, db_session):
+        """Should update multiple fields at once."""
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        payload = {
+            "quantity": 2.0,
+            "storage_location": "pantry",
+            "is_staple": True,
+        }
+        response = client.put(f"/inventory/{item.id}", json=payload, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["quantity"] == 2.0
+        assert data["storage_location"] == "pantry"
+        assert data["is_staple"] is True
+
+    def test_update_item_not_found(self, client, auth_headers):
+        """Should return 404 if item doesn't exist."""
+        fake_id = uuid4()
+        payload = {"quantity": 2.0}
+        response = client.put(f"/inventory/{fake_id}", json=payload, headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Inventory item not found"
+
+    def test_update_item_cross_user_access_denied(self, client, auth_headers, test_user2, db_session):
+        """Should return 404 if item belongs to another user."""
+        # Create item for user 2
+        item = InventoryItem(
+            name="User 2 Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user2.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # User 1 tries to update user 2's item
+        payload = {"quantity": 2.0}
+        response = client.put(f"/inventory/{item.id}", json=payload, headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Inventory item not found"
+
+    def test_update_item_invalid_field(self, client, auth_headers, test_user, db_session):
+        """Should return 422 if validation fails."""
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Try to update with invalid unit
+        payload = {"unit": "invalid_unit"}
+        response = client.put(f"/inventory/{item.id}", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+
+    def test_update_item_requires_auth(self, client, test_user, db_session):
+        """Should return 401 if no auth token provided."""
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        payload = {"quantity": 2.0}
+        response = client.put(f"/inventory/{item.id}", json=payload)
+
+        assert response.status_code == 401
+
+
+class TestDeleteInventoryItem:
+    """Tests for DELETE /inventory/{id} (delete item)."""
+
+    def test_delete_item_success(self, client, auth_headers, test_user, db_session):
+        """Should delete inventory item and return 204."""
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+        item_id = item.id
+
+        response = client.delete(f"/inventory/{item_id}", headers=auth_headers)
+
+        assert response.status_code == 204
+
+        # Verify item is deleted
+        deleted_item = db_session.query(InventoryItem).filter(InventoryItem.id == item_id).first()
+        assert deleted_item is None
+
+    def test_delete_item_not_found(self, client, auth_headers):
+        """Should return 404 if item doesn't exist."""
+        fake_id = uuid4()
+        response = client.delete(f"/inventory/{fake_id}", headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Inventory item not found"
+
+    def test_delete_item_cross_user_access_denied(self, client, auth_headers, test_user2, db_session):
+        """Should return 404 if item belongs to another user."""
+        # Create item for user 2
+        item = InventoryItem(
+            name="User 2 Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user2.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # User 1 tries to delete user 2's item
+        response = client.delete(f"/inventory/{item.id}", headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Inventory item not found"
+
+        # Verify item is NOT deleted
+        still_exists = db_session.query(InventoryItem).filter(InventoryItem.id == item.id).first()
+        assert still_exists is not None
+
+    def test_delete_item_requires_auth(self, client, test_user, db_session):
+        """Should return 401 if no auth token provided."""
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        response = client.delete(f"/inventory/{item.id}")
+
+        assert response.status_code == 401


### PR DESCRIPTION
## Work in Progress

Closes #76

[Phase 1D] Add inventory CRUD endpoints

**Time Estimate**: 2hr

**Description**:
Implement full CRUD (Create, Read, Update, Delete) endpoints for inventory items. Users need to add, view, modify, and remove items from their kitchen inventory.

**Claude Context**:
Files to Read:
- src/db/models/inventory_item.py (model with relationships)
- src/routers/substitutions.py (existing router pattern)
- src/middleware/auth.py (get_current_user dependency)

Files to Modify:
- src/routers/inventory.py (create)
- src/routers/__init__.py (register router)
- src/main.py (include router)

Related Issues: #75 (schemas must exist first)

**Acceptance Criteria**:
- [ ] POST /inventory creates item and returns 201: `curl -X POST localhost:8000/inventory -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d '{"name":"Milk","quantity":1,"unit":"gallon","category":"dairy","storage_location":"fridge"}'`
- [ ] GET /inventory returns paginated list of items: `curl localhost:8000/inventory -H "Authorization: Bearer $TOKEN"`
- [ ] GET /inventory/{id} returns single item with 200 or 404: `curl localhost:8000/inventory/{id} -H "Authorization: Bearer $TOKEN"`
- [ ] PUT /inventory/{id} updates item with partial data: `curl -X PUT localhost:8000/inventory/{id} -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d '{"quantity":0.5}'`
- [ ] DELETE /inventory/{id} removes item and returns 204: `curl -X DELETE localhost:8000/inventory/{id} -H "Authorization: Bearer $TOKEN"`
- [ ] All endpoints require authentication (401 without token)
- [ ] added_by is automatically set to current user on create

**Verification Commands**:
```bash
pytest tests/routers/test_inventory.py -v
curl -X POST http://localhost:8000/inventory \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"name":"Test Item","quantity":1,"unit":"count","category":"other","storage_location":"pantry"}'
```

**Done Definition**: Done when all CRUD endpoints work with authentication and basic unit tests pass.

**Scope Boundary**:
- DO: Implement POST, GET (list), GET (single), PUT, DELETE endpoints
- DO: Require authentication on all endpoints
- DO: Auto-set added_by to current user
- DO: Add basic unit tests for each endpoint
- DO NOT: Add filtering/search functionality (separate issue)
- DO NOT: Add store mapping endpoints (separate issue)
- DO NOT: Add quick action endpoints (separate issues)

**Dependencies**: After #75

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**5** files, **2** commits (+3 added, ~2 modified, -0 deleted)
- `A` SCRATCHPAD.md
- `M` src/main.py
- `M` src/routers/__init__.py
- `A` src/routers/inventory.py
- `A` tests/routers/test_inventory.py

### Commits
- 6828148 feat: [Phase 1D] Add inventory CRUD endpoints
- d39ebbd chore: initialize work on #76 [Phase 1D] Add inventory CRUD endpoints
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues
 Updated: #89 
**From assessment on 2026-03-19T06:02:10Z:**
- Created: #91 
- Updated: none