### PR TITLE
[Phase 1D] Add shopped items bulk endpoint

### DIFF
--- a/src/routers/inventory.py
+++ b/src/routers/inventory.py
@@ -132,10 +132,12 @@ def create_inventory_items_bulk(
         HTTPException(500): If database error occurs
     """
     created_items = []
+    current_idx = 0
 
     try:
         # Create all items with added_by set to current user
         for idx, item_data in enumerate(bulk_data.items):
+            current_idx = idx
             # Exclude added_by from request for security (override with current user)
             item_dict = item_data.model_dump(exclude={'added_by'})
             new_item = InventoryItem(
@@ -154,11 +156,11 @@ def create_inventory_items_bulk(
 
     except IntegrityError as e:
         db.rollback()
-        logger.error(f"Integrity error during bulk inventory creation for user {current_user.id}")
+        logger.error(f"Integrity error during bulk inventory creation for user {current_user.id} at index {current_idx}")
         logger.debug(f"Integrity error occurred during bulk inventory creation: {e}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Bulk inventory creation failed due to data integrity violation"
+            detail=f"Bulk inventory creation failed due to data integrity violation at item index {current_idx}"
         )
     except SQLAlchemyError as e:
         db.rollback()

--- a/src/routers/inventory.py
+++ b/src/routers/inventory.py
@@ -28,6 +28,8 @@ from src.schemas.inventory import (
     LowStockAlertItem,
     ConsumptionRequest,
     ConsumptionResponse,
+    BulkInventoryItemCreate,
+    BulkInventoryItemResponse,
 )
 from src.middleware.auth import get_current_user
 
@@ -98,6 +100,81 @@ def create_inventory_item(
     )
 
     return new_item
+
+
+@router.post("/bulk", response_model=BulkInventoryItemResponse, status_code=status.HTTP_201_CREATED)
+def create_inventory_items_bulk(
+    bulk_data: BulkInventoryItemCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Create multiple inventory items in a single atomic transaction.
+
+    All items are validated before any are created. If any validation fails,
+    no items are created and an error is returned with the index of the failing item.
+
+    The added_by field is automatically set to the current user's ID for all items,
+    ignoring any value provided in the request body.
+
+    Args:
+        bulk_data: List of inventory items to create (1-50 items)
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        BulkInventoryItemResponse: List of created inventory items with IDs
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(400): If more than 50 items provided or data integrity violation
+        HTTPException(422): If validation fails for any item (error includes item index)
+        HTTPException(500): If database error occurs
+    """
+    created_items = []
+
+    try:
+        # Create all items with added_by set to current user
+        for idx, item_data in enumerate(bulk_data.items):
+            # Exclude added_by from request for security (override with current user)
+            item_dict = item_data.model_dump(exclude={'added_by'})
+            new_item = InventoryItem(
+                **item_dict,
+                added_by=current_user.id,
+            )
+            db.add(new_item)
+            created_items.append(new_item)
+
+        # Commit all items atomically
+        db.commit()
+
+        # Refresh all items to get generated IDs
+        for item in created_items:
+            db.refresh(item)
+
+    except IntegrityError as e:
+        db.rollback()
+        logger.error(f"Integrity error during bulk inventory creation for user {current_user.id}")
+        logger.debug(f"Integrity error occurred during bulk inventory creation: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Bulk inventory creation failed due to data integrity violation"
+        )
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during bulk inventory creation for user {current_user.id}")
+        logger.debug(f"Database error occurred during bulk inventory creation: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while creating inventory items"
+        )
+
+    logger.info(
+        f"Bulk inventory creation: user_id={current_user.id}, "
+        f"items_created={len(created_items)}"
+    )
+
+    return BulkInventoryItemResponse(items=created_items)
 
 
 @router.get("", response_model=list[InventoryItemListResponse])

--- a/src/schemas/inventory.py
+++ b/src/schemas/inventory.py
@@ -307,3 +307,20 @@ class ConsumptionResponse(BaseModel):
     message: str = Field(..., description="Status message")
     deleted: bool = Field(..., description="Whether the item was deleted")
     item: Optional[InventoryItemResponse] = Field(default=None, description="Updated item (null if deleted)")
+
+
+class BulkInventoryItemCreate(BaseModel):
+    """Request schema for bulk creating inventory items."""
+
+    items: list[InventoryItemCreate] = Field(
+        ...,
+        min_length=1,
+        max_length=50,
+        description="List of items to create (1-50 items)"
+    )
+
+
+class BulkInventoryItemResponse(BaseModel):
+    """Response schema for bulk create endpoint."""
+
+    items: list[InventoryItemResponse] = Field(..., description="List of created items with IDs")

--- a/tests/routers/test_inventory.py
+++ b/tests/routers/test_inventory.py
@@ -2928,3 +2928,369 @@ class TestConsumeInventoryItem:
         )
         assert response3.status_code == 200
         assert response3.json()["deleted"] is True
