### PR TITLE
[Phase 1D] Add inventory filtering and search

### DIFF
--- a/src/routers/inventory.py
+++ b/src/routers/inventory.py
@@ -105,7 +105,7 @@ def list_inventory_items(
     is_staple: Optional[bool] = Query(default=None, description="Filter by staple status"),
     expiring_soon: Optional[bool] = Query(default=None, description="Filter items expiring within 7 days"),
     expiring_within_days: Optional[int] = Query(default=None, ge=1, description="Filter items expiring within N days"),
-    search: Optional[str] = Query(default=None, max_length=255, description="Search items by name (case-insensitive partial match)"),
+    search: Optional[str] = Query(default=None, min_length=2, max_length=255, description="Search items by name (case-insensitive partial match)"),
 ):
     """
     List inventory items for the authenticated user with filtering and pagination.

--- a/src/routers/inventory.py
+++ b/src/routers/inventory.py
@@ -7,7 +7,7 @@ All endpoints are scoped to the authenticated user's inventory.
 
 import logging
 from uuid import UUID
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
@@ -105,7 +105,7 @@ def list_inventory_items(
     is_staple: Optional[bool] = Query(default=None, description="Filter by staple status"),
     expiring_soon: Optional[bool] = Query(default=None, description="Filter items expiring within 7 days"),
     expiring_within_days: Optional[int] = Query(default=None, ge=1, description="Filter items expiring within N days"),
-    search: Optional[str] = Query(default=None, description="Search items by name (case-insensitive partial match)"),
+    search: Optional[str] = Query(default=None, max_length=255, description="Search items by name (case-insensitive partial match)"),
 ):
     """
     List inventory items for the authenticated user with filtering and pagination.
