### PR TITLE
[Phase 1D] Add inventory shareability controls

### DIFF
--- a/src/routers/inventory.py
+++ b/src/routers/inventory.py
@@ -698,7 +698,8 @@ def update_shareability(
 
     Sets the shareability status (shared/reserved/personal) and optionally
     a reserved note. When setting to "shared", reserved_note and reserved_for
-    are automatically cleared.
+    are automatically cleared. For "personal" and "reserved", the reserved_note
+    can be set if provided.
 
     Args:
         item_id: UUID of the inventory item to update
@@ -733,12 +734,13 @@ def update_shareability(
     # Update shareability
     item.shareability = request_data.shareability
 
-    # Clear reserved fields when setting to "shared" or "personal"
+    # Clear reserved fields when setting to "shared"
     if request_data.shareability == Shareability.shared.value:
         item.reserved_note = None
         item.reserved_for = None
     elif request_data.shareability == Shareability.personal.value:
-        item.reserved_note = None
+        # For "personal", set the note if provided (allows personal notes)
+        item.reserved_note = request_data.reserved_note
         item.reserved_for = None
     else:
         # For "reserved", set the note if provided

--- a/src/routers/inventory.py
+++ b/src/routers/inventory.py
@@ -733,12 +733,15 @@ def update_shareability(
     # Update shareability
     item.shareability = request_data.shareability
 
-    # Clear reserved fields when setting to "shared"
+    # Clear reserved fields when setting to "shared" or "personal"
     if request_data.shareability == Shareability.shared.value:
         item.reserved_note = None
         item.reserved_for = None
+    elif request_data.shareability == Shareability.personal.value:
+        item.reserved_note = None
+        item.reserved_for = None
     else:
-        # For "reserved" or "personal", set the note if provided
+        # For "reserved", set the note if provided
         item.reserved_note = request_data.reserved_note
 
     try:

--- a/src/routers/inventory.py
+++ b/src/routers/inventory.py
@@ -24,6 +24,7 @@ from src.schemas.inventory import (
     InventoryItemListResponse,
     SetPreferredStoreRequest,
     AddAvailableStoreRequest,
+    UpdateShareabilityRequest,
 )
 from src.middleware.auth import get_current_user
 
@@ -681,5 +682,80 @@ def remove_available_store(
             f"Available store not in list: user_id={current_user.id}, "
             f"item_id={item_id}, store_id={store_id}"
         )
+
+    return item
+
+
+@router.put("/{item_id}/shareability", response_model=InventoryItemResponse)
+def update_shareability(
+    item_id: UUID,
+    request_data: UpdateShareabilityRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Update shareability status for an inventory item.
+
+    Sets the shareability status (shared/reserved/personal) and optionally
+    a reserved note. When setting to "shared", reserved_note and reserved_for
+    are automatically cleared.
+
+    Args:
+        item_id: UUID of the inventory item to update
+        request_data: Shareability and optional reserved note
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        InventoryItemResponse: Updated inventory item
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If item doesn't exist or belongs to another user
+        HTTPException(422): If shareability is invalid or reserved_note exceeds 500 chars
+    """
+    # Query item with user ownership check
+    item = (
+        db.query(InventoryItem)
+        .filter(
+            InventoryItem.id == item_id,
+            InventoryItem.added_by == current_user.id,
+        )
+        .first()
+    )
+
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Inventory item not found"
+        )
+
+    # Update shareability
+    item.shareability = request_data.shareability
+
+    # Clear reserved fields when setting to "shared"
+    if request_data.shareability == Shareability.shared.value:
+        item.reserved_note = None
+        item.reserved_for = None
+    else:
+        # For "reserved" or "personal", set the note if provided
+        item.reserved_note = request_data.reserved_note
+
+    try:
+        db.commit()
+        db.refresh(item)
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during shareability update for user {current_user.id}")
+        logger.debug(f"Database error occurred during shareability update: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while updating shareability"
+        )
+
+    logger.info(
+        f"Shareability updated: user_id={current_user.id}, "
+        f"item_id={item_id}, shareability={request_data.shareability}"
+    )
 
     return item

--- a/src/schemas/inventory.py
+++ b/src/schemas/inventory.py
@@ -34,6 +34,22 @@ class AddAvailableStoreRequest(BaseModel):
     store_id: UUID = Field(..., description="Store ID to add to available stores")
 
 
+class UpdateShareabilityRequest(BaseModel):
+    """Request schema for updating item shareability."""
+
+    shareability: str = Field(..., description="Shareability status (shared, reserved, personal)")
+    reserved_note: Optional[str] = Field(default=None, max_length=500, description="Note for reserved items")
+
+    @field_validator('shareability')
+    @classmethod
+    def validate_shareability(cls, v: str) -> str:
+        """Ensure shareability is a valid Shareability enum value."""
+        valid_shareability = [share.value for share in Shareability]
+        if v not in valid_shareability:
+            raise ValueError(f'Shareability must be one of: {", ".join(valid_shareability)}')
+        return v
+
+
 class InventoryItemCreate(BaseModel):
     """Request schema for creating a new inventory item."""
 

--- a/tests/routers/test_inventory.py
+++ b/tests/routers/test_inventory.py
@@ -1699,3 +1699,256 @@ class TestStoreMappingEndpoints:
         # Verify store names are included
         store_names = {store["name"] for store in data["available_at_stores"]}
         assert store_names == {"Test Store", "Test Store 2"}
+
+
+class TestUpdateShareability:
+    """Tests for PUT /inventory/{id}/shareability endpoint."""
+
+    def test_update_shareability_to_reserved_with_note(self, client, auth_headers, test_user, db_session):
+        """Should update shareability to reserved with a note."""
+        # Create inventory item
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            shareability="shared",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Update to reserved with note
+        payload = {
+            "shareability": "reserved",
+            "reserved_note": "For Saturday cheesecake"
+        }
+        response = client.put(f"/inventory/{item.id}/shareability", json=payload, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["shareability"] == "reserved"
+        assert data["reserved_note"] == "For Saturday cheesecake"
+        assert data["reserved_for"] is None  # FK not implemented yet (Phase 3)
+
+    def test_update_shareability_to_personal_with_note(self, client, auth_headers, test_user, db_session):
+        """Should update shareability to personal with a note."""
+        # Create inventory item
+        item = InventoryItem(
+            name="Cheese",
+            quantity=0.5,
+            unit="lb",
+            category="dairy",
+            storage_location="fridge",
+            shareability="shared",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Update to personal with note
+        payload = {
+            "shareability": "personal",
+            "reserved_note": "My special cheese"
+        }
+        response = client.put(f"/inventory/{item.id}/shareability", json=payload, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["shareability"] == "personal"
+        assert data["reserved_note"] == "My special cheese"
+
+    def test_update_shareability_to_reserved_without_note(self, client, auth_headers, test_user, db_session):
+        """Should update shareability to reserved without a note."""
+        # Create inventory item
+        item = InventoryItem(
+            name="Yogurt",
+            quantity=1.0,
+            unit="count",
+            category="dairy",
+            storage_location="fridge",
+            shareability="shared",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Update to reserved without note
+        payload = {
+            "shareability": "reserved"
+        }
+        response = client.put(f"/inventory/{item.id}/shareability", json=payload, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["shareability"] == "reserved"
+        assert data["reserved_note"] is None
+
+    def test_update_shareability_to_shared_clears_reserved_fields(self, client, auth_headers, test_user, db_session):
+        """Should clear reserved_note and reserved_for when setting to shared."""
+        # Create inventory item with reserved status and note
+        item = InventoryItem(
+            name="Butter",
+            quantity=1.0,
+            unit="lb",
+            category="dairy",
+            storage_location="fridge",
+            shareability="reserved",
+            reserved_note="For my cookies",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Update to shared (should clear reserved fields)
+        payload = {
+            "shareability": "shared"
+        }
+        response = client.put(f"/inventory/{item.id}/shareability", json=payload, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["shareability"] == "shared"
+        assert data["reserved_note"] is None
+        assert data["reserved_for"] is None
+
+    def test_update_shareability_transition_reserved_to_personal(self, client, auth_headers, test_user, db_session):
+        """Should transition from reserved to personal, updating note."""
+        # Create inventory item with reserved status
+        item = InventoryItem(
+            name="Cream",
+            quantity=1.0,
+            unit="pint",
+            category="dairy",
+            storage_location="fridge",
+            shareability="reserved",
+            reserved_note="For dinner party",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Transition to personal with new note
+        payload = {
+            "shareability": "personal",
+            "reserved_note": "Changed my mind, this is mine"
+        }
+        response = client.put(f"/inventory/{item.id}/shareability", json=payload, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["shareability"] == "personal"
+        assert data["reserved_note"] == "Changed my mind, this is mine"
+
+    def test_update_shareability_invalid_enum(self, client, auth_headers, test_user, db_session):
+        """Should return 422 for invalid shareability value."""
+        # Create inventory item
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Try invalid shareability
+        payload = {
+            "shareability": "invalid_value"
+        }
+        response = client.put(f"/inventory/{item.id}/shareability", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+
+    def test_update_shareability_reserved_note_too_long(self, client, auth_headers, test_user, db_session):
+        """Should return 422 if reserved_note exceeds 500 characters."""
+        # Create inventory item
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Try note that's too long (501 chars)
+        long_note = "x" * 501
+        payload = {
+            "shareability": "reserved",
+            "reserved_note": long_note
+        }
+        response = client.put(f"/inventory/{item.id}/shareability", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+
+    def test_update_shareability_item_not_found(self, client, auth_headers):
+        """Should return 404 if item doesn't exist."""
+        fake_id = uuid4()
+        payload = {
+            "shareability": "reserved",
+            "reserved_note": "For dinner"
+        }
+        response = client.put(f"/inventory/{fake_id}/shareability", json=payload, headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Inventory item not found"
+
+    def test_update_shareability_cross_user_access_denied(self, client, auth_headers, test_user2, db_session):
+        """Should return 404 if item belongs to another user."""
+        # Create item for user 2
+        item = InventoryItem(
+            name="User 2 Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user2.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # User 1 tries to update user 2's item
+        payload = {
+            "shareability": "reserved",
+            "reserved_note": "For my dinner"
+        }
+        response = client.put(f"/inventory/{item.id}/shareability", json=payload, headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Inventory item not found"
+
+    def test_update_shareability_requires_auth(self, client, test_user, db_session):
+        """Should return 401 if no auth token provided."""
+        item = InventoryItem(
+            name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        payload = {
+            "shareability": "reserved",
+            "reserved_note": "For dinner"
+        }
+        response = client.put(f"/inventory/{item.id}/shareability", json=payload)
+
+        assert response.status_code == 401


### PR DESCRIPTION
## Work in Progress

Closes #79

[Phase 1D] Add inventory shareability controls

**Time Estimate**: 45min

**Description**:
Add endpoint for updating item shareability (shared/reserved/personal) with reservation notes. Prevents conflicts when items are set aside for specific meals.

**Claude Context**:
Files to Read:
- src/db/models/inventory_item.py (shareability enum, reserved_for, reserved_note fields)

Files to Modify:
- src/routers/inventory.py (add shareability endpoint)
- src/schemas/inventory.py (add shareability schema)
- tests/routers/test_inventory.py (add shareability tests)

Related Issues: #78 (store mapping)

**Acceptance Criteria**:
- [ ] PUT /inventory/{id}/shareability updates shareability and optional reserved_note: `curl -X PUT localhost:8000/inventory/{id}/shareability -d '{"shareability":"reserved","reserved_note":"For Saturday cheesecake"}'`
- [ ] Setting shareability to "shared" clears reserved_note and reserved_for
- [ ] Shareability enum validation (shared/reserved/personal only)
- [ ] reserved_note max length validation (500 chars per model)
- [ ] Tests cover shareability transitions: `pytest tests/routers/test_inventory.py -v -k shareability`

**Verification Commands**:
```bash
pytest tests/routers/test_inventory.py -v -k shareability
curl -X PUT http://localhost:8000/inventory/{id}/shareability \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"shareability":"reserved","reserved_note":"For Saturday dinner"}'
```

**Done Definition**: Done when shareability can be updated with notes, validation works, and tests pass.

**Scope Boundary**:
- DO: Add PUT endpoint for shareability
- DO: Clear reserved fields when setting to "shared"
- DO: Validate reserved_note length
- DO NOT: Implement reserved_for FK to MealPlanEntry (Phase 3, noted in model)
- DO NOT: Add notifications when reserved items are accessed

**Dependencies**: After #78

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **2** commits (+0 added, ~3 modified, -0 deleted)
- `M` src/routers/inventory.py
- `M` src/schemas/inventory.py
- `M` tests/routers/test_inventory.py

### Commits
- 394d403 feat: [Phase 1D] Add inventory shareability controls
- de45502 chore: initialize work on #79 [Phase 1D] Add inventory shareability controls
<!-- /sharkrite-changes-summary -->