### PR TITLE
Consolidate duplicate validator logic

### DIFF
--- a/src/schemas/auth.py
+++ b/src/schemas/auth.py
@@ -9,7 +9,13 @@ from typing import Optional, Any
 import re
 from pydantic import BaseModel, EmailStr, Field, field_validator, model_validator, ConfigDict
 from src.db.models.user import UserRole, DietaryProfile
-from src.schemas.validators import validate_string_list
+from src.schemas.validators import (
+    validate_string_list,
+    validate_name_not_empty,
+    validate_enum_value,
+    normalize_email,
+    validate_dietary_profile
+)
 
 
 class UserCreate(BaseModel):
@@ -74,40 +80,30 @@ class UserCreate(BaseModel):
 
     @field_validator('name')
     @classmethod
-    def validate_name_not_empty(cls, v: str) -> str:
+    def validate_name(cls, v: str) -> str:
         """Ensure name is not empty or whitespace only."""
-        if not v or not v.strip():
-            raise ValueError('Name cannot be empty')
-        return v.strip()
+        result = validate_name_not_empty(v)
+        # validate_name_not_empty handles None, but name is required so this won't be None
+        return result  # type: ignore
 
     @field_validator('role')
     @classmethod
     def validate_role(cls, v: Optional[str]) -> Optional[str]:
         """Ensure role is a valid UserRole enum value."""
-        if v is not None:
-            valid_roles = [role.value for role in UserRole]
-            if v not in valid_roles:
-                raise ValueError(f'Role must be one of: {", ".join(valid_roles)}')
-        return v
+        return validate_enum_value('Role', v, UserRole, allow_none=True)
 
     @field_validator('email')
     @classmethod
-    def normalize_email(cls, v: str) -> str:
+    def normalize_email_field(cls, v: str) -> str:
         """Normalize email to lowercase for case-insensitive comparison."""
-        return v.lower()
+        return normalize_email(v)
 
     @field_validator('dietary_profile')
     @classmethod
-    def validate_dietary_profile(cls, v: Optional[list[str]]) -> Optional[list[str]]:
+    def validate_dietary_profile_field(cls, v: Optional[list[str]]) -> Optional[list[str]]:
         """Ensure dietary_profile contains valid DietaryProfile enum values and strip whitespace."""
-        if v is not None:
-            # Strip whitespace from each item
-            v = [item.strip() for item in v if item.strip()]
-            valid_profiles = [profile.value for profile in DietaryProfile]
-            for profile in v:
-                if profile not in valid_profiles:
-                    raise ValueError(f'Invalid dietary profile: {profile}. Must be one of: {", ".join(valid_profiles)}')
-        return v
+        valid_profiles = [profile.value for profile in DietaryProfile]
+        return validate_dietary_profile(v, valid_profiles)
 
     @field_validator('allergies', 'disliked_ingredients', 'favorite_ingredients')
     @classmethod
@@ -131,9 +127,9 @@ class LoginRequest(BaseModel):
 
     @field_validator('email')
     @classmethod
-    def normalize_email(cls, v: str) -> str:
+    def normalize_email_field(cls, v: str) -> str:
         """Normalize email to lowercase for case-insensitive comparison."""
-        return v.lower()
+        return normalize_email(v)
 
 
 class UserResponse(BaseModel):
@@ -165,24 +161,16 @@ class UserUpdate(BaseModel):
 
     @field_validator('name')
     @classmethod
-    def validate_name_not_empty(cls, v: Optional[str]) -> Optional[str]:
+    def validate_name(cls, v: Optional[str]) -> Optional[str]:
         """Ensure name is not empty or whitespace only if provided."""
-        if v is not None and (not v or not v.strip()):
-            raise ValueError('Name cannot be empty')
-        return v.strip() if v else None
+        return validate_name_not_empty(v)
 
     @field_validator('dietary_profile')
     @classmethod
-    def validate_dietary_profile(cls, v: Optional[list[str]]) -> Optional[list[str]]:
+    def validate_dietary_profile_field(cls, v: Optional[list[str]]) -> Optional[list[str]]:
         """Ensure dietary_profile contains valid DietaryProfile enum values and strip whitespace."""
-        if v is not None:
-            # Strip whitespace from each item
-            v = [item.strip() for item in v if item.strip()]
-            valid_profiles = [profile.value for profile in DietaryProfile]
-            for profile in v:
-                if profile not in valid_profiles:
-                    raise ValueError(f'Invalid dietary profile: {profile}. Must be one of: {", ".join(valid_profiles)}')
-        return v
+        valid_profiles = [profile.value for profile in DietaryProfile]
+        return validate_dietary_profile(v, valid_profiles)
 
     @field_validator('allergies', 'disliked_ingredients', 'favorite_ingredients')
     @classmethod

--- a/src/schemas/inventory.py
+++ b/src/schemas/inventory.py
@@ -10,6 +10,11 @@ from typing import Optional
 from pydantic import BaseModel, Field, field_validator, ConfigDict
 
 from src.db.models.inventory_item import Category, UnitType, StorageLocation, Shareability
+from src.schemas.validators import (
+    validate_name_not_empty,
+    validate_enum_value,
+    validate_non_negative
+)
 
 
 class StoreResponse(BaseModel):
@@ -42,12 +47,11 @@ class UpdateShareabilityRequest(BaseModel):
 
     @field_validator('shareability')
     @classmethod
-    def validate_shareability(cls, v: str) -> str:
+    def validate_shareability_field(cls, v: str) -> str:
         """Ensure shareability is a valid Shareability enum value."""
-        valid_shareability = [share.value for share in Shareability]
-        if v not in valid_shareability:
-            raise ValueError(f'Shareability must be one of: {", ".join(valid_shareability)}')
-        return v
+        result = validate_enum_value('Shareability', v, Shareability, allow_none=False)
+        # validate_enum_value handles Optional, but this field is required so won't be None
+        return result  # type: ignore
 
 
 class InventoryItemCreate(BaseModel):
