### PR TITLE
[Phase 1E] Add recipe list filtering

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -8,7 +8,7 @@ from slowapi.errors import RateLimitExceeded
 
 from src.config import get_settings
 from src.db.database import Base, init_engine, get_engine, get_session_factory
-from src.routers import auth_router, users_router, substitutions_router, inventory_router
+from src.routers import auth_router, users_router, substitutions_router, inventory_router, recipes_router
 from src.middleware.rate_limit import limiter
 
 settings = get_settings()
@@ -75,6 +75,7 @@ app.include_router(auth_router)
 app.include_router(users_router)
 app.include_router(substitutions_router)
 app.include_router(inventory_router)
+app.include_router(recipes_router)
 
 
 @app.get("/health")

--- a/src/routers/__init__.py
+++ b/src/routers/__init__.py
@@ -10,5 +10,6 @@ from src.routers.auth import router as auth_router
 from src.routers.users import router as users_router
 from src.routers.substitutions import router as substitutions_router
 from src.routers.inventory import router as inventory_router
+from src.routers.recipes import router as recipes_router
 
-__all__ = ["auth_router", "users_router", "substitutions_router", "inventory_router"]
+__all__ = ["auth_router", "users_router", "substitutions_router", "inventory_router", "recipes_router"]

--- a/src/routers/recipes.py
+++ b/src/routers/recipes.py
@@ -152,13 +152,21 @@ def list_recipes(
             )
         query = query.filter(Recipe.source_type == source_type)
 
-    # Apply tag filter (case-insensitive match in JSON array)
-    # Use json_each to iterate over array elements and check for case-insensitive match
+    # Apply tag filter (case-insensitive exact match in JSON array)
+    # Match exact tag values only, not substrings within tags
     if tag is not None:
-        # SQLite/PostgreSQL compatible: use LIKE with json cast to text for case-insensitive search
-        # Cast the entire tags JSON array to text and search within it
+        # SQLite/PostgreSQL compatible: use LIKE with proper JSON delimiters
+        # to ensure exact tag match (e.g., searching "an" won't match "italian")
+        # Pattern matches: ["tag"] or ["tag", ...] or [..., "tag"] or [..., "tag", ...]
+        # Note: JSON arrays may have spaces after commas: ["a", "b"]
+        tag_lower = tag.lower()
         query = query.filter(
-            func.lower(func.cast(Recipe.tags, String)).like(f'%"{tag.lower()}"%')
+            or_(
+                # Match at start: ["tag" or ["tag",
+                func.lower(func.cast(Recipe.tags, String)).like(f'["{tag_lower}"%'),
+                # Match in middle or end: , "tag", or , "tag"] (note space after comma)
+                func.lower(func.cast(Recipe.tags, String)).like(f'%, "{tag_lower}"%')
+            )
         )
 
     # Apply max_cook_time filter

