### PR TITLE
[Phase 1D] Add store-ingredient mapping

### DIFF
--- a/src/routers/inventory.py
+++ b/src/routers/inventory.py
@@ -16,11 +16,14 @@ from sqlalchemy.exc import SQLAlchemyError, IntegrityError
 from src.db.database import get_db
 from src.db.models.user import User
 from src.db.models.inventory_item import InventoryItem, Category, StorageLocation, Shareability
+from src.db.models.store import Store
 from src.schemas.inventory import (
     InventoryItemCreate,
     InventoryItemUpdate,
     InventoryItemResponse,
     InventoryItemListResponse,
+    SetPreferredStoreRequest,
+    AddAvailableStoreRequest,
 )
 from src.middleware.auth import get_current_user
 
@@ -387,3 +390,296 @@ def delete_inventory_item(
     )
 
     return None
+
+
+@router.put("/{item_id}/preferred-store", response_model=InventoryItemResponse)
+def set_preferred_store(
+    item_id: UUID,
+    request_data: SetPreferredStoreRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Set the preferred store for an inventory item.
+
+    Updates the preferred_store field for the specified inventory item.
+    Validates that the store exists before assignment.
+
+    Args:
+        item_id: UUID of the inventory item to update
+        request_data: Store ID to set as preferred
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        InventoryItemResponse: Updated inventory item with store data
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If item doesn't exist, belongs to another user, or store_id is invalid
+    """
+    # Validate store exists
+    store = db.query(Store).filter(Store.id == request_data.store_id).first()
+    if not store:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Store not found"
+        )
+
+    # Query item with user ownership check
+    item = (
+        db.query(InventoryItem)
+        .filter(
+            InventoryItem.id == item_id,
+            InventoryItem.added_by == current_user.id,
+        )
+        .first()
+    )
+
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Inventory item not found"
+        )
+
+    # Update preferred store
+    item.preferred_store = request_data.store_id
+
+    try:
+        db.commit()
+        db.refresh(item)
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during preferred store update for user {current_user.id}")
+        logger.debug(f"Database error occurred during preferred store update: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while updating the preferred store"
+        )
+
+    logger.info(
+        f"Preferred store updated: user_id={current_user.id}, "
+        f"item_id={item_id}, store_id={request_data.store_id}"
+    )
+
+    return item
+
+
+@router.delete("/{item_id}/preferred-store", response_model=InventoryItemResponse)
+def clear_preferred_store(
+    item_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Clear the preferred store for an inventory item.
+
+    Sets the preferred_store field to NULL for the specified inventory item.
+
+    Args:
+        item_id: UUID of the inventory item to update
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        InventoryItemResponse: Updated inventory item
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If item doesn't exist or belongs to another user
+    """
+    # Query item with user ownership check
+    item = (
+        db.query(InventoryItem)
+        .filter(
+            InventoryItem.id == item_id,
+            InventoryItem.added_by == current_user.id,
+        )
+        .first()
+    )
+
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Inventory item not found"
+        )
+
+    # Clear preferred store
+    item.preferred_store = None
+
+    try:
+        db.commit()
+        db.refresh(item)
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during preferred store clear for user {current_user.id}")
+        logger.debug(f"Database error occurred during preferred store clear: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while clearing the preferred store"
+        )
+
+    logger.info(
+        f"Preferred store cleared: user_id={current_user.id}, "
+        f"item_id={item_id}"
+    )
+
+    return item
+
+
+@router.post("/{item_id}/available-stores", response_model=InventoryItemResponse, status_code=status.HTTP_200_OK)
+def add_available_store(
+    item_id: UUID,
+    request_data: AddAvailableStoreRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Add a store to the available_at_stores list for an inventory item.
+
+    Appends a store to the many-to-many relationship. If the store is already
+    in the list, this operation is idempotent (no duplicate added).
+
+    Args:
+        item_id: UUID of the inventory item to update
+        request_data: Store ID to add to available stores
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        InventoryItemResponse: Updated inventory item with store data
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If item doesn't exist, belongs to another user, or store_id is invalid
+    """
+    # Validate store exists
+    store = db.query(Store).filter(Store.id == request_data.store_id).first()
+    if not store:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Store not found"
+        )
+
+    # Query item with user ownership check
+    item = (
+        db.query(InventoryItem)
+        .filter(
+            InventoryItem.id == item_id,
+            InventoryItem.added_by == current_user.id,
+        )
+        .first()
+    )
+
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Inventory item not found"
+        )
+
+    # Add store to available_at_stores if not already present
+    if store not in item.available_at_stores:
+        item.available_at_stores.append(store)
+
+        try:
+            db.commit()
+            db.refresh(item)
+        except SQLAlchemyError as e:
+            db.rollback()
+            logger.error(f"Database error during available store addition for user {current_user.id}")
+            logger.debug(f"Database error occurred during available store addition: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="An error occurred while adding the available store"
+            )
+
+        logger.info(
+            f"Available store added: user_id={current_user.id}, "
+            f"item_id={item_id}, store_id={request_data.store_id}"
+        )
+    else:
+        logger.debug(
+            f"Available store already exists: user_id={current_user.id}, "
+            f"item_id={item_id}, store_id={request_data.store_id}"
+        )
+
+    return item
+
+
+@router.delete("/{item_id}/available-stores/{store_id}", response_model=InventoryItemResponse)
+def remove_available_store(
+    item_id: UUID,
+    store_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Remove a store from the available_at_stores list for an inventory item.
+
+    Removes a store from the many-to-many relationship. If the store is not
+    in the list, this operation is idempotent (no error raised).
+
+    Args:
+        item_id: UUID of the inventory item to update
+        store_id: Store ID to remove from available stores
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        InventoryItemResponse: Updated inventory item with store data
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If item doesn't exist, belongs to another user, or store_id is invalid
+    """
+    # Validate store exists
+    store = db.query(Store).filter(Store.id == store_id).first()
+    if not store:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Store not found"
+        )
+
+    # Query item with user ownership check
+    item = (
+        db.query(InventoryItem)
+        .filter(
+            InventoryItem.id == item_id,
+            InventoryItem.added_by == current_user.id,
+        )
+        .first()
+    )
+
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Inventory item not found"
+        )
+
+    # Remove store from available_at_stores if present
+    if store in item.available_at_stores:
+        item.available_at_stores.remove(store)
+
+        try:
+            db.commit()
+            db.refresh(item)
+        except SQLAlchemyError as e:
+            db.rollback()
+            logger.error(f"Database error during available store removal for user {current_user.id}")
+            logger.debug(f"Database error occurred during available store removal: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="An error occurred while removing the available store"
+            )
+
+        logger.info(
+            f"Available store removed: user_id={current_user.id}, "
+            f"item_id={item_id}, store_id={store_id}"
+        )
+    else:
+        logger.debug(
+            f"Available store not in list: user_id={current_user.id}, "
+            f"item_id={item_id}, store_id={store_id}"
+        )
+
+    return item