@@ -74,72 +78,61 @@ class InventoryItemCreate(BaseModel):
 
     @field_validator('quantity')
     @classmethod
-    def validate_quantity_non_negative(cls, v: float) -> float:
+    def validate_quantity_field(cls, v: float) -> float:
         """Ensure quantity is non-negative."""
-        if v < 0:
-            raise ValueError('Quantity cannot be negative')
-        return v
+        result = validate_non_negative('Quantity', v, allow_none=False)
+        # validate_non_negative handles Optional, but this field is required so won't be None
+        return result  # type: ignore
 
     @field_validator('minimum_threshold')
     @classmethod
-    def validate_threshold_non_negative(cls, v: Optional[float]) -> Optional[float]:
+    def validate_threshold_field(cls, v: Optional[float]) -> Optional[float]:
         """Ensure minimum threshold is non-negative if provided."""
-        if v is not None and v < 0:
-            raise ValueError('Minimum threshold cannot be negative')
-        return v
+        return validate_non_negative('Minimum threshold', v, allow_none=True)
 
     @field_validator('price')
     @classmethod
-    def validate_price_non_negative(cls, v: Optional[float]) -> Optional[float]:
+    def validate_price_field(cls, v: Optional[float]) -> Optional[float]:
         """Ensure price is non-negative if provided."""
-        if v is not None and v < 0:
-            raise ValueError('Price cannot be negative')
-        return v
+        return validate_non_negative('Price', v, allow_none=True)
 
     @field_validator('unit')
     @classmethod
-    def validate_unit(cls, v: str) -> str:
+    def validate_unit_field(cls, v: str) -> str:
         """Ensure unit is a valid UnitType enum value."""
-        valid_units = [unit.value for unit in UnitType]
-        if v not in valid_units:
-            raise ValueError(f'Unit must be one of: {", ".join(valid_units)}')
-        return v
+        result = validate_enum_value('Unit', v, UnitType, allow_none=False)
+        # validate_enum_value handles Optional, but this field is required so won't be None
+        return result  # type: ignore
 
     @field_validator('category')
     @classmethod
-    def validate_category(cls, v: str) -> str:
+    def validate_category_field(cls, v: str) -> str:
         """Ensure category is a valid Category enum value."""
-        valid_categories = [cat.value for cat in Category]
-        if v not in valid_categories:
-            raise ValueError(f'Category must be one of: {", ".join(valid_categories)}')
-        return v
+        result = validate_enum_value('Category', v, Category, allow_none=False)
+        # validate_enum_value handles Optional, but this field is required so won't be None
+        return result  # type: ignore
 
     @field_validator('storage_location')
     @classmethod
-    def validate_storage_location(cls, v: str) -> str:
+    def validate_storage_location_field(cls, v: str) -> str:
         """Ensure storage_location is a valid StorageLocation enum value."""
-        valid_locations = [loc.value for loc in StorageLocation]
-        if v not in valid_locations:
-            raise ValueError(f'Storage location must be one of: {", ".join(valid_locations)}')
-        return v
+        result = validate_enum_value('Storage location', v, StorageLocation, allow_none=False)
+        # validate_enum_value handles Optional, but this field is required so won't be None
+        return result  # type: ignore
 
     @field_validator('shareability')
     @classmethod
-    def validate_shareability(cls, v: Optional[str]) -> Optional[str]:
+    def validate_shareability_value(cls, v: Optional[str]) -> Optional[str]:
         """Ensure shareability is a valid Shareability enum value."""
-        if v is not None:
-            valid_shareability = [share.value for share in Shareability]
-            if v not in valid_shareability:
-                raise ValueError(f'Shareability must be one of: {", ".join(valid_shareability)}')
-        return v
+        return validate_enum_value('Shareability', v, Shareability, allow_none=True)
 
     @field_validator('name')
     @classmethod
-    def validate_name_not_empty(cls, v: str) -> str:
+    def validate_name(cls, v: str) -> str:
         """Ensure name is not empty or whitespace only."""
-        if not v or not v.strip():
-            raise ValueError('Name cannot be empty')
-        return v.strip()
+        result = validate_name_not_empty(v)
+        # validate_name_not_empty handles None, but name is required so this won't be None
+        return result  # type: ignore
 
 
 class InventoryItemUpdate(BaseModel):
@@ -166,75 +159,51 @@ class InventoryItemUpdate(BaseModel):
 
     @field_validator('quantity')
     @classmethod
-    def validate_quantity_non_negative(cls, v: Optional[float]) -> Optional[float]:
+    def validate_quantity_field(cls, v: Optional[float]) -> Optional[float]:
         """Ensure quantity is non-negative if provided."""
-        if v is not None and v < 0:
-            raise ValueError('Quantity cannot be negative')
-        return v
+        return validate_non_negative('Quantity', v, allow_none=True)
 
     @field_validator('minimum_threshold')
     @classmethod
-    def validate_threshold_non_negative(cls, v: Optional[float]) -> Optional[float]:
+    def validate_threshold_field(cls, v: Optional[float]) -> Optional[float]:
         """Ensure minimum threshold is non-negative if provided."""
-        if v is not None and v < 0:
-            raise ValueError('Minimum threshold cannot be negative')
-        return v
+        return validate_non_negative('Minimum threshold', v, allow_none=True)
 
     @field_validator('price')
     @classmethod
-    def validate_price_non_negative(cls, v: Optional[float]) -> Optional[float]:
+    def validate_price_field(cls, v: Optional[float]) -> Optional[float]:
         """Ensure price is non-negative if provided."""
-        if v is not None and v < 0:
-            raise ValueError('Price cannot be negative')
-        return v
+        return validate_non_negative('Price', v, allow_none=True)
 
     @field_validator('unit')
     @classmethod