--- a/src/routers/recipes.py
+++ b/src/routers/recipes.py
@@ -1,0 +1,392 @@
+"""
+Recipe CRUD endpoints for FreshUp.
+
+Provides endpoints for users to manage their recipes.
+All endpoints are scoped to the authenticated user's recipes.
+
+Logging Policy:
+    User-provided recipe names are NOT logged as they may contain sensitive
+    information (e.g., dietary preferences, cultural indicators).
+    Logs include operational metadata (user_id, recipe_id) for
+    debugging while protecting user privacy per OWASP recommendations.
+"""
+
+import logging
+from uuid import UUID
+from typing import Optional
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError, IntegrityError
+from sqlalchemy import func, or_, String
+
+from src.db.database import get_db
+from src.db.models.user import User
+from src.db.models.recipe import Recipe, SourceType
+from src.schemas.recipe import (
+    RecipeCreate,
+    RecipeUpdate,
+    RecipeResponse,
+    RecipeListResponse,
+)
+from src.middleware.auth import get_current_user
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/recipes", tags=["recipes"])
+
+
+@router.post("", response_model=RecipeResponse, status_code=status.HTTP_201_CREATED)
+def create_recipe(
+    recipe_data: RecipeCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Create a new recipe for the authenticated user.
+
+    The created_by field is automatically set to the current user's ID,
+    ignoring any value provided in the request body.
+
+    Args:
+        recipe_data: Recipe data (name, source_type, steps, etc.)
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        RecipeResponse: Created recipe
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(400): If data integrity violation occurs
+        HTTPException(422): If validation fails (invalid source_type, etc.)
+    """
+    # Create new recipe with created_by set to current user
+    # Ignore any created_by value from request body for security
+    recipe_dict = recipe_data.model_dump(exclude={'created_by'})
+    new_recipe = Recipe(
+        **recipe_dict,
+        created_by=current_user.id,
+    )
+
+    db.add(new_recipe)
+
+    try:
+        db.commit()
+        db.refresh(new_recipe)
+    except IntegrityError as e:
+        db.rollback()
+        logger.error(f"Integrity error during recipe creation for user {current_user.id}")
+        logger.debug(f"Integrity error occurred during recipe creation: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Recipe creation failed due to data integrity violation"
+        )
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during recipe creation for user {current_user.id}")
+        logger.debug(f"Database error occurred during recipe creation: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while creating the recipe"
+        )
+
+    logger.info(
+        f"Recipe created: user_id={current_user.id}, "
+        f"recipe_id={new_recipe.id}"
+    )
+
+    return new_recipe
+
+
+@router.get("", response_model=list[RecipeListResponse])
+def list_recipes(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+    limit: int = Query(default=50, ge=1, le=100, description="Maximum number of recipes to return"),
+    offset: int = Query(default=0, ge=0, description="Number of recipes to skip"),
+    source_type: Optional[str] = Query(default=None, description="Filter by source type (manual, hellofresh_card, etc.)"),
+    tag: Optional[str] = Query(default=None, description="Filter by tag (case-insensitive match in tags array)"),
+    max_cook_time: Optional[int] = Query(default=None, ge=0, description="Filter by maximum cook time in minutes"),
+    max_prep_time: Optional[int] = Query(default=None, ge=0, description="Filter by maximum prep time in minutes"),
+    search: Optional[str] = Query(default=None, min_length=2, max_length=255, description="Search recipes by name (case-insensitive partial match)"),
+    has_variation: Optional[bool] = Query(default=None, description="Filter by variation groups presence (true/false)"),
+):
+    """
+    List recipes for the authenticated user with filtering and pagination.
+
+    Returns recipes created by the current user, ordered by most recently added first.
+    Supports pagination via limit and offset query parameters.
+    Supports filtering by source_type, tag, cook time, prep time, name search, and
+    variation presence. Multiple filters combine with AND logic.
+
+    Args:
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+        limit: Maximum number of recipes to return (1-100, default 50)
+        offset: Number of recipes to skip (default 0)
+        source_type: Filter by source type (must be valid SourceType enum value)
+        tag: Filter by tag (case-insensitive match in tags JSON array)
+        max_cook_time: Filter by maximum cook time (recipes with cook_time_minutes <= max_cook_time)
+        max_prep_time: Filter by maximum prep time (recipes with prep_time_minutes <= max_prep_time)
+        search: Search recipes by name (case-insensitive partial match, LIKE wildcards escaped)
+        has_variation: Filter by variation groups presence (true for recipes with variations, false for none)
+
+    Returns:
+        list[RecipeListResponse]: List of user's recipes matching filters
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(422): If invalid enum value provided for source_type
+    """
+    # Start with base query filtering by user
+    query = db.query(Recipe).filter(Recipe.created_by == current_user.id)
+
+    # Apply source_type filter
+    if source_type is not None:
+        # Validate source_type enum
+        valid_source_types = [st.value for st in SourceType]
+        if source_type not in valid_source_types:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Invalid source_type. Must be one of: {', '.join(valid_source_types)}"
+            )
+        query = query.filter(Recipe.source_type == source_type)
+
+    # Apply tag filter (case-insensitive match in JSON array)
+    # Use json_each to iterate over array elements and check for case-insensitive match
+    if tag is not None:
+        # SQLite/PostgreSQL compatible: use LIKE with json cast to text for case-insensitive search
+        # Cast the entire tags JSON array to text and search within it
+        query = query.filter(
+            func.lower(func.cast(Recipe.tags, String)).like(f'%"{tag.lower()}"%')
+        )
+
+    # Apply max_cook_time filter
+    if max_cook_time is not None:
+        query = query.filter(
+            Recipe.cook_time_minutes.isnot(None),
+            Recipe.cook_time_minutes <= max_cook_time
+        )
+
+    # Apply max_prep_time filter
+    if max_prep_time is not None:
+        query = query.filter(
+            Recipe.prep_time_minutes.isnot(None),
+            Recipe.prep_time_minutes <= max_prep_time
+        )
+
+    # Apply name search filter (case-insensitive partial match)
+    if search is not None:
+        # Escape LIKE wildcards to prevent DoS via expensive pattern matching
+        escaped_search = search.replace('\\', r'\\').replace('%', r'\%').replace('_', r'\_')
+        query = query.filter(Recipe.name.ilike(f"%{escaped_search}%", escape='\\'))
+
+    # Apply has_variation filter
+    if has_variation is not None:
+        if has_variation:
+            # Filter for recipes WITH variations (variation_groups is not null and not empty dict)
+            # Check that the JSON is not null and has content (not just {})
+            query = query.filter(
+                Recipe.variation_groups.isnot(None),
+                func.cast(Recipe.variation_groups, String) != '{}'
+            )
+        else:
+            # Filter for recipes WITHOUT variations (variation_groups is null or empty dict)
+            query = query.filter(
+                or_(
+                    Recipe.variation_groups.is_(None),
+                    func.cast(Recipe.variation_groups, String) == '{}'
+                )
+            )
+
+    # Apply ordering and pagination
+    # Note: Recipe model doesn't have date_added, so we order by id (chronological proxy)
+    recipes = (
+        query
+        .order_by(Recipe.id.desc())
+        .limit(limit)
+        .offset(offset)
+        .all()
+    )
+
+    return recipes
+
+
+@router.get("/{recipe_id}", response_model=RecipeResponse)
+def get_recipe(
+    recipe_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Get a single recipe by ID.
+
+    Retrieves a specific recipe. Returns 404 if the recipe doesn't exist
+    or belongs to a different user (preventing cross-user access).
+
+    Args:
+        recipe_id: UUID of the recipe to retrieve
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        RecipeResponse: Requested recipe
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If recipe doesn't exist or belongs to another user
+    """
+    recipe = (
+        db.query(Recipe)
+        .filter(
+            Recipe.id == recipe_id,
+            Recipe.created_by == current_user.id,
+        )
+        .first()
+    )
+
+    if not recipe:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Recipe not found"
+        )
+
+    return recipe
+
+
+@router.put("/{recipe_id}", response_model=RecipeResponse)
+def update_recipe(
+    recipe_id: UUID,
+    update_data: RecipeUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Update a recipe with partial data.
+
+    Allows partial updates - only provided fields will be updated. Returns 404
+    if the recipe doesn't exist or belongs to a different user.
+
+    Args:
+        recipe_id: UUID of the recipe to update
+        update_data: Fields to update (all optional)
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        RecipeResponse: Updated recipe
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If recipe doesn't exist or belongs to another user
+        HTTPException(422): If validation fails (invalid source_type, etc.)
+    """
+    # Query recipe with user ownership check
+    recipe = (
+        db.query(Recipe)
+        .filter(
+            Recipe.id == recipe_id,
+            Recipe.created_by == current_user.id,
+        )
+        .first()
+    )
+
+    if not recipe:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Recipe not found"
+        )
+
+    # Update only the fields that were provided
+    update_dict = update_data.model_dump(exclude_unset=True)
+
+    # Apply updates
+    for field, value in update_dict.items():
+        setattr(recipe, field, value)
+
+    try:
+        db.commit()
+        db.refresh(recipe)
+    except IntegrityError as e:
+        db.rollback()
+        logger.error(f"Integrity error during recipe update for user {current_user.id}")
+        logger.debug(f"Integrity error occurred during recipe update: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Recipe update failed due to data integrity violation"
+        )
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during recipe update for user {current_user.id}")
+        logger.debug(f"Database error occurred during recipe update: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while updating the recipe"
+        )
+
+    logger.info(
+        f"Recipe updated: user_id={current_user.id}, "
+        f"recipe_id={recipe_id}"
+    )
+
+    return recipe
+
+
+@router.delete("/{recipe_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_recipe(
+    recipe_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Delete a recipe.
+
+    Removes the specified recipe. Returns 404 if the recipe doesn't exist
+    or belongs to a different user.
+
+    Args:
+        recipe_id: UUID of the recipe to delete
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        None (204 No Content on success)
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If recipe doesn't exist or belongs to another user
+    """
+    # Query recipe with user ownership check
+    recipe = (
+        db.query(Recipe)
+        .filter(
+            Recipe.id == recipe_id,
+            Recipe.created_by == current_user.id,
+        )
+        .first()
+    )
+
+    if not recipe:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Recipe not found"
+        )
+
+    try:
+        db.delete(recipe)
+        db.commit()
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during recipe deletion for user {current_user.id}")
+        logger.debug(f"Database error occurred during recipe deletion: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while deleting the recipe"
+        )
+
+    logger.info(
+        f"Recipe deleted: user_id={current_user.id}, "
+        f"recipe_id={recipe_id}"
+    )
+
+    return None

