### PR TITLE
Add password length validation for bcrypt limit

### DIFF
--- a/src/schemas/auth.py
+++ b/src/schemas/auth.py
@@ -17,7 +17,7 @@ class UserCreate(BaseModel):
 
     name: str = Field(..., min_length=1, max_length=255, description="User's display name")
     email: EmailStr = Field(..., description="User's email address (must be unique)")
-    password: str = Field(..., description="Password (minimum 8 characters, maximum 128 characters)")
+    password: str = Field(..., description="Password (minimum 8 characters, maximum 72 bytes for bcrypt compatibility)")
     dietary_profile: Optional[list[str]] = Field(default=None, description="Dietary preferences")
     allergies: Optional[list[str]] = Field(default=None, description="Food allergies")
     disliked_ingredients: Optional[list[str]] = Field(default=None, description="Disliked ingredients (stored as JSON array)")
@@ -32,7 +32,7 @@ class UserCreate(BaseModel):
 
         Password must:
         - Be at least 8 characters long
-        - Be at most 128 characters long
+        - Be at most 72 bytes (bcrypt's maximum) when encoded as UTF-8
         - Contain at least one uppercase letter (A-Z)
         - Contain at least one lowercase letter (a-z)
         - Contain at least one digit (0-9)
@@ -40,13 +40,15 @@ class UserCreate(BaseModel):
         """
         errors = []
 
-        # Check minimum length
+        # Check minimum length (in characters for user-friendliness)
         if len(v) < 8:
             errors.append('at least 8 characters')
 
-        # Check maximum length
-        if len(v) > 128:
-            errors.append('at most 128 characters')
+        # Check maximum length (in bytes for bcrypt compatibility)
+        # bcrypt has a 72-byte limit for passwords
+        password_bytes = len(v.encode('utf-8'))
+        if password_bytes > 72:
+            errors.append('at most 72 bytes (currently {} bytes)'.format(password_bytes))
 
         # Check for uppercase letter
         if not any(c.isupper() for c in v):

--- a/tests/routers/test_auth.py
+++ b/tests/routers/test_auth.py
@@ -1194,10 +1194,10 @@ class TestRegister:
         data = response.json()
         assert data["email"] == "newuser@example.com"
 
-    def test_register_password_exceeds_128_characters(self, client):
-        """POST /auth/register fails when password exceeds 128 characters."""
-        # Create a password with 129 characters that meets all complexity requirements except max length
-        password = "A1!" + "a" * 125 + "!"  # 129 chars total
+    def test_register_password_exceeds_72_bytes(self, client):
+        """POST /auth/register fails when password exceeds 72 bytes (bcrypt limit)."""
+        # Create a password with 73 bytes that meets all complexity requirements except max length
+        password = "A1!" + "a" * 69 + "!"  # 73 chars = 73 bytes total
         register_data = {
             "name": "New User",
             "email": "newuser@example.com",
@@ -1209,12 +1209,13 @@ class TestRegister:
         assert response.status_code == 422
         error_detail = response.json()["detail"]
         error_msg = str(error_detail).lower()
-        assert "128 characters" in error_msg
+        assert "72 bytes" in error_msg
 
-    def test_register_password_exactly_128_characters(self, client, db_session):
-        """POST /auth/register accepts password with exactly 128 characters if valid."""
-        # Create a password with exactly 128 characters that meets all requirements
-        password = "A1!" + "a" * 124 + "!"  # 128 chars total
+    def test_register_password_exactly_72_bytes(self, client, db_session):
+        """POST /auth/register accepts password with exactly 72 bytes (bcrypt limit)."""
+        # Create a password with exactly 72 bytes that meets all requirements
+        # Using ASCII characters: 1 byte per character
+        password = "A1!" + "a" * 68 + "!"  # 72 chars = 72 bytes total
         register_data = {
             "name": "New User",
             "email": "newuser@example.com",

--- a/tests/schemas/test_auth.py
+++ b/tests/schemas/test_auth.py
@@ -207,6 +207,180 @@ class TestPasswordComplexityValidation:
         assert errors[0]["loc"] == ("password",)
         assert "72 bytes" in errors[0]["msg"]
 
+    def test_password_with_2byte_utf8_chars_within_72_bytes_valid(self):
+        """Test that password with 2-byte UTF-8 characters is accepted if total is within 72 bytes."""
+        # 'é' is 2 bytes in UTF-8 (C3 A9)
+        # Password: "Passé123!" = 5 ASCII (5 bytes) + 1 two-byte char (2 bytes) + 4 ASCII (4 bytes) = 11 bytes total
+        password = "Passé123!"
+        user_data = {
+            "name": "Test User",
+            "email": "test@example.com",
+            "password": password,
+        }
+        user = UserCreate(**user_data)
+        assert user.password == password
+        assert len(user.password.encode('utf-8')) == 11
+
+    def test_password_with_2byte_utf8_chars_at_72_bytes_valid(self):
+        """Test that password with 2-byte UTF-8 characters at exactly 72 bytes is accepted."""
+        # 'é' is 2 bytes in UTF-8
+        # Build a password: "A1!" (3 bytes) + "é" * 23 (46 bytes) + "a" * 23 (23 bytes) = 72 bytes
+        password = "A1!" + "é" * 23 + "a" * 23
+        user_data = {
+            "name": "Test User",
+            "email": "test@example.com",
+            "password": password,
+        }
+        user = UserCreate(**user_data)
+        assert user.password == password
+        assert len(user.password.encode('utf-8')) == 72
+
+    def test_password_with_2byte_utf8_chars_exceeds_72_bytes_rejected(self):
+        """Test that password with 2-byte UTF-8 characters exceeding 72 bytes is rejected."""
+        # 'é' is 2 bytes in UTF-8
+        # Build a password: "A1!" (3 bytes) + "é" * 24 (48 bytes) + "a" * 23 (23 bytes) = 74 bytes
+        password = "A1!" + "é" * 24 + "a" * 23
+        user_data = {
+            "name": "Test User",
+            "email": "test@example.com",
+            "password": password,
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            UserCreate(**user_data)
+
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert errors[0]["loc"] == ("password",)
+        assert "72 bytes" in errors[0]["msg"]
+        assert "74 bytes" in errors[0]["msg"]  # Should show actual byte count
+
+    def test_password_with_3byte_utf8_chars_within_72_bytes_valid(self):
+        """Test that password with 3-byte UTF-8 characters is accepted if total is within 72 bytes."""
+        # '你' (Chinese character) is 3 bytes in UTF-8 (E4 BD A0)
+        # Password: "Pass你123!" = 4 ASCII (4 bytes) + 1 three-byte char (3 bytes) + 4 ASCII (4 bytes) = 11 bytes
+        password = "Pass你123!"
+        user_data = {
+            "name": "Test User",
+            "email": "test@example.com",
+            "password": password,
+        }
+        user = UserCreate(**user_data)
+        assert user.password == password
+        assert len(user.password.encode('utf-8')) == 11
+
+    def test_password_with_3byte_utf8_chars_at_72_bytes_valid(self):
+        """Test that password with 3-byte UTF-8 characters at exactly 72 bytes is accepted."""
+        # '你' is 3 bytes in UTF-8
+        # Build a password: "A1!" (3 bytes) + "你" * 15 (45 bytes) + "a" * 24 (24 bytes) = 72 bytes
+        password = "A1!" + "你" * 15 + "a" * 24
+        user_data = {
+            "name": "Test User",
+            "email": "test@example.com",
+            "password": password,
+        }
+        user = UserCreate(**user_data)
+        assert user.password == password
+        assert len(user.password.encode('utf-8')) == 72
+
+    def test_password_with_3byte_utf8_chars_exceeds_72_bytes_rejected(self):
+        """Test that password with 3-byte UTF-8 characters exceeding 72 bytes is rejected."""
+        # '你' is 3 bytes in UTF-8
+        # Build a password: "A1!" (3 bytes) + "你" * 16 (48 bytes) + "a" * 24 (24 bytes) = 75 bytes
+        password = "A1!" + "你" * 16 + "a" * 24
+        user_data = {
+            "name": "Test User",
+            "email": "test@example.com",
+            "password": password,
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            UserCreate(**user_data)
+
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert errors[0]["loc"] == ("password",)
+        assert "72 bytes" in errors[0]["msg"]
+        assert "75 bytes" in errors[0]["msg"]  # Should show actual byte count
+
+    def test_password_with_4byte_utf8_chars_within_72_bytes_valid(self):
+        """Test that password with 4-byte UTF-8 characters (emoji) is accepted if total is within 72 bytes."""
+        # '😀' (emoji) is 4 bytes in UTF-8 (F0 9F 98 80)
+        # Password: "Pass😀123!" = 4 ASCII (4 bytes) + 1 four-byte char (4 bytes) + 4 ASCII (4 bytes) = 12 bytes
+        password = "Pass😀123!"
+        user_data = {
+            "name": "Test User",
+            "email": "test@example.com",
+            "password": password,
+        }
+        user = UserCreate(**user_data)
+        assert user.password == password
+        assert len(user.password.encode('utf-8')) == 12
+
+    def test_password_with_4byte_utf8_chars_at_72_bytes_valid(self):
+        """Test that password with 4-byte UTF-8 characters (emoji) at exactly 72 bytes is accepted."""
+        # '😀' is 4 bytes in UTF-8
+        # Build a password: "A1!" (3 bytes) + "😀" * 11 (44 bytes) + "a" * 25 (25 bytes) = 72 bytes
+        password = "A1!" + "😀" * 11 + "a" * 25
+        user_data = {
+            "name": "Test User",
+            "email": "test@example.com",
+            "password": password,
+        }
+        user = UserCreate(**user_data)
+        assert user.password == password
+        assert len(user.password.encode('utf-8')) == 72
+
+    def test_password_with_4byte_utf8_chars_exceeds_72_bytes_rejected(self):
+        """Test that password with 4-byte UTF-8 characters (emoji) exceeding 72 bytes is rejected."""
+        # '😀' is 4 bytes in UTF-8
+        # Build a password: "A1!" (3 bytes) + "😀" * 12 (48 bytes) + "a" * 25 (25 bytes) = 76 bytes
+        password = "A1!" + "😀" * 12 + "a" * 25
+        user_data = {
+            "name": "Test User",
+            "email": "test@example.com",
+            "password": password,
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            UserCreate(**user_data)
+
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert errors[0]["loc"] == ("password",)
+        assert "72 bytes" in errors[0]["msg"]
+        assert "76 bytes" in errors[0]["msg"]  # Should show actual byte count
+
+    def test_password_with_mixed_multibyte_chars_at_72_bytes_valid(self):
+        """Test password with mixed multi-byte UTF-8 characters at exactly 72 bytes is accepted."""
+        # Mix of 2-byte (é), 3-byte (你), and 4-byte (😀) characters
+        # "A1!" (3 bytes) + "é" * 10 (20 bytes) + "你" * 10 (30 bytes) + "😀" * 4 (16 bytes) + "a" (1 byte) + "!" (1 byte) + "b" (1 byte) = 72 bytes
+        password = "A1!" + "é" * 10 + "你" * 10 + "😀" * 4 + "ab!"
+        user_data = {
+            "name": "Test User",
+            "email": "test@example.com",
+            "password": password,
+        }
+        user = UserCreate(**user_data)
+        assert user.password == password
+        assert len(user.password.encode('utf-8')) == 72
+
+    def test_password_with_mixed_multibyte_chars_exceeds_72_bytes_rejected(self):
+        """Test password with mixed multi-byte UTF-8 characters exceeding 72 bytes is rejected."""
+        # Mix of 2-byte (é), 3-byte (你), and 4-byte (😀) characters
+        # "A1!" (3 bytes) + "é" * 10 (20 bytes) + "你" * 10 (30 bytes) + "😀" * 5 (20 bytes) = 73 bytes
+        password = "A1!" + "é" * 10 + "你" * 10 + "😀" * 5
+        user_data = {
+            "name": "Test User",
+            "email": "test@example.com",
+            "password": password,
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            UserCreate(**user_data)
+
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert errors[0]["loc"] == ("password",)
+        assert "72 bytes" in errors[0]["msg"]
+        assert "73 bytes" in errors[0]["msg"]  # Should show actual byte count
+
     def test_password_with_spaces(self):
         """Test that passwords with spaces are accepted if they meet requirements."""
         user_data = {

--- a/tests/schemas/test_auth.py
+++ b/tests/schemas/test_auth.py
@@ -176,10 +176,11 @@ class TestPasswordComplexityValidation:
         user = UserCreate(**user_data)
         assert user.password == "Pass123!"
 
-    def test_password_exactly_128_characters_valid(self):
-        """Test that password with exactly 128 characters is accepted if it meets all requirements."""
-        # Create a password with exactly 128 characters that meets all complexity requirements
-        password = "A1!" + "a" * 124 + "!"  # 128 chars: uppercase, digit, special chars, lowercase
+    def test_password_exactly_72_bytes_valid(self):
+        """Test that password with exactly 72 bytes (bcrypt limit) is accepted if it meets all requirements."""
+        # Create a password with exactly 72 bytes that meets all complexity requirements
+        # Using ASCII characters: 1 byte per character
+        password = "A1!" + "a" * 68 + "!"  # 72 chars = 72 bytes: uppercase, digit, special chars, lowercase
         user_data = {
             "name": "Test User",
             "email": "test@example.com",
@@ -187,12 +188,12 @@ class TestPasswordComplexityValidation:
         }
         user = UserCreate(**user_data)
         assert user.password == password
-        assert len(user.password) == 128
+        assert len(user.password.encode('utf-8')) == 72
 
-    def test_password_exceeds_128_characters_rejected(self):
-        """Test that password with 129+ characters is rejected."""
-        # Create a password with 129 characters that meets all complexity requirements except length
-        password = "A1!" + "a" * 125 + "!"  # 129 chars: uppercase, digit, special chars, lowercase
+    def test_password_exceeds_72_bytes_rejected(self):
+        """Test that password with 73+ bytes is rejected (bcrypt limit)."""
+        # Create a password with 73 bytes that meets all complexity requirements except max byte length
+        password = "A1!" + "a" * 69 + "!"  # 73 chars = 73 bytes: uppercase, digit, special chars, lowercase
         user_data = {
             "name": "Test User",
             "email": "test@example.com",
@@ -204,7 +205,7 @@ class TestPasswordComplexityValidation:
         errors = exc_info.value.errors()
         assert len(errors) == 1
         assert errors[0]["loc"] == ("password",)
-        assert "128 characters" in errors[0]["msg"]
+        assert "72 bytes" in errors[0]["msg"]
 
     def test_password_with_spaces(self):
         """Test that passwords with spaces are accepted if they meet requirements."""

--- a/tests/schemas/test_auth.py
+++ b/tests/schemas/test_auth.py
@@ -459,3 +459,31 @@ class TestPasswordComplexityValidation:
         }
         user = UserCreate(**user_data)
         assert user.password == "Aa1!Aa1!"
+
+    def test_password_minimum_length_uses_characters_not_bytes(self):
+        """Test that minimum length validation uses character count, not byte count.
+
+        This ensures UX-friendly behavior where a 7-character password with multi-byte
+        UTF-8 characters (e.g., 14+ bytes) is still rejected, while the maximum length
+        of 72 bytes allows for internationalized passwords that may have fewer characters
+        but fit within bcrypt's byte limit.
+        """
+        # '😀' (emoji) is 4 bytes in UTF-8
+        # Password: "Aa1!" (4 bytes) + "😀" * 3 (12 bytes) = 7 characters, 16 bytes
+        # This is under 8 characters but well under 72 bytes
+        password = "Aa1!" + "😀" * 3  # 7 characters total, 16 bytes
+        user_data = {
+            "name": "Test User",
+            "email": "test@example.com",
+            "password": password,
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            UserCreate(**user_data)
+
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert errors[0]["loc"] == ("password",)
+        assert "8 characters" in errors[0]["msg"]
+        # Verify we're testing the right thing: password has enough bytes but not enough characters
+        assert len(password) < 8  # Less than 8 characters
+        assert len(password.encode('utf-8')) > 8  # But more than 8 bytes


### PR DESCRIPTION
## Work in Progress

Closes #68

Add password length validation for bcrypt limit

## Description
Password validation test failing - bcrypt has 72 byte limit but test expects 128 char password to work

## Location
`tests/routers/test_auth.py:test_register_password_exactly_128_characters`

## Impact
Affects: Password registration validation

## Intended Fix
Update test to reflect bcrypt's 72 byte limit or update password validation

## Done Criteria
- [ ] Test passes with correct expectations
- [ ] Tests pass
- [ ] No regressions introduced

## Origin
First observed: 2026-03-18 during work on #66

---
_Auto-generated by sharkrite workflow from encountered issues log_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **4** commits (+0 added, ~3 modified, -0 deleted)
- `M` src/schemas/auth.py
- `M` tests/routers/test_auth.py
- `M` tests/schemas/test_auth.py

### Commits
- 8aa60ce feat: Add password length validation for bcrypt limit
- ce2e31c chore: initialize work on #68 Add password length validation for bcrypt limit
- 4a34716 Merge remote-tracking branch 'origin/main' into feat/add-72-byte-password-limit-validation
- 87bb8dc chore: initialize work on #68 Add 72-byte password limit validation
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues
 Updated: #112 
**From assessment on 2026-03-19T18:46:34Z:**
- Created: #112 
- Updated: none