-    def validate_unit(cls, v: Optional[str]) -> Optional[str]:
+    def validate_unit_field(cls, v: Optional[str]) -> Optional[str]:
         """Ensure unit is a valid UnitType enum value if provided."""
-        if v is not None:
-            valid_units = [unit.value for unit in UnitType]
-            if v not in valid_units:
-                raise ValueError(f'Unit must be one of: {", ".join(valid_units)}')
-        return v
+        return validate_enum_value('Unit', v, UnitType, allow_none=True)
 
     @field_validator('category')
     @classmethod
-    def validate_category(cls, v: Optional[str]) -> Optional[str]:
+    def validate_category_field(cls, v: Optional[str]) -> Optional[str]:
         """Ensure category is a valid Category enum value if provided."""
-        if v is not None:
-            valid_categories = [cat.value for cat in Category]
-            if v not in valid_categories:
-                raise ValueError(f'Category must be one of: {", ".join(valid_categories)}')
-        return v
+        return validate_enum_value('Category', v, Category, allow_none=True)
 
     @field_validator('storage_location')
     @classmethod
-    def validate_storage_location(cls, v: Optional[str]) -> Optional[str]:
+    def validate_storage_location_field(cls, v: Optional[str]) -> Optional[str]:
         """Ensure storage_location is a valid StorageLocation enum value if provided."""
-        if v is not None:
-            valid_locations = [loc.value for loc in StorageLocation]
-            if v not in valid_locations:
-                raise ValueError(f'Storage location must be one of: {", ".join(valid_locations)}')
-        return v
+        return validate_enum_value('Storage location', v, StorageLocation, allow_none=True)
 
     @field_validator('shareability')
     @classmethod
-    def validate_shareability(cls, v: Optional[str]) -> Optional[str]:
+    def validate_shareability_value(cls, v: Optional[str]) -> Optional[str]:
         """Ensure shareability is a valid Shareability enum value if provided."""
-        if v is not None:
-            valid_shareability = [share.value for share in Shareability]
-            if v not in valid_shareability:
-                raise ValueError(f'Shareability must be one of: {", ".join(valid_shareability)}')
-        return v
+        return validate_enum_value('Shareability', v, Shareability, allow_none=True)
 
     @field_validator('name')
     @classmethod
-    def validate_name_not_empty(cls, v: Optional[str]) -> Optional[str]:
+    def validate_name(cls, v: Optional[str]) -> Optional[str]:
         """Ensure name is not empty or whitespace only if provided."""
-        if v is not None and (not v or not v.strip()):
-            raise ValueError('Name cannot be empty')
-        return v.strip() if v else None
+        return validate_name_not_empty(v)
 
 
 class InventoryItemResponse(BaseModel):

--- a/src/schemas/substitution.py
+++ b/src/schemas/substitution.py
@@ -10,7 +10,7 @@ from typing import Optional
 from pydantic import BaseModel, Field, field_validator, ConfigDict
 
 from src.db.models.substitution import SubstitutionContext
-from src.schemas.validators import validate_ingredient_name
+from src.schemas.validators import validate_ingredient_name, validate_enum_value
 
 
 class ReplacementItem(BaseModel):
@@ -64,17 +64,14 @@ class SubstitutionPreferenceCreate(BaseModel):
 
     @field_validator('context')
     @classmethod
-    def validate_context(cls, v: Optional[str]) -> str:
+    def validate_context_field(cls, v: Optional[str]) -> str:
         """Ensure context is a valid SubstitutionContext enum value."""
         if v is None:
             return SubstitutionContext.any.value
 
-        valid_contexts = [ctx.value for ctx in SubstitutionContext]
-        if v not in valid_contexts:
-            raise ValueError(
-                f'Context must be one of: {", ".join(valid_contexts)}. Got: {v}'
-            )
-        return v
+        result = validate_enum_value('Context', v, SubstitutionContext, allow_none=False)
+        # validate_enum_value handles Optional, but we've already handled None case above
+        return result  # type: ignore
 
     @field_validator('replacements')
     @classmethod

--- a/src/schemas/substitution.py
+++ b/src/schemas/substitution.py
@@ -101,15 +101,7 @@ class SubstitutionPreferenceUpdate(BaseModel):
     @classmethod
     def validate_context(cls, v: Optional[str]) -> Optional[str]:
         """Ensure context is a valid SubstitutionContext enum value if provided."""
-        if v is None:
-            return None
-
-        valid_contexts = [ctx.value for ctx in SubstitutionContext]
-        if v not in valid_contexts:
-            raise ValueError(
-                f'Context must be one of: {", ".join(valid_contexts)}. Got: {v}'
-            )
-        return v
+        return validate_enum_value('Context', v, SubstitutionContext, allow_none=True)
 
     @field_validator('replacements')
     @classmethod

