### PR TITLE
[Phase 1D] Add freeze/thaw quick action

### DIFF
--- a/src/routers/inventory.py
+++ b/src/routers/inventory.py
@@ -822,3 +822,132 @@ def update_shareability(
     )
 
     return item
+
+
+@router.post("/{item_id}/freeze", response_model=InventoryItemResponse)
+def freeze_inventory_item(
+    item_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Freeze an inventory item (quick action).
+
+    Updates the item's storage location to "freezer" and sets frozen_date to now.
+    This endpoint is idempotent - freezing an already-frozen item updates the
+    frozen_date to the current time.
+
+    Args:
+        item_id: UUID of the inventory item to freeze
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        InventoryItemResponse: Updated inventory item with freezer location and frozen_date
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If item doesn't exist or belongs to another user
+    """
+    # Query item with user ownership check
+    item = (
+        db.query(InventoryItem)
+        .filter(
+            InventoryItem.id == item_id,
+            InventoryItem.added_by == current_user.id,
+        )
+        .first()
+    )
+
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Inventory item not found"
+        )
+
+    # Update storage location and frozen date
+    item.storage_location = StorageLocation.freezer.value
+    item.frozen_date = datetime.now(timezone.utc)
+
+    try:
+        db.commit()
+        db.refresh(item)
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during freeze action for user {current_user.id}")
+        logger.debug(f"Database error occurred during freeze action: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while freezing the inventory item"
+        )
+
+    logger.info(
+        f"Inventory item frozen: user_id={current_user.id}, "
+        f"item_id={item_id}, item_name={item.name}"
+    )
+
+    return item
+
+
+@router.post("/{item_id}/thaw", response_model=InventoryItemResponse)
+def thaw_inventory_item(
+    item_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Thaw an inventory item (quick action).
+
+    Updates the item's storage location to "fridge" and clears the frozen_date.
+    This endpoint is idempotent - thawing a non-frozen item does not raise an error.
+
+    Args:
+        item_id: UUID of the inventory item to thaw
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        InventoryItemResponse: Updated inventory item with fridge location and cleared frozen_date
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If item doesn't exist or belongs to another user
+    """
+    # Query item with user ownership check
+    item = (
+        db.query(InventoryItem)
+        .filter(
+            InventoryItem.id == item_id,
+            InventoryItem.added_by == current_user.id,
+        )
+        .first()
+    )
+
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Inventory item not found"
+        )
+
+    # Update storage location and clear frozen date
+    item.storage_location = StorageLocation.fridge.value
+    item.frozen_date = None
+
+    try:
+        db.commit()
+        db.refresh(item)
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during thaw action for user {current_user.id}")
+        logger.debug(f"Database error occurred during thaw action: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while thawing the inventory item"
+        )
+
+    logger.info(
+        f"Inventory item thawed: user_id={current_user.id}, "
+        f"item_id={item_id}, item_name={item.name}"
+    )
+
+    return item

--- a/tests/routers/test_inventory.py
+++ b/tests/routers/test_inventory.py
@@ -1954,6 +1954,325 @@ class TestUpdateShareability:
         assert response.status_code == 401
 
 