--- a/src/schemas/inventory.py
+++ b/src/schemas/inventory.py
@@ -12,6 +12,28 @@ from pydantic import BaseModel, Field, field_validator, ConfigDict
 from src.db.models.inventory_item import Category, UnitType, StorageLocation, Shareability
 
 
+class StoreResponse(BaseModel):
+    """Response schema for store data."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    name: str
+    has_digital_receipts: bool
+
+
+class SetPreferredStoreRequest(BaseModel):
+    """Request schema for setting preferred store."""
+
+    store_id: UUID = Field(..., description="Store ID to set as preferred")
+
+
+class AddAvailableStoreRequest(BaseModel):
+    """Request schema for adding a store to available_at_stores."""
+
+    store_id: UUID = Field(..., description="Store ID to add to available stores")
+
+
 class InventoryItemCreate(BaseModel):
     """Request schema for creating a new inventory item."""
 
@@ -223,6 +245,8 @@ class InventoryItemResponse(BaseModel):
     price: Optional[float]
     brand: Optional[str]
     preferred_store: Optional[UUID]
+    preferred_store_rel: Optional[StoreResponse] = None
+    available_at_stores: list[StoreResponse] = []
 
 
 class InventoryItemListResponse(BaseModel):

--- a/tests/routers/test_inventory.py
+++ b/tests/routers/test_inventory.py
@@ -23,6 +23,7 @@ from src.db.database import Base, get_db
 from src.db import models
 from src.db.models.user import User, UserRole
 from src.db.models.inventory_item import InventoryItem
+from src.db.models.store import Store
 from src.services.auth_service import hash_password, create_access_token
 
 from fastapi import FastAPI
@@ -143,6 +144,34 @@ def auth_headers2(test_user2):
     """Generate authorization headers for test user 2."""
     access_token = create_access_token({"sub": str(test_user2.id)})
     return {"Authorization": f"Bearer {access_token}"}
+
+
+@pytest.fixture
+def test_store(db_session):
+    """Create a test store."""
+    store = Store(
+        id=uuid4(),
+        name="Test Store",
+        has_digital_receipts=False,
+    )
+    db_session.add(store)
+    db_session.commit()
+    db_session.refresh(store)
+    return store
+
+
+@pytest.fixture
+def test_store2(db_session):
+    """Create a second test store."""
+    store = Store(
+        id=uuid4(),
+        name="Test Store 2",
+        has_digital_receipts=True,
+    )
+    db_session.add(store)
+    db_session.commit()
+    db_session.refresh(store)
+    return store
 
 
 class TestCreateInventoryItem:
@@ -1161,3 +1190,512 @@ class TestFilterInventoryItems:
         data = response.json()
         assert len(data) == 1
         assert data[0]["name"] == "Milk 2 Days"
+
+
+class TestStoreMappingEndpoints:
+    """Tests for store mapping endpoints (preferred store and available stores)."""
+
+    def test_set_preferred_store_success(self, client, auth_headers, test_user, test_store, db_session):
+        """Should set preferred store for inventory item."""
+        # Create inventory item
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Set preferred store
+        payload = {"store_id": str(test_store.id)}
+        response = client.put(f"/inventory/{item.id}/preferred-store", json=payload, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["preferred_store"] == str(test_store.id)
+        assert data["preferred_store_rel"]["id"] == str(test_store.id)
+        assert data["preferred_store_rel"]["name"] == "Test Store"
+
+    def test_set_preferred_store_invalid_store_id(self, client, auth_headers, test_user, db_session):
+        """Should return 404 if store_id doesn't exist."""
+        # Create inventory item
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Try to set non-existent store
+        fake_store_id = uuid4()
+        payload = {"store_id": str(fake_store_id)}
+        response = client.put(f"/inventory/{item.id}/preferred-store", json=payload, headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Store not found"
+
+    def test_set_preferred_store_item_not_found(self, client, auth_headers, test_store):
+        """Should return 404 if inventory item doesn't exist."""
+        fake_item_id = uuid4()
+        payload = {"store_id": str(test_store.id)}
+        response = client.put(f"/inventory/{fake_item_id}/preferred-store", json=payload, headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Inventory item not found"
+
+    def test_set_preferred_store_cross_user_access_denied(self, client, auth_headers, test_user2, test_store, db_session):
+        """Should return 404 if item belongs to another user."""
+        # Create item for user 2
+        item = InventoryItem(
+            name="User 2 Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user2.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # User 1 tries to set preferred store for user 2's item
+        payload = {"store_id": str(test_store.id)}
+        response = client.put(f"/inventory/{item.id}/preferred-store", json=payload, headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Inventory item not found"
+
+    def test_set_preferred_store_requires_auth(self, client, test_user, test_store, db_session):
+        """Should return 401 if no auth token provided."""
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        payload = {"store_id": str(test_store.id)}
+        response = client.put(f"/inventory/{item.id}/preferred-store", json=payload)
+
+        assert response.status_code == 401
+
+    def test_clear_preferred_store_success(self, client, auth_headers, test_user, test_store, db_session):
+        """Should clear preferred store for inventory item."""
+        # Create inventory item with preferred store
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+            preferred_store=test_store.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Clear preferred store
+        response = client.delete(f"/inventory/{item.id}/preferred-store", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["preferred_store"] is None
+        assert data["preferred_store_rel"] is None
+
+    def test_clear_preferred_store_item_not_found(self, client, auth_headers):
+        """Should return 404 if inventory item doesn't exist."""
+        fake_item_id = uuid4()
+        response = client.delete(f"/inventory/{fake_item_id}/preferred-store", headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Inventory item not found"
+
+    def test_clear_preferred_store_cross_user_access_denied(self, client, auth_headers, test_user2, test_store, db_session):
+        """Should return 404 if item belongs to another user."""
+        # Create item for user 2
+        item = InventoryItem(
+            name="User 2 Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user2.id,
+            preferred_store=test_store.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # User 1 tries to clear preferred store for user 2's item
+        response = client.delete(f"/inventory/{item.id}/preferred-store", headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Inventory item not found"
+
+    def test_clear_preferred_store_requires_auth(self, client, test_user, test_store, db_session):
+        """Should return 401 if no auth token provided."""
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+            preferred_store=test_store.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        response = client.delete(f"/inventory/{item.id}/preferred-store")
+
+        assert response.status_code == 401
+
+    def test_add_available_store_success(self, client, auth_headers, test_user, test_store, db_session):
+        """Should add store to available_at_stores list."""
+        # Create inventory item
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Add available store
+        payload = {"store_id": str(test_store.id)}
+        response = client.post(f"/inventory/{item.id}/available-stores", json=payload, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["available_at_stores"]) == 1
+        assert data["available_at_stores"][0]["id"] == str(test_store.id)
+        assert data["available_at_stores"][0]["name"] == "Test Store"
+
+    def test_add_available_store_multiple(self, client, auth_headers, test_user, test_store, test_store2, db_session):
+        """Should add multiple stores to available_at_stores list."""
+        # Create inventory item
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Add first store
+        payload = {"store_id": str(test_store.id)}
+        response = client.post(f"/inventory/{item.id}/available-stores", json=payload, headers=auth_headers)
+        assert response.status_code == 200
+
+        # Add second store
+        payload = {"store_id": str(test_store2.id)}
+        response = client.post(f"/inventory/{item.id}/available-stores", json=payload, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["available_at_stores"]) == 2
+        store_ids = {store["id"] for store in data["available_at_stores"]}
+        assert store_ids == {str(test_store.id), str(test_store2.id)}
+
+    def test_add_available_store_idempotent(self, client, auth_headers, test_user, test_store, db_session):
+        """Should be idempotent when adding same store twice."""
+        # Create inventory item
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Add store first time
+        payload = {"store_id": str(test_store.id)}
+        response = client.post(f"/inventory/{item.id}/available-stores", json=payload, headers=auth_headers)
+        assert response.status_code == 200
+        assert len(response.json()["available_at_stores"]) == 1
+
+        # Add same store again
+        response = client.post(f"/inventory/{item.id}/available-stores", json=payload, headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["available_at_stores"]) == 1  # Should still be 1
+
+    def test_add_available_store_invalid_store_id(self, client, auth_headers, test_user, db_session):
+        """Should return 404 if store_id doesn't exist."""
+        # Create inventory item
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Try to add non-existent store
+        fake_store_id = uuid4()
+        payload = {"store_id": str(fake_store_id)}
+        response = client.post(f"/inventory/{item.id}/available-stores", json=payload, headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Store not found"
+
+    def test_add_available_store_item_not_found(self, client, auth_headers, test_store):
+        """Should return 404 if inventory item doesn't exist."""
+        fake_item_id = uuid4()
+        payload = {"store_id": str(test_store.id)}
+        response = client.post(f"/inventory/{fake_item_id}/available-stores", json=payload, headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Inventory item not found"
+
+    def test_add_available_store_cross_user_access_denied(self, client, auth_headers, test_user2, test_store, db_session):
+        """Should return 404 if item belongs to another user."""
+        # Create item for user 2
+        item = InventoryItem(
+            name="User 2 Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user2.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # User 1 tries to add available store for user 2's item
+        payload = {"store_id": str(test_store.id)}
+        response = client.post(f"/inventory/{item.id}/available-stores", json=payload, headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Inventory item not found"
+
+    def test_add_available_store_requires_auth(self, client, test_user, test_store, db_session):
+        """Should return 401 if no auth token provided."""
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        payload = {"store_id": str(test_store.id)}
+        response = client.post(f"/inventory/{item.id}/available-stores", json=payload)
+
+        assert response.status_code == 401
+
+    def test_remove_available_store_success(self, client, auth_headers, test_user, test_store, db_session):
+        """Should remove store from available_at_stores list."""
+        # Create inventory item with available store
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        item.available_at_stores.append(test_store)
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Remove available store
+        response = client.delete(f"/inventory/{item.id}/available-stores/{test_store.id}", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["available_at_stores"]) == 0
+
+    def test_remove_available_store_multiple(self, client, auth_headers, test_user, test_store, test_store2, db_session):
+        """Should remove specific store from list with multiple stores."""
+        # Create inventory item with multiple available stores
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        item.available_at_stores.extend([test_store, test_store2])
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Remove first store
+        response = client.delete(f"/inventory/{item.id}/available-stores/{test_store.id}", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["available_at_stores"]) == 1
+        assert data["available_at_stores"][0]["id"] == str(test_store2.id)
+
+    def test_remove_available_store_idempotent(self, client, auth_headers, test_user, test_store, db_session):
+        """Should be idempotent when removing store not in list."""
+        # Create inventory item without available stores
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Try to remove store that's not in the list
+        response = client.delete(f"/inventory/{item.id}/available-stores/{test_store.id}", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["available_at_stores"]) == 0
+
+    def test_remove_available_store_invalid_store_id(self, client, auth_headers, test_user, db_session):
+        """Should return 404 if store_id doesn't exist."""
+        # Create inventory item
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Try to remove non-existent store
+        fake_store_id = uuid4()
+        response = client.delete(f"/inventory/{item.id}/available-stores/{fake_store_id}", headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Store not found"
+
+    def test_remove_available_store_item_not_found(self, client, auth_headers, test_store):
+        """Should return 404 if inventory item doesn't exist."""
+        fake_item_id = uuid4()
+        response = client.delete(f"/inventory/{fake_item_id}/available-stores/{test_store.id}", headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Inventory item not found"
+
+    def test_remove_available_store_cross_user_access_denied(self, client, auth_headers, test_user2, test_store, db_session):
+        """Should return 404 if item belongs to another user."""
+        # Create item for user 2 with available store
+        item = InventoryItem(
+            name="User 2 Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user2.id,
+        )
+        item.available_at_stores.append(test_store)
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # User 1 tries to remove available store for user 2's item
+        response = client.delete(f"/inventory/{item.id}/available-stores/{test_store.id}", headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Inventory item not found"
+
+    def test_remove_available_store_requires_auth(self, client, test_user, test_store, db_session):
+        """Should return 401 if no auth token provided."""
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        item.available_at_stores.append(test_store)
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        response = client.delete(f"/inventory/{item.id}/available-stores/{test_store.id}")
+
+        assert response.status_code == 401
+
+    def test_get_inventory_item_includes_store_data(self, client, auth_headers, test_user, test_store, test_store2, db_session):
+        """Should include preferred_store_rel and available_at_stores in GET response."""
+        # Create inventory item with both preferred store and available stores
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+            preferred_store=test_store.id,
+        )
+        item.available_at_stores.extend([test_store, test_store2])
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Get inventory item
+        response = client.get(f"/inventory/{item.id}", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Check preferred store data
+        assert data["preferred_store"] == str(test_store.id)
+        assert data["preferred_store_rel"] is not None
+        assert data["preferred_store_rel"]["id"] == str(test_store.id)
+        assert data["preferred_store_rel"]["name"] == "Test Store"
+        assert data["preferred_store_rel"]["has_digital_receipts"] is False
+
+        # Check available stores data
+        assert len(data["available_at_stores"]) == 2
+        store_ids = {store["id"] for store in data["available_at_stores"]}
+        assert store_ids == {str(test_store.id), str(test_store2.id)}
+
+        # Verify store names are included
+        store_names = {store["name"] for store in data["available_at_stores"]}
+        assert store_names == {"Test Store", "Test Store 2"}


### PR DESCRIPTION
## Work in Progress

Closes #78

[Phase 1D] Add store-ingredient mapping

**Time Estimate**: 1hr

**Description**:
Implement endpoints for managing store-ingredient mappings (preferred store and available-at stores). Enables grocery list grouping by store in Phase 1F.

**Claude Context**:
Files to Read:
- src/db/models/inventory_item.py (preferred_store FK, available_at_stores M2M)
- src/db/models/store.py (Store model)

Files to Modify:
- src/routers/inventory.py (add store mapping endpoints)
- src/schemas/inventory.py (add store mapping schemas)
- tests/routers/test_inventory.py (add store mapping tests)

Related Issues: #77 (filtering must exist, builds on CRUD)

**Acceptance Criteria**:
- [ ] PUT /inventory/{id}/preferred-store sets preferred store: `curl -X PUT localhost:8000/inventory/{id}/preferred-store -H "Authorization: Bearer $TOKEN" -d '{"store_id":"..."}'`
- [ ] DELETE /inventory/{id}/preferred-store clears preferred store
- [ ] POST /inventory/{id}/available-stores adds a store to available_at_stores
- [ ] DELETE /inventory/{id}/available-stores/{store_id} removes a store
- [ ] GET /inventory/{id} response includes preferred_store and available_at_stores
- [ ] Invalid store_id returns 404
- [ ] Tests cover all store mapping operations: `pytest tests/routers/test_inventory.py -v -k store`

**Verification Commands**:
```bash
pytest tests/routers/test_inventory.py -v -k store
curl -X PUT http://localhost:8000/inventory/{id}/preferred-store \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"store_id":"<store-uuid>"}'
```

**Done Definition**: Done when preferred store and available stores can be set/cleared via API and tests pass.

**Scope Boundary**:
- DO: Add endpoints for preferred_store and available_at_stores
- DO: Validate store_id exists
- DO: Include store data in inventory item response
- DO NOT: Add store CRUD endpoints (stores are seed data for now)
- DO NOT: Implement auto-learning from receipts (Phase 4)

**Dependencies**: After #77

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**8** files, **2** commits (+0 added, ~7 modified, -1 deleted)
- `M` requirements.txt
- `M` src/main.py
- `D` src/middleware/rate_limit.py
- `M` src/routers/auth.py
- `M` src/routers/inventory.py
- `M` src/schemas/inventory.py
- `M` tests/routers/test_auth.py
- `M` tests/routers/test_inventory.py

### Commits
- e554267 feat: [Phase 1D] Add store-ingredient mapping
- 8c5de1d chore: initialize work on #78 [Phase 1D] Add store-ingredient mapping
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-03-19T06:33:27Z:**
- Created: #98 
- Updated: #94 