### PR TITLE
[Phase 1E] Implement recipe CRUD endpoints

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -8,7 +8,7 @@ from slowapi.errors import RateLimitExceeded
 
 from src.config import get_settings
 from src.db.database import Base, init_engine, get_engine, get_session_factory
-from src.routers import auth_router, users_router, substitutions_router, inventory_router
+from src.routers import auth_router, users_router, substitutions_router, inventory_router, recipes_router
 from src.middleware.rate_limit import limiter
 
 settings = get_settings()
@@ -75,6 +75,7 @@ app.include_router(auth_router)
 app.include_router(users_router)
 app.include_router(substitutions_router)
 app.include_router(inventory_router)
+app.include_router(recipes_router)
 
 
 @app.get("/health")

--- a/src/routers/__init__.py
+++ b/src/routers/__init__.py
@@ -10,5 +10,6 @@ from src.routers.auth import router as auth_router
 from src.routers.users import router as users_router
 from src.routers.substitutions import router as substitutions_router
 from src.routers.inventory import router as inventory_router
+from src.routers.recipes import router as recipes_router
 
-__all__ = ["auth_router", "users_router", "substitutions_router", "inventory_router"]
+__all__ = ["auth_router", "users_router", "substitutions_router", "inventory_router", "recipes_router"]

