### PR TITLE
Add X-Forwarded-For header handling for proxies

### DIFF
--- a/src/middleware/rate_limit.py
+++ b/src/middleware/rate_limit.py
@@ -5,13 +5,40 @@ Uses slowapi (FastAPI-compatible rate limiting library) to protect
 security-sensitive endpoints from abuse and brute force attacks.
 """
 
+from typing import Optional
+from fastapi import Request
 from slowapi import Limiter
-from slowapi.util import get_remote_address
+
+from src.services.audit_service import _extract_client_ip
 
 
-# Rate limiter instance configured with IP-based key function
+def get_client_ip_for_rate_limit(request: Request) -> Optional[str]:
+    """
+    Extract client IP address for rate limiting with proxy trust enforcement.
+
+    This is a wrapper around _extract_client_ip() from audit_service, providing
+    a compatible key function for slowapi's Limiter. It implements secure
+    X-Forwarded-For header handling:
+
+    - By default, X-Forwarded-For headers are NOT trusted (secure by default)
+    - Headers are only used when TRUST_X_FORWARDED_FOR=true AND the request
+      comes from a trusted proxy IP (configured via TRUSTED_PROXIES)
+    - When trust conditions are not met, falls back to direct connection IP
+
+    This prevents rate limiting bypass via proxy header spoofing.
+
+    Args:
+        request: FastAPI request object
+
+    Returns:
+        Client IP address as string, or None if unavailable
+    """
+    return _extract_client_ip(request)
+
+
+# Rate limiter instance configured with proxy-aware IP-based key function
 # Uses in-memory storage suitable for single-instance deployment
-limiter = Limiter(key_func=get_remote_address)
+limiter = Limiter(key_func=get_client_ip_for_rate_limit)
 
 
 def get_limiter() -> Limiter:

--- a/src/middleware/rate_limit.py
+++ b/src/middleware/rate_limit.py
@@ -5,14 +5,13 @@ Uses slowapi (FastAPI-compatible rate limiting library) to protect
 security-sensitive endpoints from abuse and brute force attacks.
 """
 
-from typing import Optional
 from fastapi import Request
 from slowapi import Limiter
 
 from src.services.audit_service import _extract_client_ip
 
 
-def get_client_ip_for_rate_limit(request: Request) -> Optional[str]:
+def get_client_ip_for_rate_limit(request: Request) -> str:
     """
     Extract client IP address for rate limiting with proxy trust enforcement.
 
@@ -24,16 +23,21 @@ def get_client_ip_for_rate_limit(request: Request) -> Optional[str]:
     - Headers are only used when TRUST_X_FORWARDED_FOR=true AND the request
       comes from a trusted proxy IP (configured via TRUSTED_PROXIES)
     - When trust conditions are not met, falls back to direct connection IP
+    - If no IP can be determined (malformed requests), returns "unknown" to
+      group such requests together for rate limiting (prevents bypass)
 
-    This prevents rate limiting bypass via proxy header spoofing.
+    This prevents rate limiting bypass via proxy header spoofing or missing client info.
 
     Args:
         request: FastAPI request object
 
     Returns:
-        Client IP address as string, or None if unavailable
+        Client IP address as string, or "unknown" if unavailable
     """
-    return _extract_client_ip(request)
+    ip = _extract_client_ip(request)
+    # Never return None - use fallback to prevent rate limiting bypass
+    # Grouping unknown IPs together is better than not rate limiting them
+    return ip if ip else "unknown"
 
 
 # Rate limiter instance configured with proxy-aware IP-based key function