--- a/src/routers/recipes.py
+++ b/src/routers/recipes.py
@@ -159,13 +159,15 @@ def list_recipes(
         # to ensure exact tag match (e.g., searching "an" won't match "italian")
         # Pattern matches: ["tag"] or ["tag", ...] or [..., "tag"] or [..., "tag", ...]
         # Note: JSON arrays may have spaces after commas: ["a", "b"]
-        tag_lower = tag.lower()
+        # Escape LIKE wildcards to prevent DoS via expensive pattern matching
+        escaped_tag = tag.replace('\\', r'\\').replace('%', r'\%').replace('_', r'\_')
+        tag_lower = escaped_tag.lower()
         query = query.filter(
             or_(
                 # Match at start: ["tag" or ["tag",
-                func.lower(func.cast(Recipe.tags, String)).like(f'["{tag_lower}"%'),
+                func.lower(func.cast(Recipe.tags, String)).like(f'["{tag_lower}"%', escape='\\'),
                 # Match in middle or end: , "tag", or , "tag"] (note space after comma)
-                func.lower(func.cast(Recipe.tags, String)).like(f'%, "{tag_lower}"%')
+                func.lower(func.cast(Recipe.tags, String)).like(f'%, "{tag_lower}"%', escape='\\')
             )
         )
 

--- a/src/schemas/recipe.py
+++ b/src/schemas/recipe.py
@@ -1,0 +1,141 @@
+"""
+Pydantic schemas for recipe endpoints.
+
+Defines request/response models for recipe CRUD operations.
+"""
+
+from uuid import UUID
+from typing import Optional
+from pydantic import BaseModel, Field, field_validator, ConfigDict
+
+from src.db.models.recipe import SourceType
+from src.schemas.validators import validate_enum_value, validate_non_negative
+
+
+class RecipeCreate(BaseModel):
+    """Request schema for creating a new recipe."""
+
+    name: str = Field(..., min_length=1, max_length=255, description="Recipe name")
+    source_type: str = Field(..., description="Source type (manual, hellofresh_card, etc.)")
+
+    # Optional fields
+    source_url: Optional[str] = Field(default=None, max_length=2048, description="Source URL")
+    source_image: Optional[str] = Field(default=None, max_length=2048, description="Source image URL")
+    variation_groups: Optional[dict] = Field(default=None, description="Variation groups (JSON)")
+    steps: Optional[list] = Field(default_factory=list, description="Cooking steps (JSON)")
+    prep_time_minutes: Optional[int] = Field(default=None, description="Preparation time in minutes")
+    cook_time_minutes: Optional[int] = Field(default=None, description="Cooking time in minutes")
+    base_servings: Optional[int] = Field(default=4, description="Base number of servings")
+    tags: Optional[list] = Field(default_factory=list, description="Recipe tags (JSON array)")
+    nutritional_info: Optional[dict] = Field(default=None, description="Nutritional information (JSON)")
+    notes: Optional[str] = Field(default=None, description="Recipe notes")
+    created_by: Optional[UUID] = Field(default=None, description="User ID who created the recipe")
+
+    @field_validator('source_type')
+    @classmethod
+    def validate_source_type_field(cls, v: str) -> str:
+        """Ensure source_type is a valid SourceType enum value."""
+        result = validate_enum_value('source_type', v, SourceType, allow_none=False)
+        return result  # type: ignore
+
+    @field_validator('prep_time_minutes')
+    @classmethod
+    def validate_prep_time_field(cls, v: Optional[int]) -> Optional[int]:
+        """Ensure prep_time_minutes is non-negative if provided."""
+        return validate_non_negative('prep_time_minutes', v, allow_none=True)
+
+    @field_validator('cook_time_minutes')
+    @classmethod
+    def validate_cook_time_field(cls, v: Optional[int]) -> Optional[int]:
+        """Ensure cook_time_minutes is non-negative if provided."""
+        return validate_non_negative('cook_time_minutes', v, allow_none=True)
+
+    @field_validator('base_servings')
+    @classmethod
+    def validate_base_servings_field(cls, v: Optional[int]) -> Optional[int]:
+        """Ensure base_servings is positive if provided."""
+        if v is not None and v <= 0:
+            raise ValueError("base_servings must be positive")
+        return v
+
+
+class RecipeUpdate(BaseModel):
+    """Request schema for updating a recipe (partial updates allowed)."""
+
+    name: Optional[str] = Field(default=None, min_length=1, max_length=255, description="Recipe name")
+    source_type: Optional[str] = Field(default=None, description="Source type")
+    source_url: Optional[str] = Field(default=None, max_length=2048, description="Source URL")
+    source_image: Optional[str] = Field(default=None, max_length=2048, description="Source image URL")
+    variation_groups: Optional[dict] = Field(default=None, description="Variation groups (JSON)")
+    steps: Optional[list] = Field(default=None, description="Cooking steps (JSON)")
+    prep_time_minutes: Optional[int] = Field(default=None, description="Preparation time in minutes")
+    cook_time_minutes: Optional[int] = Field(default=None, description="Cooking time in minutes")
+    base_servings: Optional[int] = Field(default=None, description="Base number of servings")
+    tags: Optional[list] = Field(default=None, description="Recipe tags (JSON array)")
+    nutritional_info: Optional[dict] = Field(default=None, description="Nutritional information (JSON)")
+    notes: Optional[str] = Field(default=None, description="Recipe notes")
+
+    @field_validator('source_type')
+    @classmethod
+    def validate_source_type_field(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure source_type is a valid SourceType enum value if provided."""
+        return validate_enum_value('source_type', v, SourceType, allow_none=True)
+
+    @field_validator('prep_time_minutes')
+    @classmethod
+    def validate_prep_time_field(cls, v: Optional[int]) -> Optional[int]:
+        """Ensure prep_time_minutes is non-negative if provided."""
+        return validate_non_negative('prep_time_minutes', v, allow_none=True)
+
+    @field_validator('cook_time_minutes')
+    @classmethod
+    def validate_cook_time_field(cls, v: Optional[int]) -> Optional[int]:
+        """Ensure cook_time_minutes is non-negative if provided."""
+        return validate_non_negative('cook_time_minutes', v, allow_none=True)
+
+    @field_validator('base_servings')
+    @classmethod
+    def validate_base_servings_field(cls, v: Optional[int]) -> Optional[int]:
+        """Ensure base_servings is positive if provided."""
+        if v is not None and v <= 0:
+            raise ValueError("base_servings must be positive")
+        return v
+
+
+class RecipeResponse(BaseModel):
+    """Response schema for recipe data."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    name: str
+    source_type: str
+    source_url: Optional[str]
+    source_image: Optional[str]
+    variation_groups: Optional[dict]
+    steps: list
+    prep_time_minutes: Optional[int]
+    cook_time_minutes: Optional[int]
+    base_servings: int
+    tags: list
+    nutritional_info: Optional[dict]
+    times_cooked: int
+    created_by: Optional[UUID]
+    notes: Optional[str]
+
+
+class RecipeListResponse(BaseModel):
+    """Response schema for recipe list items (lightweight)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    name: str
+    source_type: str
+    source_image: Optional[str]
+    prep_time_minutes: Optional[int]
+    cook_time_minutes: Optional[int]
+    base_servings: int
+    tags: list
+    times_cooked: int
+    created_by: Optional[UUID]

--- a/tests/routers/test_recipes.py
+++ b/tests/routers/test_recipes.py
@@ -1,0 +1,587 @@
+"""
+Integration tests for recipe endpoints.
+
+Tests cover:
+- POST /recipes: create recipes with validation
+- GET /recipes: list user recipes with filtering and pagination
+- GET /recipes/{id}: get single recipe
+- PUT /recipes/{id}: update recipes with partial data
+- DELETE /recipes/{id}: delete recipe
+- Filtering: source_type, tag, max_cook_time, max_prep_time, search, has_variation
+- Cross-user access prevention
+- Authentication requirements
+- Validation (source_type, times, servings, etc.)
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from uuid import uuid4
+
+from src.db.database import Base, get_db
+from src.db import models
+from src.db.models.user import User, UserRole
+from src.db.models.recipe import Recipe
+from src.services.auth_service import hash_password, create_access_token
+
+from fastapi import FastAPI
+from src.routers import recipes as recipes_router
+
+# Create a test app without lifespan
+app = FastAPI(
+    title="FreshUp",
+    description="Privacy-first kitchen management system",
+    version="0.1.0",
+)
+
+# Register the recipes router
+app.include_router(recipes_router.router)
+
+
+# Create an in-memory SQLite database for testing
+TEST_DATABASE_URL = "sqlite:///:memory:"
+
+
+@pytest.fixture(autouse=True)
+def setup_test_env(monkeypatch):
+    """Set up test environment variables."""
+    from src.config import get_settings
+    get_settings.cache_clear()
+
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars")
+    monkeypatch.setenv("JWT_ALGORITHM", "HS256")
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    monkeypatch.setenv("ACCESS_TOKEN_EXPIRE_MINUTES", "43200")
+
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def db_session():
+    """Create a fresh database session for each test."""
+    from sqlalchemy.pool import StaticPool
+
+    # Import models to ensure all SQLAlchemy model classes are registered
+    # with Base.metadata before create_all() is called
+    _ = models
+
+    engine = create_engine(
+        TEST_DATABASE_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+@pytest.fixture
+def client(db_session):
+    """Create a test client with database dependency override."""
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def test_user(db_session):
+    """Create a test user."""
+    user = User(
+        id=uuid4(),
+        email="test@example.com",
+        hashed_password=hash_password("testpassword123"),
+        name="Test User",
+        role=UserRole.member.value,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def test_user2(db_session):
+    """Create a second test user for cross-user access tests."""
+    user = User(
+        id=uuid4(),
+        email="test2@example.com",
+        hashed_password=hash_password("testpassword123"),
+        name="Test User 2",
+        role=UserRole.member.value,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def auth_headers(test_user):
+    """Generate authorization headers for test user."""
+    access_token = create_access_token({"sub": str(test_user.id)})
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+@pytest.fixture
+def auth_headers2(test_user2):
+    """Generate authorization headers for test user 2."""
+    access_token = create_access_token({"sub": str(test_user2.id)})
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+class TestRecipeCRUD:
+    """Test basic recipe CRUD operations."""
+
+    def test_create_recipe_success(self, client, auth_headers, test_user, db_session):
+        """Test creating a recipe successfully."""
+        recipe_data = {
+            "name": "Spaghetti Carbonara",
+            "source_type": "manual",
+            "prep_time_minutes": 10,
+            "cook_time_minutes": 20,
+            "base_servings": 4,
+            "tags": ["italian", "pasta"],
+            "steps": ["Cook pasta", "Make sauce", "Combine"],
+        }
+
+        response = client.post("/recipes", json=recipe_data, headers=auth_headers)
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["name"] == "Spaghetti Carbonara"
+        assert data["source_type"] == "manual"
+        assert data["prep_time_minutes"] == 10
+        assert data["cook_time_minutes"] == 20
+        assert data["base_servings"] == 4
+        assert data["tags"] == ["italian", "pasta"]
+        assert data["created_by"] == str(test_user.id)
+        assert "id" in data
+
+    def test_create_recipe_invalid_source_type(self, client, auth_headers):
+        """Test creating recipe with invalid source_type fails."""
+        recipe_data = {
+            "name": "Test Recipe",
+            "source_type": "invalid_source",
+        }
+
+        response = client.post("/recipes", json=recipe_data, headers=auth_headers)
+
+        assert response.status_code == 422
+
+    def test_create_recipe_unauthenticated(self, client):
+        """Test creating recipe without auth fails."""
+        recipe_data = {
+            "name": "Test Recipe",
+            "source_type": "manual",
+        }
+
+        response = client.post("/recipes", json=recipe_data)
+
+        assert response.status_code == 401
+
+    def test_list_recipes_empty(self, client, auth_headers):
+        """Test listing recipes when user has none."""
+        response = client.get("/recipes", headers=auth_headers)
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_list_recipes_with_data(self, client, auth_headers, test_user, db_session):
+        """Test listing recipes returns user's recipes."""
+        # Create test recipes
+        recipe1 = Recipe(
+            id=uuid4(),
+            name="Recipe 1",
+            source_type="manual",
+            created_by=test_user.id,
+            tags=["tag1"],
+            steps=[],
+        )
+        recipe2 = Recipe(
+            id=uuid4(),
+            name="Recipe 2",
+            source_type="hellofresh_card",
+            created_by=test_user.id,
+            tags=["tag2"],
+            steps=[],
+        )
+        db_session.add_all([recipe1, recipe2])
+        db_session.commit()
+
+        response = client.get("/recipes", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        assert any(r["name"] == "Recipe 1" for r in data)
+        assert any(r["name"] == "Recipe 2" for r in data)
+
+    def test_get_recipe_success(self, client, auth_headers, test_user, db_session):
+        """Test getting a single recipe by ID."""
+        recipe = Recipe(
+            id=uuid4(),
+            name="Test Recipe",
+            source_type="manual",
+            created_by=test_user.id,
+            prep_time_minutes=15,
+            cook_time_minutes=30,
+            tags=["test"],
+            steps=["step1"],
+        )
+        db_session.add(recipe)
+        db_session.commit()
+
+        response = client.get(f"/recipes/{recipe.id}", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == str(recipe.id)
+        assert data["name"] == "Test Recipe"
+        assert data["prep_time_minutes"] == 15
+        assert data["cook_time_minutes"] == 30
+
+    def test_get_recipe_not_found(self, client, auth_headers):
+        """Test getting non-existent recipe returns 404."""
+        fake_id = uuid4()
+        response = client.get(f"/recipes/{fake_id}", headers=auth_headers)
+
+        assert response.status_code == 404
+
+    def test_get_recipe_cross_user_access_denied(self, client, auth_headers, auth_headers2, test_user2, db_session):
+        """Test user cannot access another user's recipe."""
+        # Create recipe for user2
+        recipe = Recipe(
+            id=uuid4(),
+            name="User2 Recipe",
+            source_type="manual",
+            created_by=test_user2.id,
+            tags=[],
+            steps=[],
+        )
+        db_session.add(recipe)
+        db_session.commit()
+
+        # Try to access with user1's token
+        response = client.get(f"/recipes/{recipe.id}", headers=auth_headers)
+
+        assert response.status_code == 404
+
+    def test_update_recipe_success(self, client, auth_headers, test_user, db_session):
+        """Test updating a recipe."""
+        recipe = Recipe(
+            id=uuid4(),
+            name="Original Name",
+            source_type="manual",
+            created_by=test_user.id,
+            tags=[],
+            steps=[],
+        )
+        db_session.add(recipe)
+        db_session.commit()
+
+        update_data = {
+            "name": "Updated Name",
+            "prep_time_minutes": 20,
+        }
+
+        response = client.put(f"/recipes/{recipe.id}", json=update_data, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Updated Name"
+        assert data["prep_time_minutes"] == 20
+
+    def test_delete_recipe_success(self, client, auth_headers, test_user, db_session):
+        """Test deleting a recipe."""
+        recipe = Recipe(
+            id=uuid4(),
+            name="To Delete",
+            source_type="manual",
+            created_by=test_user.id,
+            tags=[],
+            steps=[],
+        )
+        db_session.add(recipe)
+        db_session.commit()
+        recipe_id = recipe.id
+
+        response = client.delete(f"/recipes/{recipe_id}", headers=auth_headers)
+
+        assert response.status_code == 204
+
+        # Verify recipe is deleted
+        deleted_recipe = db_session.query(Recipe).filter(Recipe.id == recipe_id).first()
+        assert deleted_recipe is None
+
+
+class TestRecipeFiltering:
+    """Test recipe list filtering functionality."""
+
+    @pytest.fixture
+    def sample_recipes(self, test_user, db_session):
+        """Create sample recipes for filtering tests."""
+        recipes = [
+            Recipe(
+                id=uuid4(),
+                name="Quick Tacos",
+                source_type="manual",
+                created_by=test_user.id,
+                prep_time_minutes=10,
+                cook_time_minutes=15,
+                tags=["mexican", "quick"],
+                steps=["step1"],
+            ),
+            Recipe(
+                id=uuid4(),
+                name="Slow Curry",
+                source_type="hellofresh_card",
+                created_by=test_user.id,
+                prep_time_minutes=20,
+                cook_time_minutes=60,
+                tags=["indian", "curry"],
+                steps=["step1"],
+            ),
+            Recipe(
+                id=uuid4(),
+                name="Fast Pasta",
+                source_type="manual",
+                created_by=test_user.id,
+                prep_time_minutes=5,
+                cook_time_minutes=10,
+                tags=["italian", "pasta", "quick"],
+                steps=["step1"],
+            ),
+            Recipe(
+                id=uuid4(),
+                name="Curry Pizza",
+                source_type="url_import",
+                created_by=test_user.id,
+                prep_time_minutes=15,
+                cook_time_minutes=25,
+                tags=["fusion"],
+                steps=["step1"],
+                variation_groups={"size": ["small", "large"]},
+            ),
+            Recipe(
+                id=uuid4(),
+                name="Simple Salad",
+                source_type="manual",
+                created_by=test_user.id,
+                prep_time_minutes=10,
+                cook_time_minutes=None,  # No cooking required
+                tags=["healthy", "vegetarian"],
+                steps=["step1"],
+            ),
+        ]
+        db_session.add_all(recipes)
+        db_session.commit()
+        return recipes
+
+    def test_filter_by_source_type_manual(self, client, auth_headers, sample_recipes):
+        """Test filtering by source_type=manual."""
+        response = client.get("/recipes?source_type=manual", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 3  # Quick Tacos, Fast Pasta, Simple Salad
+        assert all(r["source_type"] == "manual" for r in data)
+
+    def test_filter_by_source_type_hellofresh(self, client, auth_headers, sample_recipes):
+        """Test filtering by source_type=hellofresh_card."""
+        response = client.get("/recipes?source_type=hellofresh_card", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1  # Slow Curry
+        assert data[0]["source_type"] == "hellofresh_card"
+
+    def test_filter_by_invalid_source_type(self, client, auth_headers, sample_recipes):
+        """Test filtering by invalid source_type returns 422."""
+        response = client.get("/recipes?source_type=invalid", headers=auth_headers)
+
+        assert response.status_code == 422
+        assert "Invalid source_type" in response.json()["detail"]
+
+    def test_filter_by_tag_mexican(self, client, auth_headers, sample_recipes):
+        """Test filtering by tag=mexican."""
+        response = client.get("/recipes?tag=mexican", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1  # Quick Tacos
+        assert "mexican" in data[0]["tags"]
+
+    def test_filter_by_tag_quick(self, client, auth_headers, sample_recipes):
+        """Test filtering by tag=quick (matches multiple)."""
+        response = client.get("/recipes?tag=quick", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2  # Quick Tacos, Fast Pasta
+        assert all("quick" in r["tags"] for r in data)
+
+    def test_filter_by_tag_case_insensitive(self, client, auth_headers, sample_recipes):
+        """Test tag filtering is case-insensitive."""
+        response = client.get("/recipes?tag=MEXICAN", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1  # Quick Tacos
+
+    def test_filter_by_max_cook_time(self, client, auth_headers, sample_recipes):
+        """Test filtering by max_cook_time=30."""
+        response = client.get("/recipes?max_cook_time=30", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        # Should return: Quick Tacos (15), Fast Pasta (10), Curry Pizza (25)
+        # Should exclude: Slow Curry (60), Simple Salad (None)
+        assert len(data) == 3
+        assert all(r["cook_time_minutes"] is not None and r["cook_time_minutes"] <= 30 for r in data)
+
+    def test_filter_by_max_cook_time_15(self, client, auth_headers, sample_recipes):
+        """Test filtering by max_cook_time=15."""
+        response = client.get("/recipes?max_cook_time=15", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        # Should return: Quick Tacos (15), Fast Pasta (10)
+        assert len(data) == 2
+
+    def test_filter_by_max_prep_time(self, client, auth_headers, sample_recipes):
+        """Test filtering by max_prep_time=15."""
+        response = client.get("/recipes?max_prep_time=15", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        # Should return: Quick Tacos (10), Fast Pasta (5), Curry Pizza (15), Simple Salad (10)
+        assert len(data) == 4
+        assert all(r["prep_time_minutes"] is not None and r["prep_time_minutes"] <= 15 for r in data)
+
+    def test_filter_by_search_curry(self, client, auth_headers, sample_recipes):
+        """Test search by name=curry (case-insensitive partial match)."""
+        response = client.get("/recipes?search=curry", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        # Should return: Slow Curry, Curry Pizza
+        assert len(data) == 2
+        assert all("curry" in r["name"].lower() for r in data)
+
+    def test_filter_by_search_case_insensitive(self, client, auth_headers, sample_recipes):
+        """Test search is case-insensitive."""
+        response = client.get("/recipes?search=PASTA", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1  # Fast Pasta
+        assert "pasta" in data[0]["name"].lower()
+
+    def test_filter_by_search_escapes_wildcards(self, client, auth_headers, test_user, db_session):
+        """Test search escapes LIKE wildcards to prevent DoS."""
+        # Create recipe with special chars in name
+        recipe = Recipe(
+            id=uuid4(),
+            name="Test_Recipe%With%Special",
+            source_type="manual",
+            created_by=test_user.id,
+            tags=[],
+            steps=[],
+        )
+        db_session.add(recipe)
+        db_session.commit()
+
+        # Search for literal % character (need at least 2 chars due to min_length validation)
+        response = client.get("/recipes?search=%25W", headers=auth_headers)  # %25 is URL-encoded %, search for "%W"
+
+        assert response.status_code == 200
+        data = response.json()
+        # Should match the recipe with %W in name
+        assert len(data) == 1
+        assert "%W" in data[0]["name"]
+
+    def test_filter_by_has_variation_true(self, client, auth_headers, sample_recipes):
+        """Test filtering by has_variation=true."""
+        response = client.get("/recipes?has_variation=true", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        # Only Curry Pizza has variation_groups
+        assert len(data) == 1
+        assert data[0]["name"] == "Curry Pizza"
+
+    def test_filter_by_has_variation_false(self, client, auth_headers, sample_recipes):
+        """Test filtering by has_variation=false."""
+        response = client.get("/recipes?has_variation=false", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        # All except Curry Pizza
+        assert len(data) == 4
+
+    def test_combined_filters_and_logic(self, client, auth_headers, sample_recipes):
+        """Test multiple filters combine with AND logic."""
+        # Filter: source_type=manual AND tag=quick AND max_cook_time=20
+        response = client.get(
+            "/recipes?source_type=manual&tag=quick&max_cook_time=20",
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        # Should return: Quick Tacos (manual, quick, 15min), Fast Pasta (manual, quick, 10min)
+        assert len(data) == 2
+        assert all(r["source_type"] == "manual" for r in data)
+        assert all("quick" in r["tags"] for r in data)
+        assert all(r["cook_time_minutes"] <= 20 for r in data)
+
+    def test_combined_filters_narrow_results(self, client, auth_headers, sample_recipes):
+        """Test multiple filters narrow down results progressively."""
+        # Filter: tag=quick AND max_prep_time=8
+        response = client.get(
+            "/recipes?tag=quick&max_prep_time=8",
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        # Only Fast Pasta (quick, 5min prep)
+        assert len(data) == 1
+        assert data[0]["name"] == "Fast Pasta"
+
+    def test_pagination_with_filters(self, client, auth_headers, sample_recipes):
+        """Test pagination works with filters."""
+        response = client.get(
+            "/recipes?source_type=manual&limit=2&offset=0",
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2  # First 2 of 3 manual recipes
+
+        # Get next page
+        response = client.get(
+            "/recipes?source_type=manual&limit=2&offset=2",
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1  # Remaining 1 manual recipe

--- a/tests/routers/test_recipes.py
+++ b/tests/routers/test_recipes.py
@@ -516,6 +516,17 @@ class TestRecipeFiltering:
         assert len(data) == 1
         assert "%W" in data[0]["name"]
 
+    def test_filter_by_search_minimum_length_validation(self, client, auth_headers, sample_recipes):
+        """Test search parameter requires minimum 2 characters."""
+        # Search with only 1 character should fail validation
+        response = client.get("/recipes?search=a", headers=auth_headers)
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        # FastAPI validation error for min_length constraint
+        assert any("at least 2 characters" in str(error).lower() or "min_length" in str(error).lower()
+                   for error in detail)
+
     def test_filter_by_has_variation_true(self, client, auth_headers, sample_recipes):
         """Test filtering by has_variation=true."""
         response = client.get("/recipes?has_variation=true", headers=auth_headers)


### PR DESCRIPTION
## Work in Progress

Closes #125

[Phase 1E] Add recipe list filtering

**Time Estimate**: 1hr

**Description**:
Extend GET /recipes with filtering by source_type, tags, cook time, and text search. These are simple field-based filters that don't require cross-domain joins.

**Claude Context**:
Files to Read:
- src/routers/inventory.py (filter patterns: category, expiring_soon, search with LIKE escape)
- src/routers/recipes.py (existing GET /recipes endpoint to extend)

Files to Modify:
- src/routers/recipes.py (add query parameters to list endpoint)
- tests/routers/test_recipes.py (add filter tests)

Related Issues: After CRUD issue

**Acceptance Criteria**:
- [ ] Filter by source_type: `GET /recipes?source_type=manual` returns only manual recipes
- [ ] Filter by tag (any match in JSON array): `GET /recipes?tag=mexican` returns recipes where "mexican" is in tags array
- [ ] Filter by max cook time: `GET /recipes?max_cook_time=30` returns recipes with cook_time_minutes <= 30
- [ ] Filter by max prep time: `GET /recipes?max_prep_time=15` returns recipes with prep_time_minutes <= 15
- [ ] Search by name (case-insensitive partial match): `GET /recipes?search=curry` — LIKE wildcards escaped
- [ ] Filter by has_variation (simple check if variation_groups JSON is not null/empty): `GET /recipes?has_variation=true`
- [ ] Filters combine with AND logic
- [ ] Invalid source_type returns 422 with valid values list
- [ ] Tests cover each filter independently and combined: `pytest tests/routers/test_recipes.py::TestRecipeFiltering -v`

**Verification Commands**:
```bash
pytest tests/routers/test_recipes.py::TestRecipeFiltering -v
```

**Done Definition**: Done when all 6 filter types work and tests pass.

**Scope Boundary**:
- DO: Add query parameters for source_type, tag, max_cook_time, max_prep_time, search, has_variation
- DO: Escape LIKE wildcards in search to prevent DoS
- DO NOT: Add dietary compatibility filter (Phase 3A — requires joining user dietary_profile)
- DO NOT: Add inventory availability filter (Phase 3A — requires cross-domain query)

**Dependencies**: After "[Phase 1E] Implement recipe CRUD endpoints"

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**5** files, **2** commits (+3 added, ~2 modified, -0 deleted)
- `M` src/main.py
- `M` src/routers/__init__.py
- `A` src/routers/recipes.py
- `A` src/schemas/recipe.py
- `A` tests/routers/test_recipes.py

### Commits
- eb1eb9f feat: [Phase 1E] Add recipe list filtering
- b2eb657 chore: initialize work on #125 [Phase 1E] Add recipe list filtering
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-03-19T23:10:59Z:**
- Created: #133 #134 #135 
- Updated: none