--- a/src/routers/recipes.py
+++ b/src/routers/recipes.py
@@ -1,0 +1,340 @@
+"""
+Recipe CRUD endpoints for FreshUp.
+
+Provides endpoints for managing recipes with nested ingredients.
+Recipes are globally visible (all users can read) but only the creator
+can update/delete their own recipes. System recipes (created_by=NULL)
+cannot be edited or deleted by any user.
+
+Logging Policy:
+    Recipe names are NOT logged as they may contain sensitive health
+    information (dietary restrictions, allergens). Logs include operational
+    metadata (user_id, recipe_id, timestamps) for debugging while protecting
+    user privacy per OWASP recommendations.
+"""
+
+import logging
+from uuid import UUID
+from typing import Optional
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError, IntegrityError
+
+from src.db.database import get_db
+from src.db.models.user import User
+from src.db.models.recipe import Recipe
+from src.db.models.recipe_ingredient import RecipeIngredient
+from src.schemas.recipe import (
+    RecipeCreate,
+    RecipeUpdate,
+    RecipeResponse,
+    RecipeListResponse,
+)
+from src.middleware.auth import get_current_user
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/recipes", tags=["recipes"])
+
+
+@router.post("", response_model=RecipeResponse, status_code=status.HTTP_201_CREATED)
+def create_recipe(
+    recipe_data: RecipeCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Create a new recipe with nested ingredients.
+
+    The created_by field is automatically set to the current user's ID,
+    ensuring proper ownership tracking.
+
+    Args:
+        recipe_data: Recipe data including name, source_type, and ingredients
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        RecipeResponse: Created recipe with nested ingredients
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(400): If data integrity violation occurs
+        HTTPException(422): If validation fails (invalid source_type, etc.)
+    """
+    # Create recipe with created_by set to current user
+    recipe_dict = recipe_data.model_dump(exclude={'ingredients'})
+    new_recipe = Recipe(
+        **recipe_dict,
+        created_by=current_user.id,
+    )
+
+    db.add(new_recipe)
+
+    try:
+        # Flush to get recipe ID for ingredients
+        db.flush()
+
+        # Create nested ingredients
+        for ingredient_data in recipe_data.ingredients:
+            ingredient = RecipeIngredient(
+                recipe_id=new_recipe.id,
+                **ingredient_data.model_dump()
+            )
+            db.add(ingredient)
+
+        # Commit atomically
+        db.commit()
+        db.refresh(new_recipe)
+
+    except IntegrityError as e:
+        db.rollback()
+        logger.error(f"Integrity error during recipe creation for user {current_user.id}")
+        logger.debug(f"Integrity error occurred during recipe creation: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Recipe creation failed due to data integrity violation"
+        )
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during recipe creation for user {current_user.id}")
+        logger.debug(f"Database error occurred during recipe creation: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while creating the recipe"
+        )
+
+    logger.info(
+        f"Recipe created: user_id={current_user.id}, "
+        f"recipe_id={new_recipe.id}, ingredient_count={len(recipe_data.ingredients)}"
+    )
+
+    return new_recipe
+
+
+@router.get("", response_model=list[RecipeListResponse])
+def list_recipes(
+    db: Session = Depends(get_db),
+    limit: int = Query(default=100, ge=1, le=100, description="Maximum number of recipes to return"),
+    offset: int = Query(default=0, ge=0, description="Number of recipes to skip"),
+):
+    """
+    List all recipes with pagination (global read access).
+
+    Returns all recipes in the system, ordered by most recently created first.
+    This endpoint does not require authentication - recipes are globally visible.
+
+    Args:
+        db: Database session
+        limit: Maximum number of recipes to return (1-100, default 100)
+        offset: Number of recipes to skip (default 0)
+
+    Returns:
+        list[RecipeListResponse]: List of recipes without ingredient details
+    """
+    recipes = (
+        db.query(Recipe)
+        .order_by(Recipe.id.desc())
+        .limit(limit)
+        .offset(offset)
+        .all()
+    )
+
+    return recipes
+
+
+@router.get("/{recipe_id}", response_model=RecipeResponse)
+def get_recipe(
+    recipe_id: UUID,
+    db: Session = Depends(get_db),
+):
+    """
+    Get a single recipe by ID with nested ingredients (global read access).
+
+    Retrieves a specific recipe with all ingredients. This endpoint does not
+    require authentication - recipes are globally visible.
+
+    Args:
+        recipe_id: UUID of the recipe to retrieve
+        db: Database session
+
+    Returns:
+        RecipeResponse: Requested recipe with nested ingredients
+
+    Raises:
+        HTTPException(404): If recipe doesn't exist
+    """
+    recipe = db.query(Recipe).filter(Recipe.id == recipe_id).first()
+
+    if not recipe:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Recipe not found"
+        )
+
+    return recipe
+
+
+@router.put("/{recipe_id}", response_model=RecipeResponse)
+def update_recipe(
+    recipe_id: UUID,
+    update_data: RecipeUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Update a recipe with partial data (ownership required).
+
+    Allows partial updates - only provided fields will be updated. Returns 404
+    if the recipe doesn't exist, belongs to a different user, or is a system
+    recipe (created_by=NULL). This prevents enumeration attacks and protects
+    system recipes from modification.
+
+    Note: This endpoint does NOT support updating ingredients. Ingredient
+    updates will be handled by a separate endpoint in a future iteration.
+
+    Args:
+        recipe_id: UUID of the recipe to update
+        update_data: Fields to update (all optional)
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        RecipeResponse: Updated recipe with ingredients
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If recipe doesn't exist, belongs to another user, or is a system recipe
+        HTTPException(422): If validation fails (invalid source_type, etc.)
+    """
+    # Query recipe with ownership check
+    recipe = db.query(Recipe).filter(Recipe.id == recipe_id).first()
+
+    # Return 404 if recipe doesn't exist (prevents enumeration)
+    if not recipe:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Recipe not found"
+        )
+
+    # Return 404 if recipe is a system recipe (created_by is NULL)
+    if recipe.created_by is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Recipe not found"
+        )
+
+    # Return 404 if recipe belongs to another user (prevents enumeration)
+    if recipe.created_by != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Recipe not found"
+        )
+
+    # Update only the fields that were provided
+    update_dict = update_data.model_dump(exclude_unset=True)
+
+    # Apply updates
+    for field, value in update_dict.items():
+        setattr(recipe, field, value)
+
+    try:
+        db.commit()
+        db.refresh(recipe)
+    except IntegrityError as e:
+        db.rollback()
+        logger.error(f"Integrity error during recipe update for user {current_user.id}")
+        logger.debug(f"Integrity error occurred during recipe update: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Recipe update failed due to data integrity violation"
+        )
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during recipe update for user {current_user.id}")
+        logger.debug(f"Database error occurred during recipe update: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while updating the recipe"
+        )
+
+    logger.info(
+        f"Recipe updated: user_id={current_user.id}, "
+        f"recipe_id={recipe_id}"
+    )
+
+    return recipe
+
+
+@router.delete("/{recipe_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_recipe(
+    recipe_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Delete a recipe (ownership required).
+
+    Removes the specified recipe and all associated ingredients (cascading delete).
+    Returns 404 if the recipe doesn't exist, belongs to a different user, or is a
+    system recipe (created_by=NULL). This prevents enumeration attacks and protects
+    system recipes from deletion.
+
+    Args:
+        recipe_id: UUID of the recipe to delete
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        None (204 No Content on success)
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If recipe doesn't exist, belongs to another user, or is a system recipe
+    """
+    # Query recipe with ownership check
+    recipe = db.query(Recipe).filter(Recipe.id == recipe_id).first()
+
+    # Return 404 if recipe doesn't exist (prevents enumeration)
+    if not recipe:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Recipe not found"
+        )
+
+    # Return 404 if recipe is a system recipe (created_by is NULL)
+    if recipe.created_by is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Recipe not found"
+        )
+
+    # Return 404 if recipe belongs to another user (prevents enumeration)
+    if recipe.created_by != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Recipe not found"
+        )
+
+    try:
+        # Manually delete ingredients first (cascade not configured in DB)
+        db.query(RecipeIngredient).filter(RecipeIngredient.recipe_id == recipe_id).delete()
+
+        # Delete the recipe
+        db.delete(recipe)
+        db.commit()
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during recipe deletion for user {current_user.id}")
+        logger.debug(f"Database error occurred during recipe deletion: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while deleting the recipe"
+        )
+
+    logger.info(
+        f"Recipe deleted: user_id={current_user.id}, "
+        f"recipe_id={recipe_id}"
+    )
+
+    return None

--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -7,10 +7,24 @@ from src.schemas.inventory import (
     InventoryItemResponse,
     InventoryItemListResponse,
 )
+from src.schemas.recipe import (
+    RecipeCreate,
+    RecipeUpdate,
+    RecipeResponse,
+    RecipeListResponse,
+    RecipeIngredientCreate,
+    RecipeIngredientResponse,
+)
 
 __all__ = [
     "InventoryItemCreate",
     "InventoryItemUpdate",
     "InventoryItemResponse",
     "InventoryItemListResponse",
+    "RecipeCreate",
+    "RecipeUpdate",
+    "RecipeResponse",
+    "RecipeListResponse",
+    "RecipeIngredientCreate",
+    "RecipeIngredientResponse",
 ]

--- a/src/schemas/recipe.py
+++ b/src/schemas/recipe.py
@@ -1,0 +1,203 @@
+"""
+Pydantic schemas for recipe endpoints.
+
+Defines request/response models for recipe CRUD operations.
+"""
+
+from uuid import UUID
+from typing import Optional
+from pydantic import BaseModel, Field, field_validator, ConfigDict
+
+from src.db.models.recipe import SourceType
+from src.schemas.validators import validate_enum_value, validate_non_negative, validate_ingredient_name
+
+
+class RecipeIngredientCreate(BaseModel):
+    """Request schema for creating a recipe ingredient (nested in recipe creation)."""
+
+    ingredient_name: str = Field(..., min_length=1, max_length=255, description="Ingredient name")
+    quantity: float = Field(..., description="Quantity of ingredient")
+    unit: str = Field(..., max_length=50, description="Unit of measurement")
+    variation_group: Optional[str] = Field(default=None, max_length=100, description="Variation group identifier")
+    variation_diet: Optional[str] = Field(default=None, max_length=50, description="Dietary variation identifier")
+    is_optional: Optional[bool] = Field(default=False, description="Whether ingredient is optional")
+
+    @field_validator('ingredient_name')
+    @classmethod
+    def validate_ingredient_name_field(cls, v: str) -> str:
+        """Validate ingredient name for Unicode safety and allowed characters."""
+        return validate_ingredient_name('Ingredient name', v)
+
+    @field_validator('quantity')
+    @classmethod
+    def validate_quantity_field(cls, v: float) -> float:
+        """Ensure quantity is positive (zero not allowed for ingredients)."""
+        if v <= 0:
+            raise ValueError("Quantity must be greater than 0")
+        return v
+
+
+class RecipeIngredientResponse(BaseModel):
+    """Response schema for recipe ingredient."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    ingredient_name: str
+    quantity: float
+    unit: str
+    variation_group: Optional[str]
+    variation_diet: Optional[str]
+    is_optional: bool
+
+
+class RecipeCreate(BaseModel):
+    """Request schema for creating a new recipe."""
+
+    name: str = Field(..., min_length=1, max_length=255, description="Recipe name")
+    source_type: str = Field(..., description="Source type (e.g., manual, hellofresh_card)")
+    source_url: Optional[str] = Field(default=None, max_length=2048, description="Source URL")
+    source_image: Optional[str] = Field(default=None, max_length=2048, description="Image URL")
+    variation_groups: Optional[dict] = Field(default=None, description="Variation groups metadata")
+    steps: Optional[list] = Field(default_factory=list, description="Recipe steps")
+    prep_time_minutes: Optional[int] = Field(default=None, description="Preparation time in minutes")
+    cook_time_minutes: Optional[int] = Field(default=None, description="Cooking time in minutes")
+    base_servings: Optional[int] = Field(default=4, description="Base number of servings")
+    tags: Optional[list] = Field(default_factory=list, description="Recipe tags")
+    nutritional_info: Optional[dict] = Field(default=None, description="Nutritional information")
+    notes: Optional[str] = Field(default=None, description="Personal notes about the recipe")
+    ingredients: list[RecipeIngredientCreate] = Field(default_factory=list, description="Recipe ingredients")
+
+    @field_validator('name')
+    @classmethod
+    def validate_name_field(cls, v: str) -> str:
+        """Validate recipe name for Unicode safety and allowed characters."""
+        return validate_ingredient_name('Recipe name', v)
+
+    @field_validator('source_type')
+    @classmethod
+    def validate_source_type_field(cls, v: str) -> str:
+        """Ensure source_type is a valid SourceType enum value."""
+        result = validate_enum_value('Source type', v, SourceType, allow_none=False)
+        return result  # type: ignore
+
+    @field_validator('prep_time_minutes')
+    @classmethod
+    def validate_prep_time_field(cls, v: Optional[int]) -> Optional[int]:
+        """Ensure prep time is non-negative if provided."""
+        if v is not None and v < 0:
+            raise ValueError("Prep time cannot be negative")
+        return v
+
+    @field_validator('cook_time_minutes')
+    @classmethod
+    def validate_cook_time_field(cls, v: Optional[int]) -> Optional[int]:
+        """Ensure cook time is non-negative if provided."""
+        if v is not None and v < 0:
+            raise ValueError("Cook time cannot be negative")
+        return v
+
+    @field_validator('base_servings')
+    @classmethod
+    def validate_base_servings_field(cls, v: Optional[int]) -> Optional[int]:
+        """Ensure base servings is positive if provided."""
+        if v is not None and v <= 0:
+            raise ValueError("Base servings must be greater than 0")
+        return v
+
+
+class RecipeUpdate(BaseModel):
+    """Request schema for updating a recipe (partial updates)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    name: Optional[str] = Field(default=None, min_length=1, max_length=255, description="Recipe name")
+    source_type: Optional[str] = Field(default=None, description="Source type")
+    source_url: Optional[str] = Field(default=None, max_length=2048, description="Source URL")
+    source_image: Optional[str] = Field(default=None, max_length=2048, description="Image URL")
+    variation_groups: Optional[dict] = Field(default=None, description="Variation groups metadata")
+    steps: Optional[list] = Field(default=None, description="Recipe steps")
+    prep_time_minutes: Optional[int] = Field(default=None, description="Preparation time in minutes")
+    cook_time_minutes: Optional[int] = Field(default=None, description="Cooking time in minutes")
+    base_servings: Optional[int] = Field(default=None, description="Base number of servings")
+    tags: Optional[list] = Field(default=None, description="Recipe tags")
+    nutritional_info: Optional[dict] = Field(default=None, description="Nutritional information")
+    notes: Optional[str] = Field(default=None, description="Personal notes about the recipe")
+
+    @field_validator('name')
+    @classmethod
+    def validate_name_field(cls, v: Optional[str]) -> Optional[str]:
+        """Validate recipe name for Unicode safety and allowed characters if provided."""
+        if v is not None:
+            return validate_ingredient_name('Recipe name', v)
+        return v
+
+    @field_validator('source_type')
+    @classmethod
+    def validate_source_type_field(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure source_type is a valid SourceType enum value if provided."""
+        return validate_enum_value('Source type', v, SourceType, allow_none=True)
+
+    @field_validator('prep_time_minutes')
+    @classmethod
+    def validate_prep_time_field(cls, v: Optional[int]) -> Optional[int]:
+        """Ensure prep time is non-negative if provided."""
+        if v is not None and v < 0:
+            raise ValueError("Prep time cannot be negative")
+        return v
+
+    @field_validator('cook_time_minutes')
+    @classmethod
+    def validate_cook_time_field(cls, v: Optional[int]) -> Optional[int]:
+        """Ensure cook time is non-negative if provided."""
+        if v is not None and v < 0:
+            raise ValueError("Cook time cannot be negative")
+        return v
+
+    @field_validator('base_servings')
+    @classmethod
+    def validate_base_servings_field(cls, v: Optional[int]) -> Optional[int]:
+        """Ensure base servings is positive if provided."""
+        if v is not None and v <= 0:
+            raise ValueError("Base servings must be greater than 0")
+        return v
+
+
+class RecipeResponse(BaseModel):
+    """Response schema for single recipe with full details and ingredients."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    name: str
+    source_type: str
+    source_url: Optional[str]
+    source_image: Optional[str]
+    variation_groups: Optional[dict]
+    steps: list
+    prep_time_minutes: Optional[int]
+    cook_time_minutes: Optional[int]
+    base_servings: int
+    tags: list
+    nutritional_info: Optional[dict]
+    times_cooked: int
+    created_by: Optional[UUID]
+    notes: Optional[str]
+    ingredients: list[RecipeIngredientResponse]
+
+
+class RecipeListResponse(BaseModel):
+    """Response schema for recipe list (lighter weight without ingredients)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    name: str
+    source_type: str
+    source_image: Optional[str]
+    prep_time_minutes: Optional[int]
+    cook_time_minutes: Optional[int]
+    base_servings: int
+    tags: list
+    times_cooked: int
+    created_by: Optional[UUID]

--- a/tests/routers/test_recipes.py
+++ b/tests/routers/test_recipes.py
@@ -1,0 +1,622 @@
+"""
+Integration tests for recipe endpoints.
+
+Tests cover:
+- POST /recipes: create recipes with nested ingredients
+- GET /recipes: list all recipes with pagination (global read)
+- GET /recipes/{id}: get single recipe with ingredients (global read)
+- PUT /recipes/{id}: update recipes with ownership validation
+- DELETE /recipes/{id}: delete recipes with ownership validation
+- Cross-user access prevention (returns 404 for non-owned recipes)
+- System recipe protection (created_by=NULL cannot be edited/deleted)
+- Authentication requirements
+- Validation (source_type, quantities, etc.)
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from uuid import uuid4
+from datetime import datetime, timezone
+
+from src.db.database import Base, get_db
+from src.db import models
+from src.db.models.user import User, UserRole
+from src.db.models.recipe import Recipe
+from src.db.models.recipe_ingredient import RecipeIngredient
+from src.services.auth_service import hash_password, create_access_token
+
+from fastapi import FastAPI
+from src.routers import recipes_router
+
+# Create a test app without lifespan
+app = FastAPI(
+    title="FreshUp",
+    description="Privacy-first kitchen management system",
+    version="0.1.0",
+)
+
+# Register the recipes router
+app.include_router(recipes_router)
+
+
+# Create an in-memory SQLite database for testing
+TEST_DATABASE_URL = "sqlite:///:memory:"
+
+
+@pytest.fixture(autouse=True)
+def setup_test_env(monkeypatch):
+    """Set up test environment variables."""
+    from src.config import get_settings
+    get_settings.cache_clear()
+
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars")
+    monkeypatch.setenv("JWT_ALGORITHM", "HS256")
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    monkeypatch.setenv("ACCESS_TOKEN_EXPIRE_MINUTES", "43200")
+
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def db_session():
+    """Create a fresh database session for each test."""
+    from sqlalchemy.pool import StaticPool
+
+    # Import models to ensure all SQLAlchemy model classes are registered
+    # with Base.metadata before create_all() is called
+    _ = models
+
+    engine = create_engine(
+        TEST_DATABASE_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+@pytest.fixture
+def client(db_session):
+    """Create a test client with database dependency override."""
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def test_user(db_session):
+    """Create a test user."""
+    user = User(
+        id=uuid4(),
+        email="test@example.com",
+        hashed_password=hash_password("testpassword123"),
+        name="Test User",
+        role=UserRole.member.value,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def test_user2(db_session):
+    """Create a second test user for cross-user access tests."""
+    user = User(
+        id=uuid4(),
+        email="test2@example.com",
+        hashed_password=hash_password("testpassword123"),
+        name="Test User 2",
+        role=UserRole.member.value,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def auth_headers(test_user):
+    """Generate authorization headers for test user."""
+    access_token = create_access_token({"sub": str(test_user.id)})
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+@pytest.fixture
+def auth_headers2(test_user2):
+    """Generate authorization headers for test user 2."""
+    access_token = create_access_token({"sub": str(test_user2.id)})
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+@pytest.fixture
+def test_recipe(db_session, test_user):
+    """Create a test recipe owned by test_user."""
+    recipe = Recipe(
+        id=uuid4(),
+        name="Test Recipe",
+        source_type="manual",
+        base_servings=4,
+        created_by=test_user.id,
+    )
+    db_session.add(recipe)
+    db_session.commit()
+    db_session.refresh(recipe)
+    return recipe
+
+
+@pytest.fixture
+def test_recipe_with_ingredients(db_session, test_user):
+    """Create a test recipe with ingredients owned by test_user."""
+    recipe = Recipe(
+        id=uuid4(),
+        name="Pasta Carbonara",
+        source_type="manual",
+        base_servings=4,
+        prep_time_minutes=10,
+        cook_time_minutes=20,
+        created_by=test_user.id,
+    )
+    db_session.add(recipe)
+    db_session.flush()
+
+    ingredients = [
+        RecipeIngredient(
+            id=uuid4(),
+            recipe_id=recipe.id,
+            ingredient_name="Pasta",
+            quantity=400,
+            unit="g",
+        ),
+        RecipeIngredient(
+            id=uuid4(),
+            recipe_id=recipe.id,
+            ingredient_name="Eggs",
+            quantity=4,
+            unit="whole",
+        ),
+    ]
+    for ing in ingredients:
+        db_session.add(ing)
+
+    db_session.commit()
+    db_session.refresh(recipe)
+    return recipe
+
+
+@pytest.fixture
+def system_recipe(db_session):
+    """Create a system recipe (created_by=NULL)."""
+    recipe = Recipe(
+        id=uuid4(),
+        name="System Recipe",
+        source_type="hellofresh_card",
+        base_servings=2,
+        created_by=None,  # System recipe
+    )
+    db_session.add(recipe)
+    db_session.commit()
+    db_session.refresh(recipe)
+    return recipe
+
+
+class TestCreateRecipe:
+    """Tests for POST /recipes (create recipe)."""
+
+    def test_create_recipe_success(self, client, auth_headers, test_user, db_session):
+        """Should create recipe with nested ingredients and auto-set created_by."""
+        payload = {
+            "name": "Test Recipe",
+            "source_type": "manual",
+            "base_servings": 4,
+            "ingredients": [
+                {"ingredient_name": "Flour", "quantity": 500, "unit": "g"},
+                {"ingredient_name": "Sugar", "quantity": 200, "unit": "g"},
+            ]
+        }
+
+        response = client.post("/recipes", json=payload, headers=auth_headers)
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["name"] == "Test Recipe"
+        assert data["source_type"] == "manual"
+        assert data["base_servings"] == 4
+        assert data["created_by"] == str(test_user.id)
+        assert len(data["ingredients"]) == 2
+        assert data["ingredients"][0]["ingredient_name"] == "Flour"
+        assert data["ingredients"][0]["quantity"] == 500
+        assert data["ingredients"][1]["ingredient_name"] == "Sugar"
+
+    def test_create_recipe_without_ingredients(self, client, auth_headers, test_user):
+        """Should create recipe without ingredients."""
+        payload = {
+            "name": "Simple Recipe",
+            "source_type": "manual",
+            "ingredients": []
+        }
+
+        response = client.post("/recipes", json=payload, headers=auth_headers)
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["name"] == "Simple Recipe"
+        assert len(data["ingredients"]) == 0
+
+    def test_create_recipe_with_optional_fields(self, client, auth_headers, test_user):
+        """Should create recipe with all optional fields."""
+        payload = {
+            "name": "Complex Recipe",
+            "source_type": "manual",
+            "source_url": "https://example.com/recipe",
+            "source_image": "https://example.com/image.jpg",
+            "prep_time_minutes": 15,
+            "cook_time_minutes": 30,
+            "base_servings": 6,
+            "steps": ["Step 1", "Step 2"],
+            "tags": ["italian", "pasta"],
+            "notes": "My favorite recipe",
+            "ingredients": []
+        }
+
+        response = client.post("/recipes", json=payload, headers=auth_headers)
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["source_url"] == "https://example.com/recipe"
+        assert data["prep_time_minutes"] == 15
+        assert data["cook_time_minutes"] == 30
+        assert data["base_servings"] == 6
+        assert data["steps"] == ["Step 1", "Step 2"]
+        assert data["tags"] == ["italian", "pasta"]
+        assert data["notes"] == "My favorite recipe"
+
+    def test_create_recipe_invalid_source_type(self, client, auth_headers):
+        """Should reject invalid source_type."""
+        payload = {
+            "name": "Test Recipe",
+            "source_type": "invalid_source",
+            "ingredients": []
+        }
+
+        response = client.post("/recipes", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+
+    def test_create_recipe_negative_prep_time(self, client, auth_headers):
+        """Should reject negative prep_time_minutes."""
+        payload = {
+            "name": "Test Recipe",
+            "source_type": "manual",
+            "prep_time_minutes": -10,
+            "ingredients": []
+        }
+
+        response = client.post("/recipes", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+
+    def test_create_recipe_zero_servings(self, client, auth_headers):
+        """Should reject zero base_servings."""
+        payload = {
+            "name": "Test Recipe",
+            "source_type": "manual",
+            "base_servings": 0,
+            "ingredients": []
+        }
+
+        response = client.post("/recipes", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+
+    def test_create_recipe_zero_quantity_ingredient(self, client, auth_headers):
+        """Should reject ingredient with zero quantity."""
+        payload = {
+            "name": "Test Recipe",
+            "source_type": "manual",
+            "ingredients": [
+                {"ingredient_name": "Flour", "quantity": 0, "unit": "g"}
+            ]
+        }
+
+        response = client.post("/recipes", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+
+    def test_create_recipe_unauthenticated(self, client):
+        """Should reject unauthenticated request."""
+        payload = {
+            "name": "Test Recipe",
+            "source_type": "manual",
+            "ingredients": []
+        }
+
+        response = client.post("/recipes", json=payload)
+
+        assert response.status_code == 401
+
+
+class TestListRecipes:
+    """Tests for GET /recipes (list recipes)."""
+
+    def test_list_recipes_empty(self, client):
+        """Should return empty list when no recipes exist."""
+        response = client.get("/recipes")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data == []
+
+    def test_list_recipes_no_auth_required(self, client, db_session, test_user):
+        """Should return recipes without authentication (global read)."""
+        recipe = Recipe(
+            id=uuid4(),
+            name="Public Recipe",
+            source_type="manual",
+            base_servings=4,
+            created_by=test_user.id,
+        )
+        db_session.add(recipe)
+        db_session.commit()
+
+        response = client.get("/recipes")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Public Recipe"
+
+    def test_list_recipes_pagination(self, client, db_session, test_user):
+        """Should paginate results with limit and offset."""
+        # Create 5 recipes
+        for i in range(5):
+            recipe = Recipe(
+                id=uuid4(),
+                name=f"Recipe {i}",
+                source_type="manual",
+                base_servings=4,
+                created_by=test_user.id,
+            )
+            db_session.add(recipe)
+        db_session.commit()
+
+        # Get first 2
+        response = client.get("/recipes?limit=2&offset=0")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+
+        # Get next 2
+        response = client.get("/recipes?limit=2&offset=2")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+
+    def test_list_recipes_respects_limit(self, client, db_session, test_user):
+        """Should respect limit parameter."""
+        # Create 10 recipes
+        for i in range(10):
+            recipe = Recipe(
+                id=uuid4(),
+                name=f"Recipe {i}",
+                source_type="manual",
+                base_servings=4,
+                created_by=test_user.id,
+            )
+            db_session.add(recipe)
+        db_session.commit()
+
+        response = client.get("/recipes?limit=5")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 5
+
+
+class TestGetRecipe:
+    """Tests for GET /recipes/{id} (get single recipe)."""
+
+    def test_get_recipe_success(self, client, test_recipe_with_ingredients):
+        """Should return recipe with nested ingredients (no auth required)."""
+        response = client.get(f"/recipes/{test_recipe_with_ingredients.id}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Pasta Carbonara"
+        assert data["source_type"] == "manual"
+        assert data["prep_time_minutes"] == 10
+        assert data["cook_time_minutes"] == 20
+        assert len(data["ingredients"]) == 2
+        assert data["ingredients"][0]["ingredient_name"] == "Pasta"
+        assert data["ingredients"][0]["quantity"] == 400
+
+    def test_get_recipe_not_found(self, client):
+        """Should return 404 for non-existent recipe."""
+        fake_id = uuid4()
+        response = client.get(f"/recipes/{fake_id}")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Recipe not found"
+
+    def test_get_system_recipe(self, client, system_recipe):
+        """Should return system recipe (created_by=NULL)."""
+        response = client.get(f"/recipes/{system_recipe.id}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "System Recipe"
+        assert data["created_by"] is None
+
+
+class TestUpdateRecipe:
+    """Tests for PUT /recipes/{id} (update recipe)."""
+
+    def test_update_recipe_success(self, client, auth_headers, test_recipe):
+        """Should update recipe owned by current user."""
+        payload = {
+            "name": "Updated Recipe Name",
+            "prep_time_minutes": 15
+        }
+
+        response = client.put(f"/recipes/{test_recipe.id}", json=payload, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Updated Recipe Name"
+        assert data["prep_time_minutes"] == 15
+
+    def test_update_recipe_partial(self, client, auth_headers, test_recipe):
+        """Should support partial updates."""
+        original_name = test_recipe.name
+
+        payload = {"prep_time_minutes": 20}
+
+        response = client.put(f"/recipes/{test_recipe.id}", json=payload, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == original_name  # Unchanged
+        assert data["prep_time_minutes"] == 20
+
+    def test_update_recipe_cross_user_returns_404(self, client, auth_headers2, test_recipe):
+        """Should return 404 when trying to update another user's recipe."""
+        payload = {"name": "Hacked Recipe"}
+
+        response = client.put(f"/recipes/{test_recipe.id}", json=payload, headers=auth_headers2)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Recipe not found"
+
+    def test_update_system_recipe_returns_404(self, client, auth_headers, system_recipe):
+        """Should return 404 when trying to update system recipe."""
+        payload = {"name": "Hacked System Recipe"}
+
+        response = client.put(f"/recipes/{system_recipe.id}", json=payload, headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Recipe not found"
+
+    def test_update_recipe_not_found(self, client, auth_headers):
+        """Should return 404 for non-existent recipe."""
+        fake_id = uuid4()
+        payload = {"name": "Updated"}
+
+        response = client.put(f"/recipes/{fake_id}", json=payload, headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Recipe not found"
+
+    def test_update_recipe_unauthenticated(self, client, test_recipe):
+        """Should reject unauthenticated update request."""
+        payload = {"name": "Hacked"}
+
+        response = client.put(f"/recipes/{test_recipe.id}", json=payload)
+
+        assert response.status_code == 401
+
+    def test_update_recipe_invalid_source_type(self, client, auth_headers, test_recipe):
+        """Should reject invalid source_type."""
+        payload = {"source_type": "invalid_source"}
+
+        response = client.put(f"/recipes/{test_recipe.id}", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+
+
+class TestDeleteRecipe:
+    """Tests for DELETE /recipes/{id} (delete recipe)."""
+
+    def test_delete_recipe_success(self, client, auth_headers, test_recipe, db_session):
+        """Should delete recipe owned by current user."""
+        recipe_id = test_recipe.id
+
+        response = client.delete(f"/recipes/{recipe_id}", headers=auth_headers)
+
+        assert response.status_code == 204
+
+        # Verify recipe is deleted
+        deleted_recipe = db_session.query(Recipe).filter(Recipe.id == recipe_id).first()
+        assert deleted_recipe is None
+
+    def test_delete_recipe_with_ingredients(self, client, auth_headers, test_recipe_with_ingredients, db_session):
+        """Should delete recipe and cascade delete ingredients."""
+        recipe_id = test_recipe_with_ingredients.id
+
+        # Verify ingredients exist before deletion
+        ingredients_before = db_session.query(RecipeIngredient).filter(
+            RecipeIngredient.recipe_id == recipe_id
+        ).all()
+        assert len(ingredients_before) == 2
+
+        response = client.delete(f"/recipes/{recipe_id}", headers=auth_headers)
+
+        assert response.status_code == 204
+
+        # Verify recipe is deleted
+        deleted_recipe = db_session.query(Recipe).filter(Recipe.id == recipe_id).first()
+        assert deleted_recipe is None
+
+        # Verify ingredients are cascade deleted
+        ingredients_after = db_session.query(RecipeIngredient).filter(
+            RecipeIngredient.recipe_id == recipe_id
+        ).all()
+        assert len(ingredients_after) == 0
+
+    def test_delete_recipe_cross_user_returns_404(self, client, auth_headers2, test_recipe, db_session):
+        """Should return 404 when trying to delete another user's recipe."""
+        recipe_id = test_recipe.id
+
+        response = client.delete(f"/recipes/{recipe_id}", headers=auth_headers2)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Recipe not found"
+
+        # Verify recipe still exists
+        recipe = db_session.query(Recipe).filter(Recipe.id == recipe_id).first()
+        assert recipe is not None
+
+    def test_delete_system_recipe_returns_404(self, client, auth_headers, system_recipe, db_session):
+        """Should return 404 when trying to delete system recipe."""
+        recipe_id = system_recipe.id
+
+        response = client.delete(f"/recipes/{recipe_id}", headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Recipe not found"
+
+        # Verify system recipe still exists
+        recipe = db_session.query(Recipe).filter(Recipe.id == recipe_id).first()
+        assert recipe is not None
+
+    def test_delete_recipe_not_found(self, client, auth_headers):
+        """Should return 404 for non-existent recipe."""
+        fake_id = uuid4()
+
+        response = client.delete(f"/recipes/{fake_id}", headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Recipe not found"
+
+    def test_delete_recipe_unauthenticated(self, client, test_recipe):
+        """Should reject unauthenticated delete request."""
+        response = client.delete(f"/recipes/{test_recipe.id}")
+
+        assert response.status_code == 401


### PR DESCRIPTION
## Work in Progress

Closes #124

[Phase 1E] Implement recipe CRUD endpoints

**Time Estimate**: 2hr

**Description**:
Implement the core recipe CRUD router (create, read, update, delete) following the inventory router patterns. Recipes are globally visible (all users can read any recipe) but only the creator can update/delete their own recipes.

**Claude Context**:
Files to Read:
- src/routers/inventory.py (pattern for CRUD, error handling, logging)
- src/middleware/auth.py (get_current_user dependency)
- src/db/models/recipe.py (Recipe model and relationships)
- src/db/models/recipe_ingredient.py (RecipeIngredient for nested creation)

Files to Modify:
- src/routers/recipes.py (create new file)
- src/routers/__init__.py (export recipes_router)
- src/main.py (register recipes_router)
- tests/routers/test_recipes.py (create new file)

Related Issues: Depends on schemas issue

**Acceptance Criteria**:
- [ ] POST /recipes creates recipe with nested ingredients: `curl -X POST localhost:8000/recipes -H "Authorization: Bearer $TOKEN" -d '{"name":"Test","source_type":"manual",...}'`
- [ ] GET /recipes returns all recipes (global read — not filtered by user), paginated with limit/offset
- [ ] GET /recipes/{id} returns single recipe with nested ingredients
- [ ] PUT /recipes/{id} updates recipe — returns 404 if recipe not found OR not owned by current user (no cross-user edit)
- [ ] DELETE /recipes/{id} deletes recipe — returns 404 if recipe not found OR not owned by current user
- [ ] Nested ingredients are created atomically with recipe (single transaction)
- [ ] Recipes without created_by (NULL) are system/imported recipes — not editable by any user via PUT, not deletable
- [ ] Router registered in main.py and accessible
- [ ] All tests pass: `pytest tests/routers/test_recipes.py -v`

**Verification Commands**:
```bash
pytest tests/routers/test_recipes.py -v
# Manual verification
curl localhost:8000/recipes | jq .
```

**Done Definition**: Done when CRUD endpoints work, ownership is enforced on mutations, and tests pass.

**Scope Boundary**:
- DO: Create/Read/Update/Delete for Recipe with nested RecipeIngredient
- DO: Enforce ownership on update/delete (return 404 for non-owner to prevent enumeration)
- DO: Add tests for happy path, ownership enforcement, and validation errors
- DO NOT: Implement filtering/search (separate issue)
- DO NOT: Implement ratings (separate issue)
- DO NOT: Implement ad-hoc creation from inventory (separate issue — cross-domain)

**Dependencies**: After "[Phase 1E] Create recipe Pydantic schemas"

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**19** files, **2** commits (+0 added, ~10 modified, -9 deleted)
- `M` .env.example
- `D` .github/PULL_REQUEST_TEMPLATE.md
- `D` .github/claude-code/pr-review-instructions.md
- `D` .github/workflows/ci.yml
- `D` .github/workflows/claude.yml
- `D` .github/workflows/pr-merged-notification.yml
- `M` requirements.txt
- `M` src/config.py
- `M` src/db/models/user_recipe.py
- `M` src/middleware/rate_limit.py
- `M` src/routers/inventory.py
- `D` src/routers/recipes.py
- `M` src/schemas/__init__.py
- `D` src/schemas/recipe.py
- `D` tests/middleware/test_rate_limit.py
- `M` tests/routers/test_auth.py
- `M` tests/routers/test_inventory.py
- `D` tests/routers/test_recipes.py
- `M` tests/schemas/test_auth.py

### Commits
- f795d57 wip: auto-commit relevant changes for issue #124 (2026-03-19)
- b503f49 chore: initialize work on #124 [Phase 1E] Implement recipe CRUD endpoints
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues
 Updated: #138 
**From assessment on 2026-03-20T01:46:25Z:**
- Created: #142 
- Updated: none