--- a/tests/middleware/test_rate_limit.py
+++ b/tests/middleware/test_rate_limit.py
@@ -1,0 +1,224 @@
+"""
+Tests for rate limiting middleware with X-Forwarded-For support.
+
+These tests verify that the rate limiter correctly handles proxy headers
+to prevent rate limit bypass via header spoofing while supporting legitimate
+proxy deployments.
+"""
+
+import pytest
+from unittest.mock import Mock
+from fastapi import Request
+
+from src.middleware.rate_limit import get_client_ip_for_rate_limit, limiter
+
+
+class TestGetClientIpForRateLimit:
+    """
+    Tests for get_client_ip_for_rate_limit() function.
+
+    This function is the key function that slowapi uses to determine the client IP
+    for rate limiting. It must correctly handle X-Forwarded-For headers based on
+    the trust configuration to prevent bypass attacks.
+    """
+
+    def test_returns_direct_ip_when_no_forwarded_for_header(self, monkeypatch):
+        """
+        Test that direct connection IP is returned when no X-Forwarded-For header present.
+
+        This is the most common case - direct client connections without a proxy.
+        """
+        # Mock settings: trust enabled (shouldn't matter since no header)
+        mock_settings = Mock()
+        mock_settings.trust_x_forwarded_for = True
+        mock_settings.trusted_proxies = "10.0.0.1"
+        monkeypatch.setattr("src.services.audit_service.get_settings", lambda: mock_settings)
+
+        # Create request without X-Forwarded-For header
+        request = Mock(spec=Request)
+        request.client = Mock()
+        request.client.host = "203.0.113.45"
+        request.headers = {}
+
+        ip = get_client_ip_for_rate_limit(request)
+        assert ip == "203.0.113.45"
+
+    def test_ignores_forwarded_for_when_trust_disabled(self, monkeypatch):
+        """
+        Test that X-Forwarded-For is IGNORED when TRUST_X_FORWARDED_FOR=false.
+
+        This is the secure default behavior - protects against header spoofing.
+        Attackers cannot bypass rate limiting by adding X-Forwarded-For headers.
+        """
+        # Mock settings: trust DISABLED
+        mock_settings = Mock()
+        mock_settings.trust_x_forwarded_for = False
+        mock_settings.trusted_proxies = "10.0.0.1"
+        monkeypatch.setattr("src.services.audit_service.get_settings", lambda: mock_settings)
+
+        # Create request with X-Forwarded-For header
+        request = Mock(spec=Request)
+        request.client = Mock()
+        request.client.host = "203.0.113.45"
+        request.headers = {"X-Forwarded-For": "192.0.2.100"}
+
+        ip = get_client_ip_for_rate_limit(request)
+        # Should return direct IP, NOT the forwarded IP
+        assert ip == "203.0.113.45"
+
+    def test_ignores_forwarded_for_from_untrusted_proxy(self, monkeypatch):
+        """
+        Test that X-Forwarded-For is IGNORED when request comes from untrusted proxy.
+
+        Even when TRUST_X_FORWARDED_FOR=true, only requests from explicitly
+        trusted proxy IPs should have their headers honored. This prevents
+        attackers from spoofing the header.
+        """
+        # Mock settings: trust enabled but only for 10.0.0.1
+        mock_settings = Mock()
+        mock_settings.trust_x_forwarded_for = True
+        mock_settings.trusted_proxies = "10.0.0.1"
+        monkeypatch.setattr("src.services.audit_service.get_settings", lambda: mock_settings)
+
+        # Create request from UNTRUSTED proxy (10.0.0.99 not in trusted list)
+        request = Mock(spec=Request)
+        request.client = Mock()
+        request.client.host = "10.0.0.99"  # Untrusted proxy
+        request.headers = {"X-Forwarded-For": "192.0.2.100"}
+
+        ip = get_client_ip_for_rate_limit(request)
+        # Should return proxy IP, NOT the forwarded IP
+        assert ip == "10.0.0.99"
+
+    def test_uses_forwarded_for_from_trusted_proxy(self, monkeypatch):
+        """
+        Test that X-Forwarded-For IS USED when trust enabled and proxy is trusted.
+
+        This is the legitimate proxy use case - when behind a trusted reverse
+        proxy (nginx, AWS ALB, etc.), we want the real client IP for rate limiting.
+        """
+        # Mock settings: trust enabled and proxy is trusted
+        mock_settings = Mock()
+        mock_settings.trust_x_forwarded_for = True
+        mock_settings.trusted_proxies = "10.0.0.1"
+        monkeypatch.setattr("src.services.audit_service.get_settings", lambda: mock_settings)
+
+        # Create request from TRUSTED proxy
+        request = Mock(spec=Request)
+        request.client = Mock()
+        request.client.host = "10.0.0.1"  # Trusted proxy
+        request.headers = {"X-Forwarded-For": "192.0.2.100"}
+
+        ip = get_client_ip_for_rate_limit(request)
+        # Should return the forwarded IP (real client)
+        assert ip == "192.0.2.100"
+
+    def test_uses_forwarded_for_with_cidr_trusted_proxy(self, monkeypatch):
+        """
+        Test X-Forwarded-For with CIDR range in trusted proxy list.
+
+        Supports configuring trusted proxies as network ranges (e.g., AWS VPC
+        subnet) rather than individual IPs.
+        """
+        # Mock settings: trust enabled with CIDR range
+        mock_settings = Mock()
+        mock_settings.trust_x_forwarded_for = True
+        mock_settings.trusted_proxies = "10.0.0.0/24"
+        monkeypatch.setattr("src.services.audit_service.get_settings", lambda: mock_settings)
+
+        # Create request from proxy in trusted CIDR range
+        request = Mock(spec=Request)
+        request.client = Mock()
+        request.client.host = "10.0.0.50"  # In 10.0.0.0/24 range
+        request.headers = {"X-Forwarded-For": "192.0.2.100"}
+
+        ip = get_client_ip_for_rate_limit(request)
+        assert ip == "192.0.2.100"
+
+    def test_uses_first_ip_from_multi_proxy_chain(self, monkeypatch):
+        """
+        Test that first IP is used when X-Forwarded-For contains multiple IPs.
+
+        When requests pass through multiple proxies, X-Forwarded-For becomes
+        a comma-separated list: "client, proxy1, proxy2". The first IP is the
+        original client, which is what we want for rate limiting.
+        """
+        # Mock settings: trust enabled and proxy is trusted
+        mock_settings = Mock()
+        mock_settings.trust_x_forwarded_for = True
+        mock_settings.trusted_proxies = "10.0.0.1"
+        monkeypatch.setattr("src.services.audit_service.get_settings", lambda: mock_settings)
+
+        # Create request with multi-proxy X-Forwarded-For
+        request = Mock(spec=Request)
+        request.client = Mock()
+        request.client.host = "10.0.0.1"  # Trusted proxy
+        request.headers = {"X-Forwarded-For": "192.0.2.100, 198.51.100.5, 203.0.113.10"}
+
+        ip = get_client_ip_for_rate_limit(request)
+        # Should return the first (original client) IP
+        assert ip == "192.0.2.100"
+
+    def test_returns_unknown_when_no_client_info(self, monkeypatch):
+        """
+        Test that "unknown" is returned when request has no client information.
+
+        This prevents rate limiting bypass - requests with missing client info
+        are grouped together as "unknown" and rate limited collectively rather
+        than being allowed through without rate limiting.
+        """
+        # Mock settings
+        mock_settings = Mock()
+        mock_settings.trust_x_forwarded_for = False
+        mock_settings.trusted_proxies = ""
+        monkeypatch.setattr("src.services.audit_service.get_settings", lambda: mock_settings)
+
+        # Create request without client info
+        request = Mock(spec=Request)
+        request.client = None
+        request.headers = {}
+
+        ip = get_client_ip_for_rate_limit(request)
+        assert ip == "unknown"
+
+    def test_handles_empty_trusted_proxies_list(self, monkeypatch):
+        """
+        Test that empty TRUSTED_PROXIES means trust NO proxies (fail-secure).
+
+        Even with TRUST_X_FORWARDED_FOR=true, an empty trusted proxy list
+        should result in X-Forwarded-For being ignored. This is the fail-secure
+        default configuration.
+        """
+        # Mock settings: trust enabled but NO trusted proxies
+        mock_settings = Mock()
+        mock_settings.trust_x_forwarded_for = True
+        mock_settings.trusted_proxies = ""  # Empty list
+        monkeypatch.setattr("src.services.audit_service.get_settings", lambda: mock_settings)
+
+        # Create request with X-Forwarded-For
+        request = Mock(spec=Request)
+        request.client = Mock()
+        request.client.host = "10.0.0.1"
+        request.headers = {"X-Forwarded-For": "192.0.2.100"}
+
+        ip = get_client_ip_for_rate_limit(request)
+        # Should return direct IP (empty trusted list means trust NO proxies)
+        assert ip == "10.0.0.1"
+
+
+class TestLimiterConfiguration:
+    """
+    Tests for limiter configuration.
+
+    Verifies that the limiter is properly configured to use the custom
+    key function for IP extraction.
+    """
+
+    def test_limiter_uses_custom_key_function(self):
+        """
+        Test that limiter is configured with get_client_ip_for_rate_limit.
+
+        This ensures that the rate limiter will respect the X-Forwarded-For
+        configuration for all rate-limited endpoints.
+        """
+        assert limiter._key_func == get_client_ip_for_rate_limit