@@ -178,14 +178,14 @@ def list_inventory_items(
     # Apply expiration filters
     # expiring_within_days takes precedence over expiring_soon if both provided
     if expiring_within_days is not None:
-        expiration_cutoff = datetime.now() + timedelta(days=expiring_within_days)
+        expiration_cutoff = datetime.now(timezone.utc) + timedelta(days=expiring_within_days)
         query = query.filter(
             InventoryItem.expiration_date.isnot(None),
             InventoryItem.expiration_date <= expiration_cutoff
         )
     elif expiring_soon is not None and expiring_soon:
         # expiring_soon means within 7 days
-        expiration_cutoff = datetime.now() + timedelta(days=7)
+        expiration_cutoff = datetime.now(timezone.utc) + timedelta(days=7)
         query = query.filter(
             InventoryItem.expiration_date.isnot(None),
             InventoryItem.expiration_date <= expiration_cutoff
@@ -193,7 +193,9 @@ def list_inventory_items(
 
     # Apply name search filter (case-insensitive partial match)
     if search is not None:
-        query = query.filter(InventoryItem.name.ilike(f"%{search}%"))
+        # Escape LIKE wildcards to prevent DoS via expensive pattern matching
+        escaped_search = search.replace('%', r'\%').replace('_', r'\_')
+        query = query.filter(InventoryItem.name.ilike(f"%{escaped_search}%", escape='\\'))
 
     # Apply ordering and pagination
     items = (

--- a/src/routers/inventory.py
+++ b/src/routers/inventory.py
@@ -7,13 +7,15 @@ All endpoints are scoped to the authenticated user's inventory.
 
 import logging
 from uuid import UUID
+from datetime import datetime, timedelta
+from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError, IntegrityError
 
 from src.db.database import get_db
 from src.db.models.user import User
-from src.db.models.inventory_item import InventoryItem
+from src.db.models.inventory_item import InventoryItem, Category, StorageLocation, Shareability
 from src.schemas.inventory import (
     InventoryItemCreate,
     InventoryItemUpdate,
@@ -97,28 +99,105 @@ def list_inventory_items(
     db: Session = Depends(get_db),
     limit: int = Query(default=50, ge=1, le=100, description="Maximum number of items to return"),
     offset: int = Query(default=0, ge=0, description="Number of items to skip"),
+    category: Optional[str] = Query(default=None, description="Filter by category (e.g., produce, dairy, protein)"),
+    storage_location: Optional[str] = Query(default=None, description="Filter by storage location (pantry, fridge, freezer)"),
+    shareability: Optional[str] = Query(default=None, description="Filter by shareability (shared, reserved, personal)"),
+    is_staple: Optional[bool] = Query(default=None, description="Filter by staple status"),
+    expiring_soon: Optional[bool] = Query(default=None, description="Filter items expiring within 7 days"),
+    expiring_within_days: Optional[int] = Query(default=None, ge=1, description="Filter items expiring within N days"),
+    search: Optional[str] = Query(default=None, description="Search items by name (case-insensitive partial match)"),
 ):
     """
-    List inventory items for the authenticated user with pagination.
+    List inventory items for the authenticated user with filtering and pagination.
 
     Returns items owned by the current user, ordered by most recently added first.
     Supports pagination via limit and offset query parameters.
+    Supports filtering by category, storage location, shareability, staple status,
+    expiration status, and name search. Multiple filters combine with AND logic.
 
     Args:
         current_user: Authenticated user (injected by get_current_user dependency)
         db: Database session
         limit: Maximum number of items to return (1-100, default 50)
         offset: Number of items to skip (default 0)
+        category: Filter by category (must be valid Category enum value)
+        storage_location: Filter by storage location (must be valid StorageLocation enum value)
+        shareability: Filter by shareability (must be valid Shareability enum value)
+        is_staple: Filter by staple status (true/false)
+        expiring_soon: Filter items expiring within 7 days (true/false)
+        expiring_within_days: Filter items expiring within N days (overrides expiring_soon if both provided)
+        search: Search items by name (case-insensitive partial match)
 
     Returns:
-        list[InventoryItemListResponse]: List of user's inventory items
+        list[InventoryItemListResponse]: List of user's inventory items matching filters
 
     Raises:
         HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(422): If invalid enum value provided for category, storage_location, or shareability
     """
+    # Start with base query filtering by user
+    query = db.query(InventoryItem).filter(InventoryItem.added_by == current_user.id)
+
+    # Apply category filter
+    if category is not None:
+        # Validate category enum
+        valid_categories = [cat.value for cat in Category]
+        if category not in valid_categories:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Invalid category. Must be one of: {', '.join(valid_categories)}"
+            )
+        query = query.filter(InventoryItem.category == category)
+
+    # Apply storage_location filter
+    if storage_location is not None:
+        # Validate storage_location enum
+        valid_locations = [loc.value for loc in StorageLocation]
+        if storage_location not in valid_locations:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Invalid storage_location. Must be one of: {', '.join(valid_locations)}"
+            )
+        query = query.filter(InventoryItem.storage_location == storage_location)
+
+    # Apply shareability filter
+    if shareability is not None:
+        # Validate shareability enum
+        valid_shareability = [share.value for share in Shareability]
+        if shareability not in valid_shareability:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Invalid shareability. Must be one of: {', '.join(valid_shareability)}"
+            )
+        query = query.filter(InventoryItem.shareability == shareability)
+
+    # Apply is_staple filter
+    if is_staple is not None:
+        query = query.filter(InventoryItem.is_staple == is_staple)
+
+    # Apply expiration filters
+    # expiring_within_days takes precedence over expiring_soon if both provided
+    if expiring_within_days is not None:
+        expiration_cutoff = datetime.now() + timedelta(days=expiring_within_days)
+        query = query.filter(
+            InventoryItem.expiration_date.isnot(None),
+            InventoryItem.expiration_date <= expiration_cutoff
+        )
+    elif expiring_soon is not None and expiring_soon:
+        # expiring_soon means within 7 days
+        expiration_cutoff = datetime.now() + timedelta(days=7)
+        query = query.filter(
+            InventoryItem.expiration_date.isnot(None),
+            InventoryItem.expiration_date <= expiration_cutoff
+        )
+
+    # Apply name search filter (case-insensitive partial match)
+    if search is not None:
+        query = query.filter(InventoryItem.name.ilike(f"%{search}%"))
+
+    # Apply ordering and pagination
     items = (
-        db.query(InventoryItem)
-        .filter(InventoryItem.added_by == current_user.id)
+        query
         .order_by(InventoryItem.date_added.desc())
         .limit(limit)
         .offset(offset)

--- a/tests/routers/test_inventory.py
+++ b/tests/routers/test_inventory.py
@@ -17,7 +17,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from uuid import uuid4
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from src.db.database import Base, get_db
 from src.db import models
@@ -858,7 +858,7 @@ class TestFilterInventoryItems:
             unit="gallon",
             category="dairy",
             storage_location="fridge",
-            expiration_date=datetime.now() + timedelta(days=3),
+            expiration_date=datetime.now(timezone.utc) + timedelta(days=3),
             added_by=test_user.id,
         )
         expiring_later_item = InventoryItem(
@@ -867,7 +867,7 @@ class TestFilterInventoryItems:
             unit="gallon",
             category="dairy",
             storage_location="fridge",
-            expiration_date=datetime.now() + timedelta(days=14),
+            expiration_date=datetime.now(timezone.utc) + timedelta(days=14),
             added_by=test_user.id,
         )
         no_expiration_item = InventoryItem(
@@ -905,7 +905,7 @@ class TestFilterInventoryItems:
             unit="gallon",
             category="dairy",
             storage_location="fridge",
-            expiration_date=datetime.now() + timedelta(days=2),
+            expiration_date=datetime.now(timezone.utc) + timedelta(days=2),
             added_by=test_user.id,
         )
         expiring_in_5_days = InventoryItem(
@@ -914,7 +914,7 @@ class TestFilterInventoryItems:
             unit="gallon",
             category="dairy",
             storage_location="fridge",
-            expiration_date=datetime.now() + timedelta(days=5),
+            expiration_date=datetime.now(timezone.utc) + timedelta(days=5),
             added_by=test_user.id,
         )
         expiring_in_10_days = InventoryItem(
@@ -923,7 +923,7 @@ class TestFilterInventoryItems:
             unit="gallon",
             category="dairy",
             storage_location="fridge",
-            expiration_date=datetime.now() + timedelta(days=10),
+            expiration_date=datetime.now(timezone.utc) + timedelta(days=10),
             added_by=test_user.id,
         )
         db_session.add_all([expiring_in_2_days, expiring_in_5_days, expiring_in_10_days])
@@ -1137,7 +1137,7 @@ class TestFilterInventoryItems:
             unit="gallon",
             category="dairy",
             storage_location="fridge",
-            expiration_date=datetime.now() + timedelta(days=2),
+            expiration_date=datetime.now(timezone.utc) + timedelta(days=2),
             added_by=test_user.id,
         )
         expiring_in_5_days = InventoryItem(
@@ -1146,7 +1146,7 @@ class TestFilterInventoryItems:
             unit="gallon",
             category="dairy",
             storage_location="fridge",
-            expiration_date=datetime.now() + timedelta(days=5),
+            expiration_date=datetime.now(timezone.utc) + timedelta(days=5),
             added_by=test_user.id,
         )
         db_session.add_all([expiring_in_2_days, expiring_in_5_days])

--- a/tests/routers/test_inventory.py
+++ b/tests/routers/test_inventory.py
@@ -17,6 +17,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from uuid import uuid4
+from datetime import datetime, timedelta
 
 from src.db.database import Base, get_db
 from src.db import models
@@ -665,3 +666,498 @@ class TestDeleteInventoryItem:
         response = client.delete(f"/inventory/{item.id}")
 
         assert response.status_code == 401
+
+
+class TestFilterInventoryItems:
+    """Tests for GET /inventory filtering and search functionality."""
+
+    def test_filter_by_category(self, client, auth_headers, test_user, db_session):
+        """Should filter items by category."""
+        # Create items with different categories
+        dairy_item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        produce_item = InventoryItem(
+            name="Apple",
+            quantity=5.0,
+            unit="count",
+            category="produce",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        protein_item = InventoryItem(
+            name="Chicken",
+            quantity=2.0,
+            unit="lb",
+            category="protein",
+            storage_location="freezer",
+            added_by=test_user.id,
+        )
+        db_session.add_all([dairy_item, produce_item, protein_item])
+        db_session.commit()
+
+        # Filter by dairy category
+        response = client.get("/inventory?category=dairy", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Milk"
+        assert data[0]["category"] == "dairy"
+
+        # Filter by produce category
+        response = client.get("/inventory?category=produce", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Apple"
+
+    def test_filter_by_storage_location(self, client, auth_headers, test_user, db_session):
+        """Should filter items by storage location."""
+        # Create items with different storage locations
+        fridge_item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        freezer_item = InventoryItem(
+            name="Frozen Pizza",
+            quantity=2.0,
+            unit="count",
+            category="frozen",
+            storage_location="freezer",
+            added_by=test_user.id,
+        )
+        pantry_item = InventoryItem(
+            name="Pasta",
+            quantity=1.0,
+            unit="box",
+            category="grain",
+            storage_location="pantry",
+            added_by=test_user.id,
+        )
+        db_session.add_all([fridge_item, freezer_item, pantry_item])
+        db_session.commit()
+
+        # Filter by fridge
+        response = client.get("/inventory?storage_location=fridge", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Milk"
+        assert data[0]["storage_location"] == "fridge"
+
+        # Filter by freezer
+        response = client.get("/inventory?storage_location=freezer", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Frozen Pizza"
+
+    def test_filter_by_shareability(self, client, auth_headers, test_user, db_session):
+        """Should filter items by shareability."""
+        # Create items with different shareability
+        shared_item = InventoryItem(
+            name="Shared Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            shareability="shared",
+            added_by=test_user.id,
+        )
+        reserved_item = InventoryItem(
+            name="Reserved Yogurt",
+            quantity=1.0,
+            unit="count",
+            category="dairy",
+            storage_location="fridge",
+            shareability="reserved",
+            added_by=test_user.id,
+        )
+        personal_item = InventoryItem(
+            name="Personal Cheese",
+            quantity=1.0,
+            unit="oz",
+            category="dairy",
+            storage_location="fridge",
+            shareability="personal",
+            added_by=test_user.id,
+        )
+        db_session.add_all([shared_item, reserved_item, personal_item])
+        db_session.commit()
+
+        # Filter by shared
+        response = client.get("/inventory?shareability=shared", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Shared Milk"
+        assert data[0]["shareability"] == "shared"
+
+        # Filter by reserved
+        response = client.get("/inventory?shareability=reserved", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Reserved Yogurt"
+
+    def test_filter_by_is_staple(self, client, auth_headers, test_user, db_session):
+        """Should filter items by staple status."""
+        # Create staple and non-staple items
+        staple_item = InventoryItem(
+            name="Rice",
+            quantity=5.0,
+            unit="lb",
+            category="grain",
+            storage_location="pantry",
+            is_staple=True,
+            added_by=test_user.id,
+        )
+        non_staple_item = InventoryItem(
+            name="Ice Cream",
+            quantity=1.0,
+            unit="pint",
+            category="frozen",
+            storage_location="freezer",
+            is_staple=False,
+            added_by=test_user.id,
+        )
+        db_session.add_all([staple_item, non_staple_item])
+        db_session.commit()
+
+        # Filter by is_staple=true
+        response = client.get("/inventory?is_staple=true", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Rice"
+        assert data[0]["is_staple"] is True
+
+        # Filter by is_staple=false
+        response = client.get("/inventory?is_staple=false", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Ice Cream"
+        assert data[0]["is_staple"] is False
+
+    def test_filter_by_expiring_soon(self, client, auth_headers, test_user, db_session):
+        """Should filter items expiring within 7 days."""
+        # Create items with different expiration dates
+        expiring_soon_item = InventoryItem(
+            name="Milk Expiring Soon",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            expiration_date=datetime.now() + timedelta(days=3),
+            added_by=test_user.id,
+        )
+        expiring_later_item = InventoryItem(
+            name="Milk Expiring Later",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            expiration_date=datetime.now() + timedelta(days=14),
+            added_by=test_user.id,
+        )
+        no_expiration_item = InventoryItem(
+            name="Canned Beans",
+            quantity=1.0,
+            unit="can",
+            category="canned",
+            storage_location="pantry",
+            expiration_date=None,
+            added_by=test_user.id,
+        )
+        db_session.add_all([expiring_soon_item, expiring_later_item, no_expiration_item])
+        db_session.commit()
+
+        # Filter by expiring_soon=true
+        response = client.get("/inventory?expiring_soon=true", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Milk Expiring Soon"
+
+        # Filter by expiring_soon=false (should return all items, including those not expiring soon)
+        response = client.get("/inventory?expiring_soon=false", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        # When expiring_soon=false, no expiration filter is applied, so all items are returned
+        assert len(data) == 3
+
+    def test_filter_by_expiring_within_days(self, client, auth_headers, test_user, db_session):
+        """Should filter items expiring within N days."""
+        # Create items with different expiration dates
+        expiring_in_2_days = InventoryItem(
+            name="Milk 2 Days",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            expiration_date=datetime.now() + timedelta(days=2),
+            added_by=test_user.id,
+        )
+        expiring_in_5_days = InventoryItem(
+            name="Milk 5 Days",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            expiration_date=datetime.now() + timedelta(days=5),
+            added_by=test_user.id,
+        )
+        expiring_in_10_days = InventoryItem(
+            name="Milk 10 Days",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            expiration_date=datetime.now() + timedelta(days=10),
+            added_by=test_user.id,
+        )
+        db_session.add_all([expiring_in_2_days, expiring_in_5_days, expiring_in_10_days])
+        db_session.commit()
+
+        # Filter by expiring_within_days=3
+        response = client.get("/inventory?expiring_within_days=3", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Milk 2 Days"
+
+        # Filter by expiring_within_days=6
+        response = client.get("/inventory?expiring_within_days=6", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        item_names = {item["name"] for item in data}
+        assert item_names == {"Milk 2 Days", "Milk 5 Days"}
+
+        # Filter by expiring_within_days=15
+        response = client.get("/inventory?expiring_within_days=15", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 3
+
+    def test_filter_by_search(self, client, auth_headers, test_user, db_session):
+        """Should search items by name (case-insensitive partial match)."""
+        # Create items with different names
+        item1 = InventoryItem(
+            name="Whole Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        item2 = InventoryItem(
+            name="Almond Milk",
+            quantity=1.0,
+            unit="quart",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        item3 = InventoryItem(
+            name="Apple Juice",
+            quantity=1.0,
+            unit="bottle",
+            category="beverage",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        db_session.add_all([item1, item2, item3])
+        db_session.commit()
+
+        # Search for "milk" (case-insensitive)
+        response = client.get("/inventory?search=milk", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        item_names = {item["name"] for item in data}
+        assert item_names == {"Whole Milk", "Almond Milk"}
+
+        # Search for "MILK" (case-insensitive)
+        response = client.get("/inventory?search=MILK", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+
+        # Search for "apple"
+        response = client.get("/inventory?search=apple", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Apple Juice"
+
+        # Search for partial match "alm"
+        response = client.get("/inventory?search=alm", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Almond Milk"
+
+    def test_filter_multiple_combined_with_and_logic(self, client, auth_headers, test_user, db_session):
+        """Should combine multiple filters with AND logic."""
+        # Create diverse items
+        target_item = InventoryItem(
+            name="Organic Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            shareability="shared",
+            is_staple=True,
+            added_by=test_user.id,
+        )
+        wrong_category = InventoryItem(
+            name="Orange Juice",
+            quantity=1.0,
+            unit="bottle",
+            category="beverage",
+            storage_location="fridge",
+            shareability="shared",
+            is_staple=True,
+            added_by=test_user.id,
+        )
+        wrong_location = InventoryItem(
+            name="Frozen Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="freezer",
+            shareability="shared",
+            is_staple=True,
+            added_by=test_user.id,
+        )
+        wrong_shareability = InventoryItem(
+            name="Personal Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            shareability="personal",
+            is_staple=True,
+            added_by=test_user.id,
+        )
+        db_session.add_all([target_item, wrong_category, wrong_location, wrong_shareability])
+        db_session.commit()
+
+        # Apply multiple filters (should only match target_item)
+        response = client.get(
+            "/inventory?category=dairy&storage_location=fridge&shareability=shared",
+            headers=auth_headers
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Organic Milk"
+
+    def test_filter_invalid_category(self, client, auth_headers):
+        """Should return 422 for invalid category."""
+        response = client.get("/inventory?category=invalid_category", headers=auth_headers)
+        assert response.status_code == 422
+        assert "Invalid category" in response.json()["detail"]
+
+    def test_filter_invalid_storage_location(self, client, auth_headers):
+        """Should return 422 for invalid storage_location."""
+        response = client.get("/inventory?storage_location=invalid_location", headers=auth_headers)
+        assert response.status_code == 422
+        assert "Invalid storage_location" in response.json()["detail"]
+
+    def test_filter_invalid_shareability(self, client, auth_headers):
+        """Should return 422 for invalid shareability."""
+        response = client.get("/inventory?shareability=invalid_share", headers=auth_headers)
+        assert response.status_code == 422
+        assert "Invalid shareability" in response.json()["detail"]
+
+    def test_filter_no_matches(self, client, auth_headers, test_user, db_session):
+        """Should return empty list when no items match filters."""
+        # Create a single item
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        # Filter for produce (no matches)
+        response = client.get("/inventory?category=produce", headers=auth_headers)
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_filter_with_pagination(self, client, auth_headers, test_user, db_session):
+        """Should apply filters with pagination."""
+        # Create multiple dairy items
+        for i in range(5):
+            item = InventoryItem(
+                name=f"Dairy Item {i}",
+                quantity=1.0,
+                unit="count",
+                category="dairy",
+                storage_location="fridge",
+                added_by=test_user.id,
+            )
+            db_session.add(item)
+        db_session.commit()
+
+        # Filter by category with pagination
+        response = client.get("/inventory?category=dairy&limit=2&offset=0", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+
+        # Get next page
+        response = client.get("/inventory?category=dairy&limit=2&offset=2", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+
+    def test_filter_expiring_within_days_overrides_expiring_soon(self, client, auth_headers, test_user, db_session):
+        """Should use expiring_within_days when both expiring_soon and expiring_within_days are provided."""
+        # Create items
+        expiring_in_2_days = InventoryItem(
+            name="Milk 2 Days",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            expiration_date=datetime.now() + timedelta(days=2),
+            added_by=test_user.id,
+        )
+        expiring_in_5_days = InventoryItem(
+            name="Milk 5 Days",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            expiration_date=datetime.now() + timedelta(days=5),
+            added_by=test_user.id,
+        )
+        db_session.add_all([expiring_in_2_days, expiring_in_5_days])
+        db_session.commit()
+
+        # When both are provided, expiring_within_days should take precedence
+        response = client.get(
+            "/inventory?expiring_soon=true&expiring_within_days=3",
+            headers=auth_headers
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Milk 2 Days"


### PR DESCRIPTION
## Work in Progress

Closes #77

[Phase 1D] Add inventory filtering and search

**Time Estimate**: 1hr

**Description**:
Add query parameters to GET /inventory for filtering by category, storage location, expiration status, and shareability. Essential for finding items in a large inventory.

**Claude Context**:
Files to Read:
- src/db/models/inventory_item.py (filterable fields and enums)

Files to Modify:
- src/routers/inventory.py (add query params to list endpoint)
- src/schemas/inventory.py (add filter schema if needed)
- tests/routers/test_inventory.py (add filter tests)

Related Issues: #76 (CRUD endpoints must exist)

**Acceptance Criteria**:
- [ ] Filter by category: `GET /inventory?category=produce` returns only produce items
- [ ] Filter by storage_location: `GET /inventory?storage_location=fridge` returns fridge items
- [ ] Filter by shareability: `GET /inventory?shareability=shared` returns shared items
- [ ] Filter by expiration status: `GET /inventory?expiring_soon=true` returns items expiring within 7 days
- [ ] Filter by expiring_within_days: `GET /inventory?expiring_within_days=3` returns items expiring within 3 days
- [ ] Filter by is_staple: `GET /inventory?is_staple=true` returns staple items
- [ ] Search by name (case-insensitive partial match): `GET /inventory?search=milk`
- [ ] Multiple filters combine with AND logic
- [ ] Tests cover all filter parameters: `pytest tests/routers/test_inventory.py -v -k filter`

**Verification Commands**:
```bash
pytest tests/routers/test_inventory.py -v -k filter
curl "http://localhost:8000/inventory?category=dairy&storage_location=fridge" -H "Authorization: Bearer $TOKEN"
```

**Done Definition**: Done when all filter parameters work correctly with AND logic and tests pass.

**Scope Boundary**:
- DO: Add filter query parameters to GET /inventory
- DO: Support combining multiple filters
- DO: Add tests for each filter
- DO NOT: Add full-text search (simple LIKE is sufficient)
- DO NOT: Add sorting options (can be added later)

**Dependencies**: After #76

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+0 added, ~2 modified, -0 deleted)
- `M` src/routers/inventory.py
- `M` tests/routers/test_inventory.py

### Commits
- eb7dea7 feat: [Phase 1D] Add inventory filtering and search
- fa5773a chore: initialize work on #77 [Phase 1D] Add inventory filtering and search
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues
 Updated: #94  Updated: #94 
**From assessment on 2026-03-19T06:14:25Z:**
- Created: #94 
- Updated: none