+
+
+class TestBulkCreateInventoryItems:
+    """Test suite for bulk inventory item creation endpoint."""
+
+    def test_bulk_create_single_item(self, client, auth_headers, test_user, db_session):
+        """Should create a single item via bulk endpoint."""
+        payload = {
+            "items": [
+                {
+                    "name": "Apples",
+                    "quantity": 6.0,
+                    "unit": "count",
+                    "category": "produce",
+                    "storage_location": "fridge",
+                    "added_by": str(uuid4()),  # Should be ignored
+                }
+            ]
+        }
+
+        response = client.post("/inventory/bulk", json=payload, headers=auth_headers)
+
+        assert response.status_code == 201
+        data = response.json()
+        assert len(data["items"]) == 1
+        assert data["items"][0]["name"] == "Apples"
+        assert data["items"][0]["quantity"] == 6.0
+        assert data["items"][0]["unit"] == "count"
+        assert data["items"][0]["category"] == "produce"
+        assert data["items"][0]["added_by"] == str(test_user.id)
+        assert "id" in data["items"][0]
+
+        # Verify in database
+        db_session.expire_all()
+        items = db_session.query(InventoryItem).filter(InventoryItem.added_by == test_user.id).all()
+        assert len(items) == 1
+        assert items[0].name == "Apples"
+
+    def test_bulk_create_multiple_items(self, client, auth_headers, test_user, db_session):
+        """Should create multiple items in a single transaction."""
+        payload = {
+            "items": [
+                {
+                    "name": "Milk",
+                    "quantity": 1.0,
+                    "unit": "gallon",
+                    "category": "dairy",
+                    "storage_location": "fridge",
+                    "added_by": str(uuid4()),
+                },
+                {
+                    "name": "Bread",
+                    "quantity": 2.0,
+                    "unit": "count",
+                    "category": "grain",
+                    "storage_location": "pantry",
+                    "added_by": str(uuid4()),
+                },
+                {
+                    "name": "Chicken Breast",
+                    "quantity": 1.5,
+                    "unit": "lb",
+                    "category": "protein",
+                    "storage_location": "fridge",
+                    "added_by": str(uuid4()),
+                },
+            ]
+        }
+
+        response = client.post("/inventory/bulk", json=payload, headers=auth_headers)
+
+        assert response.status_code == 201
+        data = response.json()
+        assert len(data["items"]) == 3
+
+        # Check all items have correct user
+        for item in data["items"]:
+            assert item["added_by"] == str(test_user.id)
+            assert "id" in item
+
+        # Check specific items
+        names = [item["name"] for item in data["items"]]
+        assert "Milk" in names
+        assert "Bread" in names
+        assert "Chicken Breast" in names
+
+        # Verify in database
+        db_session.expire_all()
+        items = db_session.query(InventoryItem).filter(InventoryItem.added_by == test_user.id).all()
+        assert len(items) == 3
+
+    def test_bulk_create_max_limit_50_items(self, client, auth_headers, test_user, db_session):
+        """Should successfully create 50 items (max limit)."""
+        items = []
+        for i in range(50):
+            items.append({
+                "name": f"Item {i}",
+                "quantity": 1.0,
+                "unit": "count",
+                "category": "pantry_staple",
+                "storage_location": "pantry",
+                "added_by": str(uuid4()),
+            })
+
+        payload = {"items": items}
+
+        response = client.post("/inventory/bulk", json=payload, headers=auth_headers)
+
+        assert response.status_code == 201
+        data = response.json()
+        assert len(data["items"]) == 50
+
+        # Verify in database
+        db_session.expire_all()
+        db_items = db_session.query(InventoryItem).filter(InventoryItem.added_by == test_user.id).all()
+        assert len(db_items) == 50
+
+    def test_bulk_create_exceeds_max_limit(self, client, auth_headers, test_user, db_session):
+        """Should reject request with more than 50 items."""
+        items = []
+        for i in range(51):
+            items.append({
+                "name": f"Item {i}",
+                "quantity": 1.0,
+                "unit": "count",
+                "category": "pantry_staple",
+                "storage_location": "pantry",
+                "added_by": str(uuid4()),
+            })
+
+        payload = {"items": items}
+
+        response = client.post("/inventory/bulk", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+        data = response.json()
+        assert "detail" in data
+
+        # Verify nothing was created
+        db_session.expire_all()
+        db_items = db_session.query(InventoryItem).filter(InventoryItem.added_by == test_user.id).all()
+        assert len(db_items) == 0
+
+    def test_bulk_create_empty_list(self, client, auth_headers, test_user, db_session):
+        """Should reject empty items list."""
+        payload = {"items": []}
+
+        response = client.post("/inventory/bulk", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+        data = response.json()
+        assert "detail" in data
+
+    def test_bulk_create_validation_error_invalid_category(self, client, auth_headers, test_user, db_session):
+        """Should return 422 for validation errors with item details."""
+        payload = {
+            "items": [
+                {
+                    "name": "Valid Item",
+                    "quantity": 1.0,
+                    "unit": "count",
+                    "category": "produce",
+                    "storage_location": "fridge",
+                    "added_by": str(uuid4()),
+                },
+                {
+                    "name": "Invalid Item",
+                    "quantity": 1.0,
+                    "unit": "count",
+                    "category": "invalid_category",  # Invalid
+                    "storage_location": "fridge",
+                    "added_by": str(uuid4()),
+                },
+            ]
+        }
+
+        response = client.post("/inventory/bulk", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+        data = response.json()
+        assert "detail" in data
+
+        # Verify no items were created (atomic transaction)
+        db_session.expire_all()
+        db_items = db_session.query(InventoryItem).filter(InventoryItem.added_by == test_user.id).all()
+        assert len(db_items) == 0
+
+    def test_bulk_create_validation_error_negative_quantity(self, client, auth_headers, test_user, db_session):
+        """Should return 422 for negative quantity."""
+        payload = {
+            "items": [
+                {
+                    "name": "Bad Item",
+                    "quantity": -5.0,  # Invalid
+                    "unit": "count",
+                    "category": "produce",
+                    "storage_location": "fridge",
+                    "added_by": str(uuid4()),
+                },
+            ]
+        }
+
+        response = client.post("/inventory/bulk", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+        data = response.json()
+        assert "detail" in data
+
+        # Verify no items were created
+        db_session.expire_all()
+        db_items = db_session.query(InventoryItem).filter(InventoryItem.added_by == test_user.id).all()
+        assert len(db_items) == 0
+
+    def test_bulk_create_validation_error_invalid_unit(self, client, auth_headers, test_user, db_session):
+        """Should return 422 for invalid unit."""
+        payload = {
+            "items": [
+                {
+                    "name": "Item",
+                    "quantity": 1.0,
+                    "unit": "invalid_unit",  # Invalid
+                    "category": "produce",
+                    "storage_location": "fridge",
+                    "added_by": str(uuid4()),
+                },
+            ]
+        }
+
+        response = client.post("/inventory/bulk", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+
+        # Verify no items were created
+        db_session.expire_all()
+        db_items = db_session.query(InventoryItem).filter(InventoryItem.added_by == test_user.id).all()
+        assert len(db_items) == 0
+
+    def test_bulk_create_atomic_transaction(self, client, auth_headers, test_user, db_session):
+        """Should rollback all items if any validation fails (atomic)."""
+        payload = {
+            "items": [
+                {
+                    "name": "Good Item 1",
+                    "quantity": 1.0,
+                    "unit": "count",
+                    "category": "produce",
+                    "storage_location": "fridge",
+                    "added_by": str(uuid4()),
+                },
+                {
+                    "name": "Good Item 2",
+                    "quantity": 2.0,
+                    "unit": "lb",
+                    "category": "protein",
+                    "storage_location": "fridge",
+                    "added_by": str(uuid4()),
+                },
+                {
+                    "name": "Bad Item",
+                    "quantity": 3.0,
+                    "unit": "invalid_unit",  # This will fail
+                    "category": "dairy",
+                    "storage_location": "fridge",
+                    "added_by": str(uuid4()),
+                },
+            ]
+        }
+
+        response = client.post("/inventory/bulk", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+
+        # Verify NO items were created (all-or-nothing)
+        db_session.expire_all()
+        db_items = db_session.query(InventoryItem).filter(InventoryItem.added_by == test_user.id).all()
+        assert len(db_items) == 0
+
+    def test_bulk_create_requires_authentication(self, client, db_session):
+        """Should require authentication."""
+        payload = {
+            "items": [
+                {
+                    "name": "Apples",
+                    "quantity": 6.0,
+                    "unit": "count",
+                    "category": "produce",
+                    "storage_location": "fridge",
+                    "added_by": str(uuid4()),
+                }
+            ]
+        }
+
+        response = client.post("/inventory/bulk", json=payload)
+
+        assert response.status_code == 401
+        data = response.json()
+        assert data["detail"] == "Not authenticated"
+
+    def test_bulk_create_with_optional_fields(self, client, auth_headers, test_user, db_session):
+        """Should create items with optional fields."""
+        expiration = datetime.now(timezone.utc) + timedelta(days=7)
+
+        payload = {
+            "items": [
+                {
+                    "name": "Premium Cheese",
+                    "quantity": 1.0,
+                    "unit": "lb",
+                    "category": "dairy",
+                    "storage_location": "fridge",
+                    "added_by": str(uuid4()),
+                    "expiration_date": expiration.isoformat(),
+                    "is_staple": True,
+                    "minimum_threshold": 0.5,
+                    "price": 8.99,
+                    "brand": "Organic Valley",
+                    "vegan_friendly": False,
+                }
+            ]
+        }
+
+        response = client.post("/inventory/bulk", json=payload, headers=auth_headers)
+
+        assert response.status_code == 201
+        data = response.json()
+        assert len(data["items"]) == 1
+        assert data["items"][0]["name"] == "Premium Cheese"
+        assert data["items"][0]["is_staple"] is True
+        assert data["items"][0]["minimum_threshold"] == 0.5
+        assert data["items"][0]["price"] == 8.99
+        assert data["items"][0]["brand"] == "Organic Valley"
+        assert data["items"][0]["vegan_friendly"] is False
+
+    def test_bulk_create_returns_all_fields(self, client, auth_headers, test_user, db_session):
+        """Should return complete item data including generated fields."""
+        payload = {
+            "items": [
+                {
+                    "name": "Test Item",
+                    "quantity": 1.0,
+                    "unit": "count",
+                    "category": "other",
+                    "storage_location": "pantry",
+                    "added_by": str(uuid4()),
+                }
+            ]
+        }
+
+        response = client.post("/inventory/bulk", json=payload, headers=auth_headers)
+
+        assert response.status_code == 201
+        data = response.json()
+        item = data["items"][0]
+
+        # Check all expected fields are present
+        assert "id" in item
+        assert "name" in item
+        assert "quantity" in item
+        assert "unit" in item
+        assert "category" in item
+        assert "storage_location" in item
+        assert "date_added" in item
+        assert "added_by" in item
+        assert "shareability" in item
+        assert "is_staple" in item
+        assert "vegan_friendly" in item


### PR DESCRIPTION
## Work in Progress

Closes #83

[Phase 1D] Add shopped items bulk endpoint

**Time Estimate**: 1hr

**Description**:
Add bulk endpoint for adding multiple items after shopping. Supports the "I shopped" home screen action with efficient batch creation.

**Claude Context**:
Files to Read:
- src/db/models/inventory_item.py (all fields)
- src/routers/inventory.py (existing CRUD patterns)

Files to Modify:
- src/routers/inventory.py (add bulk create endpoint)
- src/schemas/inventory.py (add bulk create schema)
- tests/routers/test_inventory.py (add bulk tests)

Related Issues: #82 (snack consumption)

**Acceptance Criteria**:
- [ ] POST /inventory/bulk creates multiple items in one request: `curl -X POST localhost:8000/inventory/bulk -d '{"items":[...]}'`
- [ ] All items validated before any are created (atomic transaction)
- [ ] Returns list of created items with IDs
- [ ] Validation errors include index of failing item
- [ ] Maximum 50 items per request (400 if exceeded)
- [ ] Tests cover bulk creation and validation: `pytest tests/routers/test_inventory.py -v -k bulk`

**Verification Commands**:
```bash
pytest tests/routers/test_inventory.py -v -k bulk
curl -X POST http://localhost:8000/inventory/bulk \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"items":[{"name":"Apples","quantity":6,"unit":"count","category":"produce","storage_location":"fridge"}]}'
```

**Done Definition**: Done when bulk endpoint creates multiple items atomically with proper validation.

**Scope Boundary**:
- DO: Add POST endpoint for bulk item creation
- DO: Validate all items before committing
- DO: Return created items with IDs
- DO: Limit batch size to 50
- DO NOT: Implement receipt parsing (Phase 4)
- DO NOT: Add merge logic for existing items (separate enhancement)

**Dependencies**: After #82

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **2** commits (+0 added, ~3 modified, -0 deleted)
- `M` src/routers/inventory.py
- `M` src/schemas/inventory.py
- `M` tests/routers/test_inventory.py

### Commits
- 304c4be wip: auto-commit relevant changes for issue #83 (2026-03-19)
- 9c47fc2 chore: initialize work on #83 [Phase 1D] Add shopped items bulk endpoint
<!-- /sharkrite-changes-summary -->