--- a/src/schemas/validators.py
+++ b/src/schemas/validators.py
@@ -6,7 +6,8 @@ across all schema modules. This prevents security vulnerabilities from duplicate
 validation logic diverging over time.
 """
 
-from typing import Optional
+from typing import Optional, Any
+from enum import Enum
 import unicodedata
 
 
@@ -172,3 +173,132 @@ def validate_string_list(
         normalized.append(normalized_item)
 
     return normalized
+
+
+def validate_name_not_empty(value: Optional[str], strip: bool = True) -> Optional[str]:
+    """
+    Validate that a name field is not empty or whitespace-only.
+
+    Args:
+        value: The name to validate
+        strip: Whether to strip whitespace from the result (default: True)
+
+    Returns:
+        Stripped name if valid, or None if input was None
+
+    Raises:
+        ValueError: If name is empty or whitespace-only
+    """
+    if value is None:
+        return None
+
+    if not value or not value.strip():
+        raise ValueError('Name cannot be empty')
+
+    return value.strip() if strip else value
+
+
+def validate_enum_value(
+    field_name: str,
+    value: Optional[str],
+    enum_class: type[Enum],
+    allow_none: bool = False
+) -> Optional[str]:
+    """
+    Validate that a string value matches a valid enum value.
+
+    Args:
+        field_name: Name of the field being validated (for error messages)
+        value: The value to validate
+        enum_class: The Enum class to validate against
+        allow_none: Whether None is allowed (default: False)
+
+    Returns:
+        The validated value, or None if value was None and allow_none is True
+
+    Raises:
+        ValueError: If value is not a valid enum value
+    """
+    if value is None:
+        if allow_none:
+            return None
+        raise ValueError(f'{field_name} cannot be None')
+
+    valid_values = [item.value for item in enum_class]
+    if value not in valid_values:
+        raise ValueError(f'{field_name} must be one of: {", ".join(valid_values)}')
+
+    return value
+
+
+def validate_non_negative(
+    field_name: str,
+    value: Optional[float],
+    allow_none: bool = True
+) -> Optional[float]:
+    """
+    Validate that a numeric value is non-negative.
+
+    Args:
+        field_name: Name of the field being validated (for error messages)
+        value: The numeric value to validate
+        allow_none: Whether None is allowed (default: True)
+
+    Returns:
+        The validated value, or None if value was None and allow_none is True
+
+    Raises:
+        ValueError: If value is negative or None when not allowed
+    """
+    if value is None:
+        if allow_none:
+            return None
+        raise ValueError(f'{field_name} cannot be None')
+
+    if value < 0:
+        raise ValueError(f'{field_name} cannot be negative')
+
+    return value
+
+
+def normalize_email(email: str) -> str:
+    """
+    Normalize email to lowercase for case-insensitive comparison.
+
+    Args:
+        email: The email address to normalize
+
+    Returns:
+        Lowercase email address
+    """
+    return email.lower()
+
+
+def validate_dietary_profile(values: Optional[list[str]], valid_profiles: list[str]) -> Optional[list[str]]:
+    """
+    Validate dietary profile list against allowed values.
+
+    Strips whitespace from each item and filters out empty strings.
+
+    Args:
+        values: List of dietary profile strings to validate
+        valid_profiles: List of valid profile values
+
+    Returns:
+        Cleaned list of valid profiles, or None if input was None
+
+    Raises:
+        ValueError: If any profile is not in the valid list
+    """
+    if values is None:
+        return None
+
+    # Strip whitespace from each item and filter empty strings
+    cleaned = [item.strip() for item in values if item.strip()]
+
+    # Validate each profile
+    for profile in cleaned:
+        if profile not in valid_profiles:
+            raise ValueError(f'Invalid dietary profile: {profile}. Must be one of: {", ".join(valid_profiles)}')
+
+    return cleaned

--- a/src/schemas/validators.py
+++ b/src/schemas/validators.py
@@ -6,7 +6,7 @@ across all schema modules. This prevents security vulnerabilities from duplicate
 validation logic diverging over time.
 """
 
-from typing import Optional, Any
+from typing import Optional
 from enum import Enum
 import unicodedata
 
