### PR TITLE
[Phase 1D] Add snack consumption endpoint

### DIFF
--- a/src/routers/inventory.py
+++ b/src/routers/inventory.py
@@ -1010,7 +1010,7 @@ def consume_inventory_item(
     new_quantity = item.quantity - consumption_data.amount
 
     # Check if item should be deleted (using tolerance for float comparison)
-    if abs(new_quantity) < 1e-9 and consumption_data.delete_when_empty:
+    if new_quantity < 1e-9 and consumption_data.delete_when_empty:
         # Delete the item
         try:
             db.delete(item)

--- a/src/routers/inventory.py
+++ b/src/routers/inventory.py
@@ -1009,8 +1009,8 @@ def consume_inventory_item(
     # Calculate new quantity
     new_quantity = item.quantity - consumption_data.amount
 
-    # Check if item should be deleted (exact zero match, relying on float precision)
-    if new_quantity == 0 and consumption_data.delete_when_empty:
+    # Check if item should be deleted (using tolerance for float comparison)
+    if abs(new_quantity) < 1e-9 and consumption_data.delete_when_empty:
         # Delete the item
         try:
             db.delete(item)
@@ -1030,7 +1030,7 @@ def consume_inventory_item(
         )
 
         return ConsumptionResponse(
-            message=f"Consumed {consumption_data.amount} {item.unit}. Item deleted (quantity reached 0).",
+            message=f"Consumed {consumption_data.amount:.10g} {item.unit}. Item deleted (quantity reached 0).",
             deleted=True,
             item=None
         )
@@ -1057,7 +1057,7 @@ def consume_inventory_item(
         )
 
         return ConsumptionResponse(
-            message=f"Consumed {consumption_data.amount} {item.unit}. {new_quantity} {item.unit} remaining.",
+            message=f"Consumed {consumption_data.amount:.10g} {item.unit}. {new_quantity:.10g} {item.unit} remaining.",
             deleted=False,
             item=item
         )

--- a/src/routers/inventory.py
+++ b/src/routers/inventory.py
@@ -26,6 +26,8 @@ from src.schemas.inventory import (
     AddAvailableStoreRequest,
     UpdateShareabilityRequest,
     LowStockAlertItem,
+    ConsumptionRequest,
+    ConsumptionResponse,
 )
 from src.middleware.auth import get_current_user
 
@@ -951,3 +953,111 @@ def thaw_inventory_item(
     )
 
     return item
+
+
+@router.post("/{item_id}/consume", response_model=ConsumptionResponse)
+def consume_inventory_item(
+    item_id: UUID,
+    consumption_data: ConsumptionRequest = ConsumptionRequest(),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Consume (decrement) inventory item quantity.
+
+    Decrements the item's quantity by the specified amount. If quantity reaches
+    zero and delete_when_empty is true (default), the item is deleted.
+
+    Args:
+        item_id: UUID of the inventory item to consume
+        consumption_data: Amount to consume and deletion preference
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        ConsumptionResponse: Status message, deletion flag, and updated item (if not deleted)
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If item doesn't exist or belongs to another user
+        HTTPException(400): If consumption amount exceeds available quantity
+        HTTPException(422): If amount is negative or zero
+    """
+    # Query item with user ownership check
+    item = (
+        db.query(InventoryItem)
+        .filter(
+            InventoryItem.id == item_id,
+            InventoryItem.added_by == current_user.id,
+        )
+        .first()
+    )
+
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Inventory item not found"
+        )
+
+    # Validate consumption amount doesn't exceed available quantity
+    if consumption_data.amount > item.quantity:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Cannot consume {consumption_data.amount} {item.unit}. Only {item.quantity} {item.unit} available."
+        )
+
+    # Calculate new quantity
+    new_quantity = item.quantity - consumption_data.amount
+
+    # Check if item should be deleted (exact zero match, relying on float precision)
+    if new_quantity == 0 and consumption_data.delete_when_empty:
+        # Delete the item
+        try:
+            db.delete(item)
+            db.commit()
+        except SQLAlchemyError as e:
+            db.rollback()
+            logger.error(f"Database error during item consumption deletion for user {current_user.id}")
+            logger.debug(f"Database error occurred during item consumption deletion: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="An error occurred while deleting the consumed item"
+            )
+
+        logger.info(
+            f"Inventory item consumed and deleted: user_id={current_user.id}, "
+            f"item_id={item_id}, item_name={item.name}, amount={consumption_data.amount}"
+        )
+
+        return ConsumptionResponse(
+            message=f"Consumed {consumption_data.amount} {item.unit}. Item deleted (quantity reached 0).",
+            deleted=True,
+            item=None
+        )
+    else:
+        # Update quantity
+        item.quantity = new_quantity
+
+        try:
+            db.commit()
+            db.refresh(item)
+        except SQLAlchemyError as e:
+            db.rollback()
+            logger.error(f"Database error during item consumption for user {current_user.id}")
+            logger.debug(f"Database error occurred during item consumption: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="An error occurred while consuming the item"
+            )
+
+        logger.info(
+            f"Inventory item consumed: user_id={current_user.id}, "
+            f"item_id={item_id}, item_name={item.name}, amount={consumption_data.amount}, "
+            f"new_quantity={new_quantity}"
+        )
+
+        return ConsumptionResponse(
+            message=f"Consumed {consumption_data.amount} {item.unit}. {new_quantity} {item.unit} remaining.",
+            deleted=False,
+            item=item
+        )

--- a/src/schemas/inventory.py
+++ b/src/schemas/inventory.py
@@ -292,3 +292,18 @@ class LowStockAlertItem(BaseModel):
     unit: str
     minimum_threshold: float
     deficit: float = Field(..., description="How many units below threshold (threshold - quantity)")
+
+
+class ConsumptionRequest(BaseModel):
+    """Request schema for consuming inventory items."""
+
+    amount: float = Field(default=1.0, gt=0, description="Amount to consume (must be positive)")
+    delete_when_empty: bool = Field(default=True, description="Auto-delete item when quantity reaches 0")
+
+
+class ConsumptionResponse(BaseModel):
+    """Response schema for consumption endpoint."""
+
+    message: str = Field(..., description="Status message")
+    deleted: bool = Field(..., description="Whether the item was deleted")
+    item: Optional[InventoryItemResponse] = Field(default=None, description="Updated item (null if deleted)")

--- a/tests/routers/test_inventory.py
+++ b/tests/routers/test_inventory.py
@@ -2603,3 +2603,328 @@ class TestLowStockAlerts:
         # Only low_stock_staple should be returned
         assert len(data) == 1
         assert data[0]["name"] == "Low Stock Staple"
+
+
+class TestConsumeInventoryItem:
+    """Test suite for inventory item consumption endpoint."""
+
+    def test_consume_item_default_amount(self, client, auth_headers, test_user, db_session):
+        """Should consume item with default amount (1) and return updated item."""
+        item = InventoryItem(
+            name="Chocolate Bar",
+            quantity=5.0,
+            unit="count",
+            category="snack",
+            storage_location="pantry",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        item_id = item.id
+
+        response = client.post(f"/inventory/{item_id}/consume", headers=auth_headers, json={})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["deleted"] is False
+        assert data["message"] == "Consumed 1.0 count. 4.0 count remaining."
+        assert data["item"] is not None
+        assert data["item"]["quantity"] == 4.0
+        assert data["item"]["name"] == "Chocolate Bar"
+
+        # Verify in database
+        db_session.expire_all()
+        updated_item = db_session.query(InventoryItem).filter(InventoryItem.id == item_id).first()
+        assert updated_item.quantity == 4.0
+
+    def test_consume_item_specific_amount(self, client, auth_headers, test_user, db_session):
+        """Should consume item with specified amount."""
+        item = InventoryItem(
+            name="Milk",
+            quantity=10.0,
+            unit="oz",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        item_id = item.id
+
+        response = client.post(
+            f"/inventory/{item_id}/consume",
+            headers=auth_headers,
+            json={"amount": 3.5}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["deleted"] is False
+        assert data["message"] == "Consumed 3.5 oz. 6.5 oz remaining."
+        assert data["item"]["quantity"] == 6.5
+
+    def test_consume_exact_quantity_with_auto_delete(self, client, auth_headers, test_user, db_session):
+        """Should delete item when consuming exact quantity with delete_when_empty=true (default)."""
+        item = InventoryItem(
+            name="Last Cookie",
+            quantity=1.0,
+            unit="count",
+            category="snack",
+            storage_location="pantry",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        item_id = item.id
+
+        response = client.post(
+            f"/inventory/{item_id}/consume",
+            headers=auth_headers,
+            json={"amount": 1.0}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["deleted"] is True
+        assert data["message"] == "Consumed 1.0 count. Item deleted (quantity reached 0)."
+        assert data["item"] is None
+
+        # Verify item is deleted from database
+        db_session.expire_all()
+        deleted_item = db_session.query(InventoryItem).filter(InventoryItem.id == item_id).first()
+        assert deleted_item is None
+
+    def test_consume_exact_quantity_without_auto_delete(self, client, auth_headers, test_user, db_session):
+        """Should keep item at quantity 0 when delete_when_empty=false."""
+        item = InventoryItem(
+            name="Empty Container",
+            quantity=2.0,
+            unit="count",
+            category="snack",
+            storage_location="pantry",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        item_id = item.id
+
+        response = client.post(
+            f"/inventory/{item_id}/consume",
+            headers=auth_headers,
+            json={"amount": 2.0, "delete_when_empty": False}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["deleted"] is False
+        assert data["message"] == "Consumed 2.0 count. 0.0 count remaining."
+        assert data["item"] is not None
+        assert data["item"]["quantity"] == 0.0
+
+        # Verify item still exists in database with quantity 0
+        db_session.expire_all()
+        kept_item = db_session.query(InventoryItem).filter(InventoryItem.id == item_id).first()
+        assert kept_item is not None
+        assert kept_item.quantity == 0.0
+
+    def test_consume_over_consumption_error(self, client, auth_headers, test_user, db_session):
+        """Should return 400 error when trying to consume more than available."""
+        item = InventoryItem(
+            name="Limited Snack",
+            quantity=2.0,
+            unit="count",
+            category="snack",
+            storage_location="pantry",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        item_id = item.id
+
+        response = client.post(
+            f"/inventory/{item_id}/consume",
+            headers=auth_headers,
+            json={"amount": 5.0}
+        )
+
+        assert response.status_code == 400
+        data = response.json()
+        assert "Cannot consume 5.0 count. Only 2.0 count available" in data["detail"]
+
+        # Verify quantity unchanged
+        db_session.expire_all()
+        unchanged_item = db_session.query(InventoryItem).filter(InventoryItem.id == item_id).first()
+        assert unchanged_item.quantity == 2.0
+
+    def test_consume_negative_amount_validation_error(self, client, auth_headers, test_user, db_session):
+        """Should return 422 validation error for negative amount."""
+        item = InventoryItem(
+            name="Some Snack",
+            quantity=5.0,
+            unit="count",
+            category="snack",
+            storage_location="pantry",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        item_id = item.id
+
+        response = client.post(
+            f"/inventory/{item_id}/consume",
+            headers=auth_headers,
+            json={"amount": -1.0}
+        )
+
+        assert response.status_code == 422
+
+    def test_consume_zero_amount_validation_error(self, client, auth_headers, test_user, db_session):
+        """Should return 422 validation error for zero amount."""
+        item = InventoryItem(
+            name="Some Snack",
+            quantity=5.0,
+            unit="count",
+            category="snack",
+            storage_location="pantry",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        item_id = item.id
+
+        response = client.post(
+            f"/inventory/{item_id}/consume",
+            headers=auth_headers,
+            json={"amount": 0}
+        )
+
+        assert response.status_code == 422
+
+    def test_consume_item_not_found(self, client, auth_headers):
+        """Should return 404 when item doesn't exist."""
+        non_existent_id = uuid4()
+
+        response = client.post(
+            f"/inventory/{non_existent_id}/consume",
+            headers=auth_headers,
+            json={"amount": 1.0}
+        )
+
+        assert response.status_code == 404
+        data = response.json()
+        assert data["detail"] == "Inventory item not found"
+
+    def test_consume_cross_user_access_denied(self, client, auth_headers, test_user2, db_session):
+        """Should return 404 when trying to consume another user's item."""
+        # Create item for test_user2
+        item = InventoryItem(
+            name="User2's Snack",
+            quantity=5.0,
+            unit="count",
+            category="snack",
+            storage_location="pantry",
+            added_by=test_user2.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        item_id = item.id
+
+        # Try to consume with test_user's auth (auth_headers)
+        response = client.post(
+            f"/inventory/{item_id}/consume",
+            headers=auth_headers,
+            json={"amount": 1.0}
+        )
+
+        assert response.status_code == 404
+        data = response.json()
+        assert data["detail"] == "Inventory item not found"
+
+        # Verify quantity unchanged for user2's item
+        db_session.expire_all()
+        unchanged_item = db_session.query(InventoryItem).filter(InventoryItem.id == item_id).first()
+        assert unchanged_item.quantity == 5.0
+
+    def test_consume_requires_auth(self, client, test_user, db_session):
+        """Should return 401 when Authorization header is missing."""
+        item = InventoryItem(
+            name="Some Snack",
+            quantity=5.0,
+            unit="count",
+            category="snack",
+            storage_location="pantry",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        item_id = item.id
+
+        response = client.post(f"/inventory/{item_id}/consume", json={"amount": 1.0})
+
+        assert response.status_code == 401
+
+    def test_consume_partial_with_decimal(self, client, auth_headers, test_user, db_session):
+        """Should handle decimal quantities correctly."""
+        item = InventoryItem(
+            name="Olive Oil",
+            quantity=16.5,
+            unit="oz",
+            category="oil_vinegar",
+            storage_location="pantry",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        item_id = item.id
+
+        response = client.post(
+            f"/inventory/{item_id}/consume",
+            headers=auth_headers,
+            json={"amount": 0.25}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["deleted"] is False
+        assert data["item"]["quantity"] == 16.25
+
+    def test_consume_multiple_times(self, client, auth_headers, test_user, db_session):
+        """Should handle multiple consumption requests correctly."""
+        item = InventoryItem(
+            name="Crackers",
+            quantity=10.0,
+            unit="count",
+            category="snack",
+            storage_location="pantry",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        item_id = item.id
+
+        # First consumption
+        response1 = client.post(
+            f"/inventory/{item_id}/consume",
+            headers=auth_headers,
+            json={"amount": 3.0}
+        )
+        assert response1.status_code == 200
+        assert response1.json()["item"]["quantity"] == 7.0
+
+        # Second consumption
+        response2 = client.post(
+            f"/inventory/{item_id}/consume",
+            headers=auth_headers,
+            json={"amount": 2.0}
+        )
+        assert response2.status_code == 200
+        assert response2.json()["item"]["quantity"] == 5.0
+
+        # Third consumption (exact remaining)
+        response3 = client.post(
+            f"/inventory/{item_id}/consume",
+            headers=auth_headers,
+            json={"amount": 5.0}
+        )
+        assert response3.status_code == 200
+        assert response3.json()["deleted"] is True


### PR DESCRIPTION
## Work in Progress

Closes #82

[Phase 1D] Add snack consumption endpoint

**Time Estimate**: 45min

**Description**:
Add endpoint for logging snack consumption that decrements inventory quantities. Supports the "I ate snacks" home screen action.

**Claude Context**:
Files to Read:
- src/db/models/inventory_item.py (quantity field, snack category)

Files to Modify:
- src/routers/inventory.py (add consume endpoint)
- src/schemas/inventory.py (add consumption schema)
- tests/routers/test_inventory.py (add consumption tests)

Related Issues: #81 (freeze/thaw)

**Acceptance Criteria**:
- [ ] POST /inventory/{id}/consume decrements quantity by specified amount: `curl -X POST localhost:8000/inventory/{id}/consume -d '{"amount":1}'`
- [ ] Amount defaults to 1 if not specified
- [ ] Cannot consume more than available (400 error with clear message)
- [ ] Item is auto-deleted when quantity reaches 0 (configurable via delete_when_empty param, default true)
- [ ] Response includes updated item (or confirmation of deletion)
- [ ] Tests cover consumption edge cases: `pytest tests/routers/test_inventory.py -v -k consume`

**Verification Commands**:
```bash
pytest tests/routers/test_inventory.py -v -k consume
curl -X POST http://localhost:8000/inventory/{id}/consume \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"amount":1}'
```

**Done Definition**: Done when consume endpoint decrements quantity correctly with edge case handling.

**Scope Boundary**:
- DO: Add POST endpoint for consumption
- DO: Validate against over-consumption
- DO: Auto-delete depleted items (optional flag)
- DO NOT: Log consumption history per user (Phase 3D daily reconciliation)
- DO NOT: Add batch consumption for multiple items (single-item for now)

**Dependencies**: After #81

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **2** commits (+0 added, ~3 modified, -0 deleted)
- `M` src/routers/inventory.py
- `M` src/schemas/inventory.py
- `M` tests/routers/test_inventory.py

### Commits
- 4e87cfe feat: [Phase 1D] Add snack consumption endpoint
- 375144d chore: initialize work on #82 [Phase 1D] Add snack consumption endpoint
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-03-19T07:35:54Z:**
- Created: #109 
- Updated: none