+class TestFreezeThawActions:
+    """Tests for POST /inventory/{id}/freeze and POST /inventory/{id}/thaw endpoints."""
+
+    def test_freeze_item_success(self, client, auth_headers, test_user, db_session):
+        """Should freeze item by setting storage_location to freezer and frozen_date to now."""
+        # Create inventory item in fridge
+        item = InventoryItem(
+            name="Chicken Breast",
+            quantity=2.0,
+            unit="lb",
+            category="protein",
+            storage_location="fridge",
+            frozen_date=None,
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Freeze the item
+        response = client.post(f"/inventory/{item.id}/freeze", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["storage_location"] == "freezer"
+        assert data["frozen_date"] is not None
+        # Verify frozen_date is recent (within last minute)
+        from datetime import datetime, timezone, timedelta
+        frozen_date = datetime.fromisoformat(data["frozen_date"].replace('Z', '+00:00'))
+        now = datetime.now(timezone.utc)
+        assert (now - frozen_date) < timedelta(minutes=1)
+
+    def test_freeze_item_already_frozen_is_idempotent(self, client, auth_headers, test_user, db_session):
+        """Should update frozen_date when freezing already-frozen item (idempotent)."""
+        # Create inventory item already frozen with old frozen_date
+        from datetime import datetime, timezone, timedelta
+        old_frozen_date = datetime.now(timezone.utc) - timedelta(days=5)
+        item = InventoryItem(
+            name="Frozen Pizza",
+            quantity=1.0,
+            unit="count",
+            category="frozen",
+            storage_location="freezer",
+            frozen_date=old_frozen_date,
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Freeze again
+        response = client.post(f"/inventory/{item.id}/freeze", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["storage_location"] == "freezer"
+        # Verify frozen_date is updated to recent time (not old date)
+        frozen_date = datetime.fromisoformat(data["frozen_date"].replace('Z', '+00:00'))
+        now = datetime.now(timezone.utc)
+        assert (now - frozen_date) < timedelta(minutes=1)
+        assert frozen_date > old_frozen_date
+
+    def test_freeze_item_from_pantry(self, client, auth_headers, test_user, db_session):
+        """Should freeze item from pantry storage location."""
+        # Create inventory item in pantry
+        item = InventoryItem(
+            name="Bread",
+            quantity=1.0,
+            unit="count",
+            category="grain",
+            storage_location="pantry",
+            frozen_date=None,
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Freeze the item
+        response = client.post(f"/inventory/{item.id}/freeze", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["storage_location"] == "freezer"
+        assert data["frozen_date"] is not None
+
+    def test_freeze_item_not_found(self, client, auth_headers):
+        """Should return 404 if item doesn't exist."""
+        fake_id = uuid4()
+        response = client.post(f"/inventory/{fake_id}/freeze", headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Inventory item not found"
+
+    def test_freeze_item_cross_user_access_denied(self, client, auth_headers, test_user2, db_session):
+        """Should return 404 if item belongs to another user."""
+        # Create item for user 2
+        item = InventoryItem(
+            name="User 2 Meat",
+            quantity=1.0,
+            unit="lb",
+            category="protein",
+            storage_location="fridge",
+            added_by=test_user2.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # User 1 tries to freeze user 2's item
+        response = client.post(f"/inventory/{item.id}/freeze", headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Inventory item not found"
+
+    def test_freeze_item_requires_auth(self, client, test_user, db_session):
+        """Should return 401 if no auth token provided."""
+        item = InventoryItem(
+            name="Chicken",
+            quantity=1.0,
+            unit="lb",
+            category="protein",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        response = client.post(f"/inventory/{item.id}/freeze")
+
+        assert response.status_code == 401
+
+    def test_thaw_item_success(self, client, auth_headers, test_user, db_session):
+        """Should thaw item by setting storage_location to fridge and clearing frozen_date."""
+        # Create inventory item in freezer with frozen_date
+        from datetime import datetime, timezone, timedelta
+        item = InventoryItem(
+            name="Frozen Chicken",
+            quantity=2.0,
+            unit="lb",
+            category="protein",
+            storage_location="freezer",
+            frozen_date=datetime.now(timezone.utc) - timedelta(days=3),
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Thaw the item
+        response = client.post(f"/inventory/{item.id}/thaw", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["storage_location"] == "fridge"
+        assert data["frozen_date"] is None
+
+    def test_thaw_item_not_frozen_is_idempotent(self, client, auth_headers, test_user, db_session):
+        """Should succeed when thawing non-frozen item (idempotent)."""
+        # Create inventory item in fridge (not frozen)
+        item = InventoryItem(
+            name="Fresh Milk",
+            quantity=1.0,
+            unit="gallon",
+            category="dairy",
+            storage_location="fridge",
+            frozen_date=None,
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Thaw non-frozen item
+        response = client.post(f"/inventory/{item.id}/thaw", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["storage_location"] == "fridge"
+        assert data["frozen_date"] is None
+
+    def test_thaw_item_from_pantry(self, client, auth_headers, test_user, db_session):
+        """Should thaw item from pantry storage location."""
+        # Create inventory item in pantry
+        item = InventoryItem(
+            name="Frozen Bread",
+            quantity=1.0,
+            unit="count",
+            category="grain",
+            storage_location="pantry",
+            frozen_date=None,
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Thaw the item
+        response = client.post(f"/inventory/{item.id}/thaw", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["storage_location"] == "fridge"
+        assert data["frozen_date"] is None
+
+    def test_thaw_item_not_found(self, client, auth_headers):
+        """Should return 404 if item doesn't exist."""
+        fake_id = uuid4()
+        response = client.post(f"/inventory/{fake_id}/thaw", headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Inventory item not found"
+
+    def test_thaw_item_cross_user_access_denied(self, client, auth_headers, test_user2, db_session):
+        """Should return 404 if item belongs to another user."""
+        # Create frozen item for user 2
+        from datetime import datetime, timezone
+        item = InventoryItem(
+            name="User 2 Frozen Meat",
+            quantity=1.0,
+            unit="lb",
+            category="protein",
+            storage_location="freezer",
+            frozen_date=datetime.now(timezone.utc),
+            added_by=test_user2.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # User 1 tries to thaw user 2's item
+        response = client.post(f"/inventory/{item.id}/thaw", headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Inventory item not found"
+
+    def test_thaw_item_requires_auth(self, client, test_user, db_session):
+        """Should return 401 if no auth token provided."""
+        from datetime import datetime, timezone
+        item = InventoryItem(
+            name="Frozen Chicken",
+            quantity=1.0,
+            unit="lb",
+            category="protein",
+            storage_location="freezer",
+            frozen_date=datetime.now(timezone.utc),
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        response = client.post(f"/inventory/{item.id}/thaw")
+
+        assert response.status_code == 401
+
+    def test_freeze_then_thaw_transition(self, client, auth_headers, test_user, db_session):
+        """Should transition item from freeze to thaw correctly."""
+        # Create fresh item
+        item = InventoryItem(
+            name="Chicken",
+            quantity=2.0,
+            unit="lb",
+            category="protein",
+            storage_location="fridge",
+            frozen_date=None,
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Freeze it
+        freeze_response = client.post(f"/inventory/{item.id}/freeze", headers=auth_headers)
+        assert freeze_response.status_code == 200
+        freeze_data = freeze_response.json()
+        assert freeze_data["storage_location"] == "freezer"
+        assert freeze_data["frozen_date"] is not None
+
+        # Thaw it
+        thaw_response = client.post(f"/inventory/{item.id}/thaw", headers=auth_headers)
+        assert thaw_response.status_code == 200
+        thaw_data = thaw_response.json()
+        assert thaw_data["storage_location"] == "fridge"
+        assert thaw_data["frozen_date"] is None
+
+    def test_thaw_then_freeze_transition(self, client, auth_headers, test_user, db_session):
+        """Should transition item from thaw to freeze correctly."""
+        from datetime import datetime, timezone
+        # Create frozen item
+        item = InventoryItem(
+            name="Frozen Pizza",
+            quantity=1.0,
+            unit="count",
+            category="frozen",
+            storage_location="freezer",
+            frozen_date=datetime.now(timezone.utc),
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Thaw it
+        thaw_response = client.post(f"/inventory/{item.id}/thaw", headers=auth_headers)
+        assert thaw_response.status_code == 200
+        thaw_data = thaw_response.json()
+        assert thaw_data["storage_location"] == "fridge"
+        assert thaw_data["frozen_date"] is None
+
+        # Freeze it again
+        freeze_response = client.post(f"/inventory/{item.id}/freeze", headers=auth_headers)
+        assert freeze_response.status_code == 200
+        freeze_data = freeze_response.json()
+        assert freeze_data["storage_location"] == "freezer"
+        assert freeze_data["frozen_date"] is not None
+
+
 class TestLowStockAlerts:
     """Tests for GET /inventory/alerts/low-stock endpoint (threshold alerts)."""
 


### PR DESCRIPTION
## Work in Progress

Closes #81

[Phase 1D] Add freeze/thaw quick action

**Time Estimate**: 30min

**Description**:
Add endpoint for quick freeze/thaw action to update storage location and set frozen_date. Supports the "I froze/thawed items" home screen action.

**Claude Context**:
Files to Read:
- src/db/models/inventory_item.py (storage_location, frozen_date fields)

Files to Modify:
- src/routers/inventory.py (add freeze/thaw endpoint)
- src/schemas/inventory.py (add freeze/thaw schema)
- tests/routers/test_inventory.py (add freeze/thaw tests)

Related Issues: #80 (threshold alerts)

**Acceptance Criteria**:
- [ ] POST /inventory/{id}/freeze moves item to freezer and sets frozen_date to now: `curl -X POST localhost:8000/inventory/{id}/freeze`
- [ ] POST /inventory/{id}/thaw moves item to fridge and clears frozen_date
- [ ] Freezing already-frozen item is idempotent (updates frozen_date)
- [ ] Thawing non-frozen item is idempotent (no error)
- [ ] Response includes updated item with new storage_location and frozen_date
- [ ] Tests cover freeze/thaw transitions: `pytest tests/routers/test_inventory.py -v -k freeze`

**Verification Commands**:
```bash
pytest tests/routers/test_inventory.py -v -k freeze
curl -X POST http://localhost:8000/inventory/{id}/freeze -H "Authorization: Bearer $TOKEN"
curl -X POST http://localhost:8000/inventory/{id}/thaw -H "Authorization: Bearer $TOKEN"
```

**Done Definition**: Done when freeze/thaw endpoints update storage location and dates correctly.

**Scope Boundary**:
- DO: Add POST endpoints for freeze and thaw actions
- DO: Set/clear frozen_date appropriately
- DO: Update storage_location (freezer/fridge)
- DO NOT: Track thaw expiration recommendations (future enhancement)
- DO NOT: Add bulk freeze/thaw (simple single-item for now)

**Dependencies**: After #80

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+0 added, ~2 modified, -0 deleted)
- `M` src/routers/inventory.py
- `M` tests/routers/test_inventory.py

### Commits
- b884c58 feat: [Phase 1D] Add freeze/thaw quick action
- 5600152 chore: initialize work on #81 [Phase 1D] Add freeze/thaw quick action
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-03-19T07:14:53Z:**
- Created: none
- Updated: #67 