### PR TITLE
Add distributed rate limiter for multi-instance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,13 @@ TRUST_X_FORWARDED_FOR=false
 # Empty = trust NO proxies (fail-secure default - X-Forwarded-For will be ignored)
 # You MUST explicitly list your proxy IPs to enable X-Forwarded-For trust
 TRUSTED_PROXIES=
+
+# Redis Configuration (for distributed rate limiting)
+# Optional: If not set, rate limiter falls back to in-memory storage
+# Format: redis://host:port/db or redis://host:port (defaults to db 0)
+# Examples:
+#   Local Redis: REDIS_URL=redis://localhost:6379/0
+#   Redis with auth: REDIS_URL=redis://:password@localhost:6379/0
+#   Redis Cloud: REDIS_URL=redis://user:password@redis-host.cloud:6379/0
+# Empty = in-memory rate limiting (single-instance only)
+REDIS_URL=

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,6 @@ passlib[bcrypt]==1.7.4
 # bcrypt pinned to 4.2.1 for passlib 1.7.4 compatibility (passlib has known issues with bcrypt 5.x)
 bcrypt==4.2.1
 slowapi==0.1.9
+redis==5.2.1
 pytest==8.3.4
 httpx==0.28.1

--- a/src/config.py
+++ b/src/config.py
@@ -29,6 +29,11 @@ class Settings(BaseSettings):
     # Empty string = trust NO proxies (fail-secure default, X-Forwarded-For will be ignored)
     trusted_proxies: str = ""
 
+    # Redis Configuration (for distributed rate limiting)
+    # Optional: If not set, rate limiter falls back to in-memory storage
+    # Format: redis://host:port/db or redis://host:port (defaults to db 0)
+    redis_url: str = ""
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/src/middleware/rate_limit.py
+++ b/src/middleware/rate_limit.py
@@ -96,6 +96,7 @@ def _create_limiter() -> Limiter:
 
             # Test Redis connection
             redis_client.ping()
