### PR TITLE
[tech-debt] test-failure: Test expects 400 status

### DIFF
--- a/tests/routers/test_auth.py
+++ b/tests/routers/test_auth.py
@@ -1736,7 +1736,7 @@ class TestAuditLogging:
         registration_data = {
             "name": "Duplicate User",
             "email": test_user.email,
-            "password": "password123",
+            "password": "ValidPass123!",
         }
 
         response = client.post("/auth/register", json=registration_data)


### PR DESCRIPTION
## Work in Progress

Closes #69

[tech-debt] test-failure: Test expects 400 status

## Description
Test expects 400 status but gets 422 when password fails complexity validation

## Location
`tests/routers/test_auth.py:test_duplicate_registration_creates_failure_audit_log`

## Impact
Affects: Audit logging tests

## Intended Fix
Update test to use a valid password that meets complexity requirements

## Done Criteria
- [ ] Test passes with valid password
- [ ] Tests pass
- [ ] No regressions introduced

## Origin
First observed: 2026-03-18 during work on #66

---
_Auto-generated by sharkrite workflow from encountered issues log_

---

## Additional Assessment (PR #85)

**Severity:** MEDIUM
**Reasoning:** These functions are implemented with tests but not integrated. This is dead code that suggests incomplete implementation. However, integrating them requires identifying the correct endpoints and potentially modifying multiple unrelated modules.
**Context:** While these functions relate to the logging theme, integrating them into password change and authorization endpoints is separate work that expands beyond the user switch logging focus of this PR.
**Defer Reason:** Needs separate focused PR - requires identifying and modifying endpoints in potentially different modules

_Added by Sharkrite on 2026-03-19T05:45:29Z_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**1** files, **2** commits (+0 added, ~1 modified, -0 deleted)
- `M` tests/routers/test_auth.py

### Commits
- 28c16ce test: [tech-debt] test-failure: Test expects 400 status
- 55956f2 chore: initialize work on #69 [tech-debt] test-failure: Test expects 400 status
<!-- /sharkrite-changes-summary -->