@@ -226,7 +226,7 @@ def validate_enum_value(
 
     valid_values = [item.value for item in enum_class]
     if value not in valid_values:
-        raise ValueError(f'{field_name} must be one of: {", ".join(valid_values)}')
+        raise ValueError(f'{field_name} must be one of: {", ".join(valid_values)}. Got: {value}')
 
     return value
 

--- a/tests/schemas/test_validators.py
+++ b/tests/schemas/test_validators.py
@@ -95,6 +95,21 @@ class TestValidateEnumValue:
             validate_enum_value("Context", "bad_value", self.MockEnum)
         assert "Got: bad_value" in str(exc_info.value)
 
+    def test_case_sensitivity(self):
+        """Test that enum validation is case-sensitive."""
+        # Uppercase version should not match lowercase enum value
+        with pytest.raises(ValueError, match="Field must be one of: option_a, option_b, option_c. Got: OPTION_A"):
+            validate_enum_value("Field", "OPTION_A", self.MockEnum)
+
+        # Mixed case should not match
+        with pytest.raises(ValueError, match="Field must be one of: option_a, option_b, option_c. Got: Option_A"):
+            validate_enum_value("Field", "Option_A", self.MockEnum)
+
+    def test_empty_string_input(self):
+        """Test that empty string is rejected as invalid enum value."""
+        with pytest.raises(ValueError, match="Field must be one of: option_a, option_b, option_c. Got: "):
+            validate_enum_value("Field", "", self.MockEnum)
+
 
 class TestValidateNonNegative:
     """Tests for validate_non_negative function."""

--- a/tests/schemas/test_validators.py
+++ b/tests/schemas/test_validators.py
@@ -1,0 +1,219 @@
+"""
+Unit tests for shared validator functions.
+
+Tests cover the five new consolidated validator functions:
+- validate_name_not_empty
+- validate_enum_value
+- validate_non_negative
+- normalize_email
+- validate_dietary_profile
+"""
+
+import pytest
+from enum import Enum
+from src.schemas.validators import (
+    validate_name_not_empty,
+    validate_enum_value,
+    validate_non_negative,
+    normalize_email,
+    validate_dietary_profile,
+)
+
+
+class TestValidateNameNotEmpty:
+    """Tests for validate_name_not_empty function."""
+
+    def test_valid_name_with_content(self):
+        """Test that a valid name with content is accepted and stripped."""
+        result = validate_name_not_empty("  John Doe  ")
+        assert result == "John Doe"
+
+    def test_valid_name_without_stripping(self):
+        """Test that a valid name without stripping preserves whitespace."""
+        result = validate_name_not_empty("  John Doe  ", strip=False)
+        assert result == "  John Doe  "
+
+    def test_none_value_returns_none(self):
+        """Test that None input returns None."""
+        result = validate_name_not_empty(None)
+        assert result is None
+
+    def test_empty_string_raises_error(self):
+        """Test that empty string raises ValueError."""
+        with pytest.raises(ValueError, match="Name cannot be empty"):
+            validate_name_not_empty("")
+
+    def test_whitespace_only_raises_error(self):
+        """Test that whitespace-only string raises ValueError."""
+        with pytest.raises(ValueError, match="Name cannot be empty"):
+            validate_name_not_empty("   ")
+
+    def test_single_character_name(self):
+        """Test that single character names are valid."""
+        result = validate_name_not_empty("A")
+        assert result == "A"
+
+
+class TestValidateEnumValue:
+    """Tests for validate_enum_value function."""
+
+    class MockEnum(Enum):
+        """Mock enum for testing."""
+        OPTION_A = "option_a"
+        OPTION_B = "option_b"
+        OPTION_C = "option_c"
+
+    def test_valid_enum_value(self):
+        """Test that valid enum values are accepted."""
+        result = validate_enum_value("Field", "option_a", self.MockEnum)
+        assert result == "option_a"
+
+    def test_invalid_enum_value_raises_error(self):
+        """Test that invalid enum value raises ValueError with proper message."""
+        with pytest.raises(ValueError, match="Field must be one of: option_a, option_b, option_c. Got: invalid"):
+            validate_enum_value("Field", "invalid", self.MockEnum)
+
+    def test_none_value_not_allowed_by_default(self):
+        """Test that None raises ValueError when allow_none is False."""
+        with pytest.raises(ValueError, match="Field cannot be None"):
+            validate_enum_value("Field", None, self.MockEnum)
+
+    def test_none_value_allowed_when_specified(self):
+        """Test that None is accepted when allow_none is True."""
+        result = validate_enum_value("Field", None, self.MockEnum, allow_none=True)
+        assert result is None
+
+    def test_all_enum_values_accepted(self):
+        """Test that all values from the enum are accepted."""
+        for enum_item in self.MockEnum:
+            result = validate_enum_value("Field", enum_item.value, self.MockEnum)
+            assert result == enum_item.value
+
+    def test_error_message_includes_invalid_value(self):
+        """Test that error message includes the invalid value that was provided."""
+        with pytest.raises(ValueError) as exc_info:
+            validate_enum_value("Context", "bad_value", self.MockEnum)
+        assert "Got: bad_value" in str(exc_info.value)
+
+
+class TestValidateNonNegative:
+    """Tests for validate_non_negative function."""
+
+    def test_positive_value(self):
+        """Test that positive values are accepted."""
+        result = validate_non_negative("Field", 42.5)
+        assert result == 42.5
+
+    def test_zero_value(self):
+        """Test that zero is accepted as non-negative."""
+        result = validate_non_negative("Field", 0.0)
+        assert result == 0.0
+
+    def test_negative_value_raises_error(self):
+        """Test that negative values raise ValueError."""
+        with pytest.raises(ValueError, match="Field cannot be negative"):
+            validate_non_negative("Field", -1.0)
+
+    def test_none_value_allowed_by_default(self):
+        """Test that None is accepted when allow_none is True (default)."""
+        result = validate_non_negative("Field", None)
+        assert result is None
+
+    def test_none_value_not_allowed_when_specified(self):
+        """Test that None raises ValueError when allow_none is False."""
+        with pytest.raises(ValueError, match="Field cannot be None"):
+            validate_non_negative("Field", None, allow_none=False)
+
+    def test_integer_value(self):
+        """Test that integer values work correctly."""
+        result = validate_non_negative("Field", 10)
+        assert result == 10
+
+    def test_very_small_negative_value(self):
+        """Test that even very small negative values are rejected."""
+        with pytest.raises(ValueError, match="Field cannot be negative"):
+            validate_non_negative("Field", -0.0001)
+
+
+class TestNormalizeEmail:
+    """Tests for normalize_email function."""
+
+    def test_uppercase_email(self):
+        """Test that uppercase email is converted to lowercase."""
+        result = normalize_email("USER@EXAMPLE.COM")
+        assert result == "user@example.com"
+
+    def test_mixed_case_email(self):
+        """Test that mixed case email is converted to lowercase."""
+        result = normalize_email("User@Example.Com")
+        assert result == "user@example.com"
+
+    def test_already_lowercase_email(self):
+        """Test that already lowercase email remains unchanged."""
+        result = normalize_email("user@example.com")
+        assert result == "user@example.com"
+
+    def test_email_with_plus_addressing(self):
+        """Test that email with plus addressing is normalized correctly."""
+        result = normalize_email("User+Tag@Example.Com")
+        assert result == "user+tag@example.com"
+
+    def test_email_with_subdomain(self):
+        """Test that email with subdomain is normalized correctly."""
+        result = normalize_email("User@Mail.Example.Com")
+        assert result == "user@mail.example.com"
+
+
+class TestValidateDietaryProfile:
+    """Tests for validate_dietary_profile function."""
+
+    VALID_PROFILES = ["vegetarian", "vegan", "gluten-free", "dairy-free"]
+
+    def test_valid_single_profile(self):
+        """Test that a single valid profile is accepted."""
+        result = validate_dietary_profile(["vegetarian"], self.VALID_PROFILES)
+        assert result == ["vegetarian"]
+
+    def test_valid_multiple_profiles(self):
+        """Test that multiple valid profiles are accepted."""
+        result = validate_dietary_profile(["vegetarian", "gluten-free"], self.VALID_PROFILES)
+        assert result == ["vegetarian", "gluten-free"]
+
+    def test_none_value_returns_none(self):
+        """Test that None input returns None."""
+        result = validate_dietary_profile(None, self.VALID_PROFILES)
+        assert result is None
+
+    def test_invalid_profile_raises_error(self):
+        """Test that invalid profile raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid dietary profile: invalid"):
+            validate_dietary_profile(["invalid"], self.VALID_PROFILES)
+
+    def test_mixed_valid_and_invalid_raises_error(self):
+        """Test that mix of valid and invalid profiles raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid dietary profile: bad-profile"):
+            validate_dietary_profile(["vegetarian", "bad-profile"], self.VALID_PROFILES)
+
+    def test_whitespace_stripping(self):
+        """Test that whitespace is stripped from profile values."""
+        result = validate_dietary_profile(["  vegetarian  ", "vegan"], self.VALID_PROFILES)
+        assert result == ["vegetarian", "vegan"]
+
+    def test_empty_strings_filtered_out(self):
+        """Test that empty strings are filtered out."""
+        result = validate_dietary_profile(["vegetarian", "", "  ", "vegan"], self.VALID_PROFILES)
+        assert result == ["vegetarian", "vegan"]
+
+    def test_all_empty_strings_returns_empty_list(self):
+        """Test that list of only empty strings returns empty list."""
+        result = validate_dietary_profile(["", "  ", "   "], self.VALID_PROFILES)
+        assert result == []
+
+    def test_error_message_includes_valid_options(self):
+        """Test that error message includes list of valid options."""
+        with pytest.raises(ValueError) as exc_info:
+            validate_dietary_profile(["invalid"], self.VALID_PROFILES)
+        assert "vegetarian" in str(exc_info.value)
+        assert "vegan" in str(exc_info.value)
+        assert "gluten-free" in str(exc_info.value)
+        assert "dairy-free" in str(exc_info.value)

--- a/tests/schemas/test_validators.py
+++ b/tests/schemas/test_validators.py
@@ -232,3 +232,370 @@ class TestValidateDietaryProfile:
         assert "vegan" in str(exc_info.value)
         assert "gluten-free" in str(exc_info.value)
         assert "dairy-free" in str(exc_info.value)
+
+
+# Integration tests for auth schemas using consolidated validators
+class TestUserCreateSchemaIntegration:
+    """Integration tests for UserCreate schema validation using consolidated validators."""
+
+    def test_valid_user_create_minimal(self):
+        """Test creating user with minimal required fields."""
+        from src.schemas.auth import UserCreate
+
+        user_data = {
+            "name": "John Doe",
+            "email": "john@example.com",
+            "password": "SecurePass123!"
+        }
+        user = UserCreate(**user_data)
+        assert user.name == "John Doe"
+        assert user.email == "john@example.com"
+        assert user.password == "SecurePass123!"
+        assert user.dietary_profile is None
+        assert user.allergies is None
+        assert user.disliked_ingredients is None
+        assert user.favorite_ingredients is None
+        assert user.role is None
+
+    def test_valid_user_create_with_all_fields(self):
+        """Test creating user with all fields populated."""
+        from src.schemas.auth import UserCreate
+
+        user_data = {
+            "name": "Jane Smith",
+            "email": "JANE@EXAMPLE.COM",
+            "password": "AnotherPass456!",
+            "dietary_profile": ["vegetarian", "vegan"],
+            "allergies": ["peanuts", "shellfish"],
+            "disliked_ingredients": ["olives", "mushrooms"],
+            "favorite_ingredients": ["tomatoes", "basil"],
+            "role": "coordinator"
+        }
+        user = UserCreate(**user_data)
+        assert user.name == "Jane Smith"
+        assert user.email == "jane@example.com"  # Email normalized to lowercase
+        assert user.dietary_profile == ["vegetarian", "vegan"]
+        assert user.allergies == ["peanuts", "shellfish"]
+        assert user.role == "coordinator"
+
+    def test_user_create_email_normalization(self):
+        """Test that email is normalized to lowercase."""
+        from src.schemas.auth import UserCreate
+
+        user_data = {
+            "name": "Test User",
+            "email": "Test.User@EXAMPLE.COM",
+            "password": "Password123!"
+        }
+        user = UserCreate(**user_data)
+        assert user.email == "test.user@example.com"
+
+    def test_user_create_name_validation_strips_whitespace(self):
+        """Test that name validator strips whitespace."""
+        from src.schemas.auth import UserCreate
+
+        user_data = {
+            "name": "  John Doe  ",
+            "email": "john@example.com",
+            "password": "Password123!"
+        }
+        user = UserCreate(**user_data)
+        assert user.name == "John Doe"
+
+    def test_user_create_name_validation_rejects_empty(self):
+        """Test that empty name is rejected."""
+        from src.schemas.auth import UserCreate
+
+        user_data = {
+            "name": "   ",
+            "email": "john@example.com",
+            "password": "Password123!"
+        }
+        with pytest.raises(ValueError, match="Name cannot be empty"):
+            UserCreate(**user_data)
+
+    def test_user_create_role_validation_valid_roles(self):
+        """Test that valid role values are accepted."""
+        from src.schemas.auth import UserCreate
+
+        for role in ["coordinator", "member"]:
+            user_data = {
+                "name": "Test User",
+                "email": "test@example.com",
+                "password": "Password123!",
+                "role": role
+            }
+            user = UserCreate(**user_data)
+            assert user.role == role
+
+    def test_user_create_role_validation_invalid_role(self):
+        """Test that invalid role is rejected."""
+        from src.schemas.auth import UserCreate
+
+        user_data = {
+            "name": "Test User",
+            "email": "test@example.com",
+            "password": "Password123!",
+            "role": "admin"
+        }
+        with pytest.raises(ValueError, match="Role must be one of: coordinator, member"):
+            UserCreate(**user_data)
+
+    def test_user_create_dietary_profile_validation(self):
+        """Test dietary profile validation with valid and invalid values."""
+        from src.schemas.auth import UserCreate
+
+        # Valid profiles
+        user_data = {
+            "name": "Test User",
+            "email": "test@example.com",
+            "password": "Password123!",
+            "dietary_profile": ["vegetarian", "vegan"]
+        }
+        user = UserCreate(**user_data)
+        assert user.dietary_profile == ["vegetarian", "vegan"]
+
+        # Invalid profile
+        user_data["dietary_profile"] = ["invalid-profile"]
+        with pytest.raises(ValueError, match="Invalid dietary profile: invalid-profile"):
+            UserCreate(**user_data)
+
+    def test_user_create_dietary_profile_whitespace_handling(self):
+        """Test that dietary profile strips whitespace and filters empty strings."""
+        from src.schemas.auth import UserCreate
+
+        user_data = {
+            "name": "Test User",
+            "email": "test@example.com",
+            "password": "Password123!",
+            "dietary_profile": ["  vegetarian  ", "", "  ", "vegan"]
+        }
+        user = UserCreate(**user_data)
+        assert user.dietary_profile == ["vegetarian", "vegan"]
+
+    def test_user_create_ingredient_lists_validation(self):
+        """Test that ingredient lists are validated correctly."""
+        from src.schemas.auth import UserCreate
+
+        user_data = {
+            "name": "Test User",
+            "email": "test@example.com",
+            "password": "Password123!",
+            "allergies": ["peanuts", "shellfish"],
+            "disliked_ingredients": ["olives"],
+            "favorite_ingredients": ["tomatoes", "basil"]
+        }
+        user = UserCreate(**user_data)
+        assert user.allergies == ["peanuts", "shellfish"]
+        assert user.disliked_ingredients == ["olives"]
+        assert user.favorite_ingredients == ["tomatoes", "basil"]
+
+    def test_user_create_ingredient_lists_whitespace_handling(self):
+        """Test that ingredient lists strip whitespace and filter empty strings."""
+        from src.schemas.auth import UserCreate
+
+        user_data = {
+            "name": "Test User",
+            "email": "test@example.com",
+            "password": "Password123!",
+            "allergies": ["  peanuts  ", "", "shellfish"]
+        }
+        user = UserCreate(**user_data)
+        assert user.allergies == ["peanuts", "shellfish"]
+
+    def test_user_create_password_validation_complexity(self):
+        """Test password complexity validation."""
+        from src.schemas.auth import UserCreate
+
+        base_data = {
+            "name": "Test User",
+            "email": "test@example.com"
+        }
+
+        # Valid password
+        user = UserCreate(**base_data, password="ValidPass123!")
+        assert user.password == "ValidPass123!"
+
+        # Too short
+        with pytest.raises(ValueError, match="at least 8 characters"):
+            UserCreate(**base_data, password="Short1!")
+
+        # No uppercase
+        with pytest.raises(ValueError, match="at least one uppercase letter"):
+            UserCreate(**base_data, password="lowercase123!")
+
+        # No lowercase
+        with pytest.raises(ValueError, match="at least one lowercase letter"):
+            UserCreate(**base_data, password="UPPERCASE123!")
+
+        # No digit
+        with pytest.raises(ValueError, match="at least one digit"):
+            UserCreate(**base_data, password="NoDigitsHere!")
+
+        # No special character
+        with pytest.raises(ValueError, match="at least one special character"):
+            UserCreate(**base_data, password="NoSpecial123")
+
+    def test_user_create_password_validation_bcrypt_limit(self):
+        """Test that password exceeding bcrypt 72-byte limit is rejected."""
+        from src.schemas.auth import UserCreate
+
+        # Create a password that exceeds 72 bytes
+        long_password = "A1!" + "a" * 100  # Will exceed 72 bytes
+        user_data = {
+            "name": "Test User",
+            "email": "test@example.com",
+            "password": long_password
+        }
+        with pytest.raises(ValueError, match="at most 72 bytes"):
+            UserCreate(**user_data)
+
+
+class TestUserUpdateSchemaIntegration:
+    """Integration tests for UserUpdate schema validation using consolidated validators."""
+
+    def test_valid_user_update_single_field(self):
+        """Test updating a single field."""
+        from src.schemas.auth import UserUpdate
+
+        update_data = {"name": "Updated Name"}
+        update = UserUpdate(**update_data)
+        assert update.name == "Updated Name"
+        assert update.dietary_profile is None
+        assert update.allergies is None
+
+    def test_valid_user_update_multiple_fields(self):
+        """Test updating multiple fields."""
+        from src.schemas.auth import UserUpdate
+
+        update_data = {
+            "name": "Updated Name",
+            "dietary_profile": ["vegan"],
+            "allergies": ["nuts"],
+            "disliked_ingredients": ["onions"],
+            "favorite_ingredients": ["garlic"]
+        }
+        update = UserUpdate(**update_data)
+        assert update.name == "Updated Name"
+        assert update.dietary_profile == ["vegan"]
+        assert update.allergies == ["nuts"]
+        assert update.disliked_ingredients == ["onions"]
+        assert update.favorite_ingredients == ["garlic"]
+
+    def test_user_update_name_validation_strips_whitespace(self):
+        """Test that name validator strips whitespace in updates."""
+        from src.schemas.auth import UserUpdate
+
+        update_data = {"name": "  Updated Name  "}
+        update = UserUpdate(**update_data)
+        assert update.name == "Updated Name"
+
+    def test_user_update_name_validation_rejects_empty(self):
+        """Test that empty name is rejected in updates."""
+        from src.schemas.auth import UserUpdate
+
+        update_data = {"name": "   "}
+        with pytest.raises(ValueError, match="Name cannot be empty"):
+            UserUpdate(**update_data)
+
+    def test_user_update_dietary_profile_validation(self):
+        """Test dietary profile validation in updates."""
+        from src.schemas.auth import UserUpdate
+
+        # Valid profiles
+        update_data = {"dietary_profile": ["keto", "low_carb"]}
+        update = UserUpdate(**update_data)
+        assert update.dietary_profile == ["keto", "low_carb"]
+
+        # Invalid profile
+        update_data = {"dietary_profile": ["invalid-diet"]}
+        with pytest.raises(ValueError, match="Invalid dietary profile: invalid-diet"):
+            UserUpdate(**update_data)
+
+    def test_user_update_dietary_profile_whitespace_handling(self):
+        """Test that dietary profile handles whitespace in updates."""
+        from src.schemas.auth import UserUpdate
+
+        update_data = {"dietary_profile": ["  vegan  ", "", "vegetarian"]}
+        update = UserUpdate(**update_data)
+        assert update.dietary_profile == ["vegan", "vegetarian"]
+
+    def test_user_update_ingredient_lists_validation(self):
+        """Test that ingredient lists are validated in updates."""
+        from src.schemas.auth import UserUpdate
+
+        update_data = {
+            "allergies": ["soy", "wheat"],
+            "disliked_ingredients": ["cilantro"],
+            "favorite_ingredients": ["cheese", "bacon"]
+        }
+        update = UserUpdate(**update_data)
+        assert update.allergies == ["soy", "wheat"]
+        assert update.disliked_ingredients == ["cilantro"]
+        assert update.favorite_ingredients == ["cheese", "bacon"]
+
+    def test_user_update_ingredient_lists_whitespace_handling(self):
+        """Test ingredient lists whitespace handling in updates."""
+        from src.schemas.auth import UserUpdate
+
+        update_data = {"allergies": ["  soy  ", "", "  wheat  "]}
+        update = UserUpdate(**update_data)
+        assert update.allergies == ["soy", "wheat"]
+
+    def test_user_update_protected_fields_rejected_email(self):
+        """Test that protected field 'email' cannot be updated."""
+        from src.schemas.auth import UserUpdate
+
+        update_data = {"email": "newemail@example.com"}
+        with pytest.raises(ValueError, match="Cannot modify protected fields: email"):
+            UserUpdate(**update_data)
+
+    def test_user_update_protected_fields_rejected_role(self):
+        """Test that protected field 'role' cannot be updated."""
+        from src.schemas.auth import UserUpdate
+
+        update_data = {"role": "coordinator"}
+        with pytest.raises(ValueError, match="Cannot modify protected fields: role"):
+            UserUpdate(**update_data)
+
+    def test_user_update_protected_fields_rejected_both(self):
+        """Test that both protected fields are rejected together."""
+        from src.schemas.auth import UserUpdate
+
+        update_data = {"email": "newemail@example.com", "role": "coordinator"}
+        with pytest.raises(ValueError, match="Cannot modify protected fields"):
+            UserUpdate(**update_data)
+
+    def test_user_update_unknown_fields_ignored(self):
+        """Test that unknown fields are silently ignored due to extra='ignore'."""
+        from src.schemas.auth import UserUpdate
+
+        update_data = {
+            "name": "Updated Name",
+            "unknown_field": "should be ignored",
+            "another_unknown": 123
+        }
+        update = UserUpdate(**update_data)
+        assert update.name == "Updated Name"
+        # Unknown fields should be ignored, not raise an error
+
+    def test_user_update_empty_update(self):
+        """Test that empty update (no fields) is valid."""
+        from src.schemas.auth import UserUpdate
+
+        update_data = {}
+        update = UserUpdate(**update_data)
+        assert update.name is None
+        assert update.dietary_profile is None
+
+    def test_user_update_partial_updates_preserve_none(self):
+        """Test that unset fields remain None in partial updates."""
+        from src.schemas.auth import UserUpdate
+
+        update_data = {"name": "Only Name Updated"}
+        update = UserUpdate(**update_data)
+        assert update.name == "Only Name Updated"
+        assert update.dietary_profile is None
+        assert update.allergies is None
+        assert update.disliked_ingredients is None
+        assert update.favorite_ingredients is None


### PR DESCRIPTION
## Work in Progress

Closes #86

Consolidate duplicate validator logic

<!-- sharkrite-source-issue:75 -->## From PR #84 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
This is a valid DRY principle violation, but refactoring to a mixin/shared validators is architectural work that exceeds the scope of creating the initial schemas. The current implementation is correct and functional.

## Context
The original issue scope is to create Pydantic schemas with validation. The validators work correctly; this is a maintainability improvement rather than a correctness issue.

## Defer Reason
Architectural refactor needed - extracting to mixin requires design decision on inheritance pattern

---
_Created by Sharkrite assessment on 2026-03-19T05:40:03Z_
_Parent PR: #84_

---

## Additional Assessment (PR #84)

**Severity:** MEDIUM
**Reasoning:** This was previously classified as ACTIONABLE_LATER. While src/schemas/inventory.py has changed since the prior classification, the changes (per commit abcd798 "fix: address review findings") do not indicate the duplication was addressed - it remains a valid DRY concern for future refactoring.
**Context:** The current implementation is correct and functional. Extracting shared validators is architectural work exceeding initial schema creation scope.
**Defer Reason:** Architectural refactor needed

_Added by Sharkrite on 2026-03-19T05:41:40Z_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**6** files, **2** commits (+0 added, ~6 modified, -0 deleted)
- `M` src/routers/inventory.py
- `M` src/schemas/auth.py
- `M` src/schemas/inventory.py
- `M` src/schemas/substitution.py
- `M` src/schemas/validators.py
- `M` tests/routers/test_inventory.py

### Commits
- b954d59 wip: auto-commit relevant changes for issue #86 (2026-03-19)
- 055dffc chore: initialize work on #86 Consolidate duplicate validator logic
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues
 Updated: #112 
**From assessment on 2026-03-19T21:27:41Z:**
- Created: #122 
- Updated: #112 