### PR TITLE
Deprecated Pydantic Config Class

### DIFF
--- a/src/schemas/auth.py
+++ b/src/schemas/auth.py
@@ -137,6 +137,8 @@ class LoginRequest(BaseModel):
 class UserResponse(BaseModel):
     """Response schema for user data (excludes password)."""
 
+    model_config = ConfigDict(from_attributes=True)
+
     id: UUID
     name: str
     email: str
@@ -145,9 +147,6 @@ class UserResponse(BaseModel):
     allergies: list[str]
     disliked_ingredients: list[str]
     favorite_ingredients: list[str]
-
-    class Config:
-        from_attributes = True
 
 
 class UserUpdate(BaseModel):
@@ -219,6 +218,8 @@ class UserUpdate(BaseModel):
 class UserListResponse(BaseModel):
     """Response schema for user list (excludes email and password for privacy)."""
 
+    model_config = ConfigDict(from_attributes=True)
+
     id: UUID
     name: str
     role: str
@@ -226,9 +227,6 @@ class UserListResponse(BaseModel):
     allergies: list[str]
     disliked_ingredients: list[str]
     favorite_ingredients: list[str]
-
-    class Config:
-        from_attributes = True
 
 
 class SwitchUserRequest(BaseModel):

--- a/src/schemas/substitution.py
+++ b/src/schemas/substitution.py
@@ -8,7 +8,7 @@ user-defined ingredient substitution preferences.
 from uuid import UUID
 from typing import Optional
 import unicodedata
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, ConfigDict
 
 from src.db.models.substitution import SubstitutionContext
 from src.schemas.validators import (
@@ -178,11 +178,10 @@ class SubstitutionPreferenceUpdate(BaseModel):
 class SubstitutionPreferenceResponse(BaseModel):
     """Response schema for substitution preference data."""
 
+    model_config = ConfigDict(from_attributes=True)
+
     id: UUID
     user_id: UUID
     original_ingredient: str
     replacements: list[dict]  # List of {"ingredient": str, "rank": int}
     context: Optional[str]
-
-    class Config:
-        from_attributes = True


### PR DESCRIPTION
## Work in Progress

Closes #65

Deprecated Pydantic Config Class

<!-- sharkrite-source-issue:13 -->## From PR #63 Assessment

**Severity:** LOW
**Category:** Standards

## Issue
While the inner `Config` class still works in Pydantic v2, it is deprecated and may be removed in future versions. This is a real deprecation warning, not a style preference, but fixing it across the codebase requires checking other schemas for consistency.

## Context
Not blocking functionality now, but should be tracked to avoid future breakage when Pydantic v3 releases.

## Defer Reason
Scope exceeds time budget - should be addressed consistently across all schemas in the project

---
_Created by Sharkrite assessment on 2026-03-18T22:59:28Z_
_Parent PR: #63_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+0 added, ~2 modified, -0 deleted)
- `M` src/schemas/auth.py
- `M` src/schemas/substitution.py

### Commits
- 20b7051 chore: Deprecated Pydantic Config Class
- 2c2365a chore: initialize work on #65 Deprecated Pydantic Config Class
<!-- /sharkrite-changes-summary -->