+            # Close test connection - Limiter will create its own connection pool
             redis_client.close()
 
             logger.info(

--- a/src/middleware/rate_limit.py
+++ b/src/middleware/rate_limit.py
@@ -3,12 +3,25 @@ Rate limiting middleware for FreshUp API endpoints.
 
 Uses slowapi (FastAPI-compatible rate limiting library) to protect
 security-sensitive endpoints from abuse and brute force attacks.
+
+Supports distributed rate limiting via Redis for multi-instance deployments.
+Falls back to in-memory storage if Redis is not configured.
 """
+
+import logging
+from typing import Optional
+from urllib.parse import urlparse
 
 from fastapi import Request
 from slowapi import Limiter
 
+from src.config import get_settings
 from src.services.audit_service import _extract_client_ip
+
+logger = logging.getLogger(__name__)
+
+# Global limiter instance - initialized once at module load
+limiter: Optional[Limiter] = None
 
 
 def get_client_ip_for_rate_limit(request: Request) -> str:
@@ -40,9 +53,94 @@ def get_client_ip_for_rate_limit(request: Request) -> str:
     return ip if ip else "unknown"
 
 
-# Rate limiter instance configured with proxy-aware IP-based key function
-# Uses in-memory storage suitable for single-instance deployment
-limiter = Limiter(key_func=get_client_ip_for_rate_limit)
+def _sanitize_redis_url(redis_url: str) -> str:
+    """
+    Sanitize Redis URL for logging by removing password.
+
+    Args:
+        redis_url: Full Redis URL potentially containing password
+
+    Returns:
+        str: Sanitized URL safe for logging
+    """
+    parsed = urlparse(redis_url)
+    if parsed.port:
+        return f"{parsed.scheme}://{parsed.hostname}:{parsed.port}{parsed.path}"
+    return f"{parsed.scheme}://{parsed.hostname}{parsed.path}"
+
+
+def _create_limiter() -> Limiter:
+    """
+    Create and configure the rate limiter instance.
+
+    Attempts to use Redis for distributed rate limiting if redis_url is configured.
+    Falls back to in-memory storage if Redis is not configured or connection fails.
+
+    Returns:
+        Limiter: Configured slowapi Limiter instance with Redis or in-memory storage
+    """
+    settings = get_settings()
+
+    # Attempt Redis-backed distributed rate limiting
+    if settings.redis_url:
+        try:
+            import redis
+
+            redis_client = redis.from_url(
+                settings.redis_url,
+                encoding="utf-8",
+                decode_responses=True,
+                socket_connect_timeout=5,
+                socket_timeout=5,
+            )
+
+            # Test Redis connection
+            redis_client.ping()
+            redis_client.close()
+
+            logger.info(
+                "Rate limiter initialized with Redis backend (distributed mode): %s",
+                _sanitize_redis_url(settings.redis_url)
+            )
+
+            return Limiter(
+                key_func=get_client_ip_for_rate_limit,
+                storage_uri=settings.redis_url,
+            )
+
+        except ImportError:
+            logger.warning(
+                "Redis library not installed. Rate limiter falling back to in-memory storage. "
+                "Install redis package for distributed rate limiting: pip install redis"
+            )
+        except redis.exceptions.ConnectionError as e:
+            logger.warning(
+                "Failed to connect to Redis at %s: %s. "
+                "Rate limiter falling back to in-memory storage. "
+                "This is acceptable for single-instance deployments but will not work correctly "
+                "for multi-instance deployments.",
+                _sanitize_redis_url(settings.redis_url),
+                str(e)
+            )
+        except redis.exceptions.RedisError as e:
+            logger.warning(
+                "Redis error during rate limiter initialization: %s. "
+                "Rate limiter falling back to in-memory storage.",
+                str(e)
+            )
+        except Exception as e:
+            logger.error(
+                "Unexpected error initializing Redis rate limiter: %s. "
+                "Rate limiter falling back to in-memory storage.",
+                str(e)
+            )
+
+    # Fall back to in-memory storage
+    logger.info(
+        "Rate limiter initialized with in-memory storage (single-instance mode). "
+        "For multi-instance deployments, configure REDIS_URL in environment."
+    )
+    return Limiter(key_func=get_client_ip_for_rate_limit)
 
 
 def get_limiter() -> Limiter:
@@ -52,4 +150,7 @@ def get_limiter() -> Limiter:
     Returns:
         Limiter: Configured slowapi Limiter instance
     """
+    global limiter
+    if limiter is None:
+        limiter = _create_limiter()
     return limiter

--- a/tests/middleware/test_rate_limit.py
+++ b/tests/middleware/test_rate_limit.py
@@ -10,7 +10,7 @@ import pytest
 from unittest.mock import Mock
 from fastapi import Request
 
-from src.middleware.rate_limit import get_client_ip_for_rate_limit, limiter
+from src.middleware.rate_limit import get_client_ip_for_rate_limit, get_limiter
 
 
 class TestGetClientIpForRateLimit:
@@ -221,4 +221,4 @@ class TestLimiterConfiguration:
         This ensures that the rate limiter will respect the X-Forwarded-For
         configuration for all rate-limited endpoints.
         """
-        assert limiter._key_func == get_client_ip_for_rate_limit
+        assert get_limiter()._key_func == get_client_ip_for_rate_limit


### PR DESCRIPTION
## Work in Progress

Closes #95

Add distributed rate limiter for multi-instance

<!-- sharkrite-source-issue:51 -->## From PR #93 Assessment

**Severity:** HIGH
**Category:** Security

## Issue
This is a valid security concern about distributed deployments, but the current codebase shows no evidence of multi-instance deployment configuration. The implementation correctly adds rate limiting as specified in the issue scope.

## Context
The original issue scope is "Missing rate limiting on switch-user endpoint" - not "implement production-grade distributed rate limiting infrastructure." Redis integration requires new dependencies and architectural decisions about deployment topology.

## Defer Reason
Architectural refactor needed - requires adding Redis dependency and deployment architecture decisions

---
_Created by Sharkrite assessment on 2026-03-19T06:17:05Z_
_Parent PR: #93_

---

## Additional Assessment (PR #93)

**Severity:** HIGH
**Reasoning:** This is functionally identical to the prior assessment finding "In-memory rate limiter will not work in multi-instance deployments" which was classified as ACTIONABLE_LATER. The changes to src/main.py and tests/routers/test_auth.py do not address the storage backend concern - they are unrelated modifications.
**Context:** The original issue scope is "Missing rate limiting on switch-user endpoint" which has been implemented. Redis/shared storage infrastructure is a deployment architecture concern outside the scope of adding rate limiting to a single endpoint.
**Defer Reason:** Architectural refactor needed - rate limiting storage backend should be addressed based on deployment architecture audit

_Added by Sharkrite on 2026-03-19T06:19:53Z_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**14** files, **2** commits (+0 added, ~13 modified, -1 deleted)
- `M` .env.example
- `M` .gitignore
- `M` requirements.txt
- `M` src/config.py
- `M` src/middleware/rate_limit.py
- `M` src/routers/auth.py
- `M` src/routers/inventory.py
- `M` src/routers/substitutions.py
- `M` src/schemas/auth.py
- `M` src/schemas/inventory.py
- `M` src/schemas/substitution.py
- `M` src/schemas/validators.py
- `M` tests/routers/test_auth.py
- `D` tests/schemas/test_validators.py

### Commits
- 40fc7d0 wip: auto-commit relevant changes for issue #95 (2026-03-19)
- 80292ed chore: initialize work on #95 Add distributed rate limiter for multi-instance
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues
 Updated: #122 
**From assessment on 2026-03-19T22:38:33Z:**
- Created: #131 
- Updated: none