### PR DESCRIPTION
## Work in Progress

Closes #96

Add X-Forwarded-For header handling for proxies

<!-- sharkrite-source-issue:51 -->## From PR #93 Assessment

**Severity:** MEDIUM
**Category:** Security

## Issue
This is functionally identical to the prior assessment finding "Rate limiting by IP address can be bypassed via proxy headers" which was classified as ACTIONABLE_LATER. The changes to src/main.py and tests/routers/test_auth.py do not implement proxy header handling - they are unrelated modifications.

## Context
Proxy configuration depends on deployment infrastructure which requires architectural knowledge outside the scope of implementing rate limiting on a single endpoint. The default `get_remote_address` is the standard approach.

## Defer Reason
Needs separate focused PR - requires deployment architecture audit to implement correctly

---
_Created by Sharkrite assessment on 2026-03-19T06:19:53Z_
_Parent PR: #93_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**18** files, **2** commits (+0 added, ~12 modified, -6 deleted)
- `D` .github/PULL_REQUEST_TEMPLATE.md
- `D` .github/claude-code/pr-review-instructions.md
- `D` .github/workflows/ci.yml
- `D` .github/workflows/claude.yml
- `D` .github/workflows/pr-merged-notification.yml
- `M` .gitignore
- `M` src/middleware/rate_limit.py
- `M` src/routers/auth.py
- `M` src/routers/inventory.py
- `M` src/routers/substitutions.py
- `M` src/schemas/auth.py
- `M` src/schemas/inventory.py
- `M` src/schemas/substitution.py
- `M` src/schemas/validators.py
- `M` tests/routers/test_auth.py
- `M` tests/routers/test_inventory.py
- `M` tests/schemas/test_auth.py
- `D` tests/schemas/test_validators.py

### Commits
- e43e96f wip: auto-commit relevant changes for issue #96 (2026-03-19)
- 3ae7447 chore: initialize work on #96 Add X-Forwarded-For header handling for proxies
<!-- /sharkrite-changes-summary -->