### PR TITLE
Add explicit type preservation to column rename

### DIFF
--- a/alembic/versions/1bf9b813a278_rename_audit_log_metadata_to_event_.py
+++ b/alembic/versions/1bf9b813a278_rename_audit_log_metadata_to_event_.py
@@ -20,9 +20,23 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     # Rename metadata column to event_metadata to avoid SQLAlchemy reserved word conflict
-    op.alter_column('auth_audit_logs', 'metadata', new_column_name='event_metadata')
+    # Explicit type preservation improves portability across different database backends
+    op.alter_column(
+        'auth_audit_logs',
+        'metadata',
+        new_column_name='event_metadata',
+        existing_type=sa.JSON(),
+        existing_nullable=True
+    )
 
 
 def downgrade() -> None:
     # Revert the column name back to metadata
-    op.alter_column('auth_audit_logs', 'event_metadata', new_column_name='metadata')
+    # Explicit type preservation improves portability across different database backends
+    op.alter_column(
+        'auth_audit_logs',
+        'event_metadata',
+        new_column_name='metadata',
+        existing_type=sa.JSON(),
+        existing_nullable=True
+    )


### PR DESCRIPTION
## Work in Progress

Closes #61

Add explicit type preservation to column rename

<!-- sharkrite-source-issue:11 -->## From PR #60 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
The migration works correctly in standard PostgreSQL/SQLite configurations. Adding explicit `existing_type` and `existing_nullable` parameters is defensive programming but not required for correct functionality - this is a robustness improvement, not a bug fix.

## Context
The original issue scope is adding auth integration tests, not modifying migration robustness patterns. The migration already exists and functions correctly. This is a valid improvement for database portability but outside the testing scope of this PR.

## Defer Reason
Scope exceeds time budget - this is an infrastructure/migration pattern improvement unrelated to the test implementation work

---
_Created by Sharkrite assessment on 2026-03-18T22:43:57Z_
_Parent PR: #60_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**1** files, **2** commits (+0 added, ~1 modified, -0 deleted)
- `M` alembic/versions/1bf9b813a278_rename_audit_log_metadata_to_event_.py

### Commits
- f35c6c1 feat: Add explicit type preservation to column rename
- 36cd2fc chore: initialize work on #61 Add explicit type preservation to column rename
<!-- /sharkrite-changes-summary -->