### PR TITLE
[Phase 1E] Implement recipe ingredient CRUD

### DIFF
--- a/src/routers/recipes.py
+++ b/src/routers/recipes.py
@@ -22,11 +22,15 @@ from sqlalchemy import func, or_, String
 from src.db.database import get_db
 from src.db.models.user import User
 from src.db.models.recipe import Recipe, SourceType
+from src.db.models.recipe_ingredient import RecipeIngredient
 from src.schemas.recipe import (
     RecipeCreate,
     RecipeUpdate,
     RecipeResponse,
     RecipeListResponse,
+    RecipeIngredientCreate,
+    RecipeIngredientUpdate,
+    RecipeIngredientResponse,
 )
 from src.middleware.auth import get_current_user
 
@@ -397,6 +401,305 @@ def delete_recipe(
     logger.info(
         f"Recipe deleted: user_id={current_user.id}, "
         f"recipe_id={recipe_id}"
+    )
+
+    return None
+
+
+@router.post("/{recipe_id}/ingredients", response_model=RecipeIngredientResponse, status_code=status.HTTP_201_CREATED)
+def add_recipe_ingredient(
+    recipe_id: UUID,
+    ingredient_data: RecipeIngredientCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Add a new ingredient to a recipe.
+
+    Creates a new RecipeIngredient entry for the specified recipe.
+    Only the recipe owner can add ingredients. System recipes (created_by is NULL)
+    cannot be modified.
+
+    Args:
+        recipe_id: UUID of the recipe to add ingredient to
+        ingredient_data: Ingredient data (name, quantity, unit, etc.)
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        RecipeIngredientResponse: Created ingredient
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(403): If recipe is a system recipe (created_by is NULL)
+        HTTPException(404): If recipe doesn't exist or belongs to another user
+        HTTPException(400): If data integrity violation occurs
+    """
+    # Query recipe with user ownership check
+    recipe = (
+        db.query(Recipe)
+        .filter(
+            Recipe.id == recipe_id,
+        )
+        .first()
+    )
+
+    if not recipe:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Recipe not found"
+        )
+
+    # Check if recipe is a system recipe (cannot be modified)
+    if recipe.created_by is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Cannot modify system recipes"
+        )
+
+    # Check if recipe belongs to current user
+    if recipe.created_by != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Recipe not found"
+        )
+
+    # Create new ingredient
+    ingredient_dict = ingredient_data.model_dump()
+    new_ingredient = RecipeIngredient(
+        **ingredient_dict,
+        recipe_id=recipe_id,
+    )
+
+    db.add(new_ingredient)
+
+    try:
+        db.commit()
+        db.refresh(new_ingredient)
+    except IntegrityError as e:
+        db.rollback()
+        logger.error(f"Integrity error during ingredient creation for user {current_user.id}")
+        logger.debug(f"Integrity error occurred during ingredient creation: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Ingredient creation failed due to data integrity violation"
+        )
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during ingredient creation for user {current_user.id}")
+        logger.debug(f"Database error occurred during ingredient creation: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while creating the ingredient"
+        )
+
+    logger.info(
+        f"Recipe ingredient created: user_id={current_user.id}, "
+        f"recipe_id={recipe_id}, ingredient_id={new_ingredient.id}"
+    )
+
+    return new_ingredient
+
+
+@router.put("/{recipe_id}/ingredients/{ingredient_id}", response_model=RecipeIngredientResponse)
+def update_recipe_ingredient(
+    recipe_id: UUID,
+    ingredient_id: UUID,
+    update_data: RecipeIngredientUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Update a recipe ingredient with partial data.
+
+    Allows partial updates - only provided fields will be updated.
+    Only the recipe owner can update ingredients. System recipes (created_by is NULL)
+    cannot be modified.
+
+    Args:
+        recipe_id: UUID of the recipe containing the ingredient
+        ingredient_id: UUID of the ingredient to update
+        update_data: Fields to update (all optional)
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        RecipeIngredientResponse: Updated ingredient
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(403): If recipe is a system recipe (created_by is NULL)
+        HTTPException(404): If recipe doesn't exist, belongs to another user, or ingredient not found
+        HTTPException(400): If data integrity violation occurs
+    """
+    # Query recipe with user ownership check
+    recipe = (
+        db.query(Recipe)
+        .filter(
+            Recipe.id == recipe_id,
+        )
+        .first()
+    )
+
+    if not recipe:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Recipe not found"
+        )
+
+    # Check if recipe is a system recipe (cannot be modified)
+    if recipe.created_by is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Cannot modify system recipes"
+        )
+
+    # Check if recipe belongs to current user
+    if recipe.created_by != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Recipe not found"
+        )
+
+    # Query ingredient and verify it belongs to the recipe
+    ingredient = (
+        db.query(RecipeIngredient)
+        .filter(
+            RecipeIngredient.id == ingredient_id,
+            RecipeIngredient.recipe_id == recipe_id,
+        )
+        .first()
+    )
+
+    if not ingredient:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Ingredient not found"
+        )
+
+    # Update only the fields that were provided
+    update_dict = update_data.model_dump(exclude_unset=True)
+
+    # Apply updates
+    for field, value in update_dict.items():
+        setattr(ingredient, field, value)
+
+    try:
+        db.commit()
+        db.refresh(ingredient)
+    except IntegrityError as e:
+        db.rollback()
+        logger.error(f"Integrity error during ingredient update for user {current_user.id}")
+        logger.debug(f"Integrity error occurred during ingredient update: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Ingredient update failed due to data integrity violation"
+        )
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during ingredient update for user {current_user.id}")
+        logger.debug(f"Database error occurred during ingredient update: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while updating the ingredient"
+        )
+
+    logger.info(
+        f"Recipe ingredient updated: user_id={current_user.id}, "
+        f"recipe_id={recipe_id}, ingredient_id={ingredient_id}"
+    )
+
+    return ingredient
+
+
+@router.delete("/{recipe_id}/ingredients/{ingredient_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_recipe_ingredient(
+    recipe_id: UUID,
+    ingredient_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Delete a recipe ingredient.
+
+    Removes the specified ingredient from a recipe.
+    Only the recipe owner can delete ingredients. System recipes (created_by is NULL)
+    cannot be modified.
+
+    Args:
+        recipe_id: UUID of the recipe containing the ingredient
+        ingredient_id: UUID of the ingredient to delete
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        None (204 No Content on success)
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(403): If recipe is a system recipe (created_by is NULL)
+        HTTPException(404): If recipe doesn't exist, belongs to another user, or ingredient not found
+    """
+    # Query recipe with user ownership check
+    recipe = (
+        db.query(Recipe)
+        .filter(
+            Recipe.id == recipe_id,
+        )
+        .first()
+    )
+
+    if not recipe:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Recipe not found"
+        )
+
+    # Check if recipe is a system recipe (cannot be modified)
+    if recipe.created_by is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Cannot modify system recipes"
+        )
+
+    # Check if recipe belongs to current user
+    if recipe.created_by != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Recipe not found"
+        )
+
+    # Query ingredient and verify it belongs to the recipe
+    ingredient = (
+        db.query(RecipeIngredient)
+        .filter(
+            RecipeIngredient.id == ingredient_id,
+            RecipeIngredient.recipe_id == recipe_id,
+        )
+        .first()
+    )
+
+    if not ingredient:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Ingredient not found"
+        )
+
+    try:
+        db.delete(ingredient)
+        db.commit()
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during ingredient deletion for user {current_user.id}")
+        logger.debug(f"Database error occurred during ingredient deletion: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while deleting the ingredient"
+        )
+
+    logger.info(
+        f"Recipe ingredient deleted: user_id={current_user.id}, "
+        f"recipe_id={recipe_id}, ingredient_id={ingredient_id}"
     )
 
     return None

--- a/src/schemas/recipe.py
+++ b/src/schemas/recipe.py
@@ -139,3 +139,40 @@ class RecipeListResponse(BaseModel):
     tags: list
     times_cooked: int
     created_by: Optional[UUID]
+
+
+class RecipeIngredientCreate(BaseModel):
+    """Request schema for creating a new recipe ingredient."""
+
+    ingredient_name: str = Field(..., min_length=1, max_length=255, description="Ingredient name")
+    quantity: float = Field(..., gt=0, description="Ingredient quantity (must be positive)")
+    unit: str = Field(..., min_length=1, max_length=50, description="Unit of measurement")
+    variation_group: Optional[str] = Field(default=None, max_length=100, description="Variation group identifier")
+    variation_diet: Optional[str] = Field(default=None, max_length=50, description="Dietary variation identifier")
+    is_optional: bool = Field(default=False, description="Whether ingredient is optional")
+
+
+class RecipeIngredientUpdate(BaseModel):
+    """Request schema for updating a recipe ingredient (partial updates allowed)."""
+
+    ingredient_name: Optional[str] = Field(default=None, min_length=1, max_length=255, description="Ingredient name")
+    quantity: Optional[float] = Field(default=None, gt=0, description="Ingredient quantity (must be positive)")
+    unit: Optional[str] = Field(default=None, min_length=1, max_length=50, description="Unit of measurement")
+    variation_group: Optional[str] = Field(default=None, max_length=100, description="Variation group identifier")
+    variation_diet: Optional[str] = Field(default=None, max_length=50, description="Dietary variation identifier")
+    is_optional: Optional[bool] = Field(default=None, description="Whether ingredient is optional")
+
+
+class RecipeIngredientResponse(BaseModel):
+    """Response schema for recipe ingredient data."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    recipe_id: UUID
+    ingredient_name: str
+    quantity: float
+    unit: str
+    variation_group: Optional[str]
+    variation_diet: Optional[str]
+    is_optional: bool

--- a/src/schemas/recipe.py
+++ b/src/schemas/recipe.py
@@ -151,6 +151,24 @@ class RecipeIngredientCreate(BaseModel):
     variation_diet: Optional[str] = Field(default=None, max_length=50, description="Dietary variation identifier")
     is_optional: bool = Field(default=False, description="Whether ingredient is optional")
 
+    @field_validator('ingredient_name', 'unit')
+    @classmethod
+    def strip_required_strings(cls, v: str) -> str:
+        """Strip whitespace from required string fields."""
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("Field cannot be empty or only whitespace")
+        return stripped
+
+    @field_validator('variation_group', 'variation_diet')
+    @classmethod
+    def strip_optional_strings(cls, v: Optional[str]) -> Optional[str]:
+        """Strip whitespace from optional string fields."""
+        if v is None:
+            return None
+        stripped = v.strip()
+        return stripped if stripped else None
+
 
 class RecipeIngredientUpdate(BaseModel):
     """Request schema for updating a recipe ingredient (partial updates allowed)."""
@@ -161,6 +179,26 @@ class RecipeIngredientUpdate(BaseModel):
     variation_group: Optional[str] = Field(default=None, max_length=100, description="Variation group identifier")
     variation_diet: Optional[str] = Field(default=None, max_length=50, description="Dietary variation identifier")
     is_optional: Optional[bool] = Field(default=None, description="Whether ingredient is optional")
+
+    @field_validator('ingredient_name', 'unit')
+    @classmethod
+    def strip_required_strings(cls, v: Optional[str]) -> Optional[str]:
+        """Strip whitespace from string fields."""
+        if v is None:
+            return None
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("Field cannot be empty or only whitespace")
+        return stripped
+
+    @field_validator('variation_group', 'variation_diet')
+    @classmethod
+    def strip_optional_strings(cls, v: Optional[str]) -> Optional[str]:
+        """Strip whitespace from optional string fields."""
+        if v is None:
+            return None
+        stripped = v.strip()
+        return stripped if stripped else None
 
 
 class RecipeIngredientResponse(BaseModel):

--- a/tests/routers/test_recipes.py
+++ b/tests/routers/test_recipes.py
@@ -596,3 +596,338 @@ class TestRecipeFiltering:
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 1  # Remaining 1 manual recipe
+
+
+class TestRecipeIngredientCRUD:
+    """Test recipe ingredient CRUD operations."""
+
+    @pytest.fixture
+    def test_recipe(self, db_session, test_user):
+        """Create a test recipe owned by test_user."""
+        recipe = Recipe(
+            id=uuid4(),
+            name="Test Recipe",
+            source_type="manual",
+            created_by=test_user.id,
+            tags=[],
+            steps=[],
+        )
+        db_session.add(recipe)
+        db_session.commit()
+        db_session.refresh(recipe)
+        return recipe
+
+    @pytest.fixture
+    def system_recipe(self, db_session):
+        """Create a system recipe (created_by is NULL)."""
+        recipe = Recipe(
+            id=uuid4(),
+            name="System Recipe",
+            source_type="manual",
+            created_by=None,
+            tags=[],
+            steps=[],
+        )
+        db_session.add(recipe)
+        db_session.commit()
+        db_session.refresh(recipe)
+        return recipe
+
+    @pytest.fixture
+    def test_ingredient(self, db_session, test_recipe):
+        """Create a test ingredient for test_recipe."""
+        from src.db.models.recipe_ingredient import RecipeIngredient
+        ingredient = RecipeIngredient(
+            id=uuid4(),
+            recipe_id=test_recipe.id,
+            ingredient_name="Test Ingredient",
+            quantity=1.5,
+            unit="cups",
+            variation_group=None,
+            variation_diet=None,
+            is_optional=False,
+        )
+        db_session.add(ingredient)
+        db_session.commit()
+        db_session.refresh(ingredient)
+        return ingredient
+
+    def test_add_ingredient_success(self, client, auth_headers, test_recipe, db_session):
+        """Test adding an ingredient to a recipe successfully."""
+        ingredient_data = {
+            "ingredient_name": "Tomatoes",
+            "quantity": 2.0,
+            "unit": "lbs",
+            "is_optional": False,
+        }
+
+        response = client.post(
+            f"/recipes/{test_recipe.id}/ingredients",
+            json=ingredient_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["ingredient_name"] == "Tomatoes"
+        assert data["quantity"] == 2.0
+        assert data["unit"] == "lbs"
+        assert data["recipe_id"] == str(test_recipe.id)
+        assert data["is_optional"] is False
+        assert "id" in data
+
+    def test_add_ingredient_with_variations(self, client, auth_headers, test_recipe):
+        """Test adding ingredient with variation fields."""
+        ingredient_data = {
+            "ingredient_name": "Chicken",
+            "quantity": 1.0,
+            "unit": "lb",
+            "variation_group": "protein",
+            "variation_diet": "non-vegetarian",
+            "is_optional": False,
+        }
+
+        response = client.post(
+            f"/recipes/{test_recipe.id}/ingredients",
+            json=ingredient_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["ingredient_name"] == "Chicken"
+        assert data["variation_group"] == "protein"
+        assert data["variation_diet"] == "non-vegetarian"
+
+    def test_add_ingredient_recipe_not_found(self, client, auth_headers):
+        """Test adding ingredient to non-existent recipe returns 404."""
+        ingredient_data = {
+            "ingredient_name": "Test",
+            "quantity": 1.0,
+            "unit": "cup",
+        }
+
+        fake_recipe_id = uuid4()
+        response = client.post(
+            f"/recipes/{fake_recipe_id}/ingredients",
+            json=ingredient_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Recipe not found"
+
+    def test_add_ingredient_recipe_not_owned(self, client, auth_headers2, test_recipe):
+        """Test adding ingredient to another user's recipe returns 404."""
+        ingredient_data = {
+            "ingredient_name": "Test",
+            "quantity": 1.0,
+            "unit": "cup",
+        }
+
+        response = client.post(
+            f"/recipes/{test_recipe.id}/ingredients",
+            json=ingredient_data,
+            headers=auth_headers2
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Recipe not found"
+
+    def test_add_ingredient_system_recipe(self, client, auth_headers, system_recipe):
+        """Test adding ingredient to system recipe returns 403."""
+        ingredient_data = {
+            "ingredient_name": "Test",
+            "quantity": 1.0,
+            "unit": "cup",
+        }
+
+        response = client.post(
+            f"/recipes/{system_recipe.id}/ingredients",
+            json=ingredient_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Cannot modify system recipes"
+
+    def test_add_ingredient_unauthenticated(self, client, test_recipe):
+        """Test adding ingredient without auth returns 401."""
+        ingredient_data = {
+            "ingredient_name": "Test",
+            "quantity": 1.0,
+            "unit": "cup",
+        }
+
+        response = client.post(
+            f"/recipes/{test_recipe.id}/ingredients",
+            json=ingredient_data
+        )
+
+        assert response.status_code == 401
+
+    def test_update_ingredient_success(self, client, auth_headers, test_recipe, test_ingredient):
+        """Test updating an ingredient successfully."""
+        update_data = {
+            "quantity": 2.5,
+            "unit": "tablespoons",
+        }
+
+        response = client.put(
+            f"/recipes/{test_recipe.id}/ingredients/{test_ingredient.id}",
+            json=update_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["quantity"] == 2.5
+        assert data["unit"] == "tablespoons"
+        assert data["ingredient_name"] == "Test Ingredient"  # Unchanged
+
+    def test_update_ingredient_all_fields(self, client, auth_headers, test_recipe, test_ingredient):
+        """Test updating all ingredient fields."""
+        update_data = {
+            "ingredient_name": "Updated Ingredient",
+            "quantity": 3.0,
+            "unit": "oz",
+            "variation_group": "base",
+            "variation_diet": "vegan",
+            "is_optional": True,
+        }
+
+        response = client.put(
+            f"/recipes/{test_recipe.id}/ingredients/{test_ingredient.id}",
+            json=update_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["ingredient_name"] == "Updated Ingredient"
+        assert data["quantity"] == 3.0
+        assert data["unit"] == "oz"
+        assert data["variation_group"] == "base"
+        assert data["variation_diet"] == "vegan"
+        assert data["is_optional"] is True
+
+    def test_update_ingredient_not_found(self, client, auth_headers, test_recipe):
+        """Test updating non-existent ingredient returns 404."""
+        update_data = {"quantity": 2.0}
+        fake_ingredient_id = uuid4()
+
+        response = client.put(
+            f"/recipes/{test_recipe.id}/ingredients/{fake_ingredient_id}",
+            json=update_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Ingredient not found"
+
+    def test_update_ingredient_recipe_not_owned(self, client, auth_headers2, test_recipe, test_ingredient):
+        """Test updating ingredient on another user's recipe returns 404."""
+        update_data = {"quantity": 2.0}
+
+        response = client.put(
+            f"/recipes/{test_recipe.id}/ingredients/{test_ingredient.id}",
+            json=update_data,
+            headers=auth_headers2
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Recipe not found"
+
+    def test_update_ingredient_system_recipe(self, client, auth_headers, system_recipe, db_session):
+        """Test updating ingredient on system recipe returns 403."""
+        from src.db.models.recipe_ingredient import RecipeIngredient
+        # Create ingredient for system recipe
+        ingredient = RecipeIngredient(
+            id=uuid4(),
+            recipe_id=system_recipe.id,
+            ingredient_name="System Ingredient",
+            quantity=1.0,
+            unit="cup",
+        )
+        db_session.add(ingredient)
+        db_session.commit()
+
+        update_data = {"quantity": 2.0}
+
+        response = client.put(
+            f"/recipes/{system_recipe.id}/ingredients/{ingredient.id}",
+            json=update_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Cannot modify system recipes"
+
+    def test_delete_ingredient_success(self, client, auth_headers, test_recipe, test_ingredient, db_session):
+        """Test deleting an ingredient successfully."""
+        from src.db.models.recipe_ingredient import RecipeIngredient
+
+        response = client.delete(
+            f"/recipes/{test_recipe.id}/ingredients/{test_ingredient.id}",
+            headers=auth_headers
+        )
+
+        assert response.status_code == 204
+
+        # Verify ingredient is deleted
+        ingredient = db_session.query(RecipeIngredient).filter(
+            RecipeIngredient.id == test_ingredient.id
+        ).first()
+        assert ingredient is None
+
+    def test_delete_ingredient_not_found(self, client, auth_headers, test_recipe):
+        """Test deleting non-existent ingredient returns 404."""
+        fake_ingredient_id = uuid4()
+
+        response = client.delete(
+            f"/recipes/{test_recipe.id}/ingredients/{fake_ingredient_id}",
+            headers=auth_headers
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Ingredient not found"
+
+    def test_delete_ingredient_recipe_not_owned(self, client, auth_headers2, test_recipe, test_ingredient):
+        """Test deleting ingredient from another user's recipe returns 404."""
+        response = client.delete(
+            f"/recipes/{test_recipe.id}/ingredients/{test_ingredient.id}",
+            headers=auth_headers2
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Recipe not found"
+
+    def test_delete_ingredient_system_recipe(self, client, auth_headers, system_recipe, db_session):
+        """Test deleting ingredient from system recipe returns 403."""
+        from src.db.models.recipe_ingredient import RecipeIngredient
+        # Create ingredient for system recipe
+        ingredient = RecipeIngredient(
+            id=uuid4(),
+            recipe_id=system_recipe.id,
+            ingredient_name="System Ingredient",
+            quantity=1.0,
+            unit="cup",
+        )
+        db_session.add(ingredient)
+        db_session.commit()
+
+        response = client.delete(
+            f"/recipes/{system_recipe.id}/ingredients/{ingredient.id}",
+            headers=auth_headers
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Cannot modify system recipes"
+
+    def test_delete_ingredient_unauthenticated(self, client, test_recipe, test_ingredient):
+        """Test deleting ingredient without auth returns 401."""
+        response = client.delete(
+            f"/recipes/{test_recipe.id}/ingredients/{test_ingredient.id}"
+        )
+
+        assert response.status_code == 401

--- a/tests/routers/test_recipes.py
+++ b/tests/routers/test_recipes.py
@@ -11,6 +11,7 @@ Tests cover:
 - Cross-user access prevention
 - Authentication requirements
 - Validation (source_type, times, servings, etc.)
+- Recipe ingredient CRUD operations with edge case validation
 """
 
 import pytest
@@ -931,3 +932,213 @@ class TestRecipeIngredientCRUD:
         )
 
         assert response.status_code == 401
+
+    def test_add_ingredient_empty_name(self, client, auth_headers, test_recipe):
+        """Test adding ingredient with empty name fails validation."""
+        ingredient_data = {
+            "ingredient_name": "",
+            "quantity": 1.0,
+            "unit": "cup",
+        }
+
+        response = client.post(
+            f"/recipes/{test_recipe.id}/ingredients",
+            json=ingredient_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        # Should fail either min_length or whitespace validation
+        assert any("ingredient_name" in str(error).lower() for error in detail)
+
+    def test_add_ingredient_whitespace_only_name(self, client, auth_headers, test_recipe):
+        """Test adding ingredient with whitespace-only name fails validation."""
+        ingredient_data = {
+            "ingredient_name": "   ",
+            "quantity": 1.0,
+            "unit": "cup",
+        }
+
+        response = client.post(
+            f"/recipes/{test_recipe.id}/ingredients",
+            json=ingredient_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        # Should fail whitespace validation
+        assert any("ingredient_name" in str(error).lower() or "empty" in str(error).lower() or "whitespace" in str(error).lower() for error in detail)
+
+    def test_add_ingredient_empty_unit(self, client, auth_headers, test_recipe):
+        """Test adding ingredient with empty unit fails validation."""
+        ingredient_data = {
+            "ingredient_name": "Salt",
+            "quantity": 1.0,
+            "unit": "",
+        }
+
+        response = client.post(
+            f"/recipes/{test_recipe.id}/ingredients",
+            json=ingredient_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        # Should fail either min_length or whitespace validation
+        assert any("unit" in str(error).lower() for error in detail)
+
+    def test_add_ingredient_whitespace_only_unit(self, client, auth_headers, test_recipe):
+        """Test adding ingredient with whitespace-only unit fails validation."""
+        ingredient_data = {
+            "ingredient_name": "Salt",
+            "quantity": 1.0,
+            "unit": "   ",
+        }
+
+        response = client.post(
+            f"/recipes/{test_recipe.id}/ingredients",
+            json=ingredient_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        # Should fail whitespace validation
+        assert any("unit" in str(error).lower() or "empty" in str(error).lower() or "whitespace" in str(error).lower() for error in detail)
+
+    def test_add_ingredient_zero_quantity(self, client, auth_headers, test_recipe):
+        """Test adding ingredient with zero quantity fails validation."""
+        ingredient_data = {
+            "ingredient_name": "Salt",
+            "quantity": 0,
+            "unit": "tsp",
+        }
+
+        response = client.post(
+            f"/recipes/{test_recipe.id}/ingredients",
+            json=ingredient_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        # Should fail gt=0 validation
+        assert any("quantity" in str(error).lower() for error in detail)
+
+    def test_add_ingredient_negative_quantity(self, client, auth_headers, test_recipe):
+        """Test adding ingredient with negative quantity fails validation."""
+        ingredient_data = {
+            "ingredient_name": "Salt",
+            "quantity": -1.5,
+            "unit": "tsp",
+        }
+
+        response = client.post(
+            f"/recipes/{test_recipe.id}/ingredients",
+            json=ingredient_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        # Should fail gt=0 validation
+        assert any("quantity" in str(error).lower() for error in detail)
+
+    def test_update_ingredient_empty_name(self, client, auth_headers, test_recipe, test_ingredient):
+        """Test updating ingredient with empty name fails validation."""
+        update_data = {
+            "ingredient_name": "",
+        }
+
+        response = client.put(
+            f"/recipes/{test_recipe.id}/ingredients/{test_ingredient.id}",
+            json=update_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        assert any("ingredient_name" in str(error).lower() for error in detail)
+
+    def test_update_ingredient_whitespace_only_name(self, client, auth_headers, test_recipe, test_ingredient):
+        """Test updating ingredient with whitespace-only name fails validation."""
+        update_data = {
+            "ingredient_name": "   ",
+        }
+
+        response = client.put(
+            f"/recipes/{test_recipe.id}/ingredients/{test_ingredient.id}",
+            json=update_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        assert any("ingredient_name" in str(error).lower() or "empty" in str(error).lower() or "whitespace" in str(error).lower() for error in detail)
+
+    def test_update_ingredient_empty_unit(self, client, auth_headers, test_recipe, test_ingredient):
+        """Test updating ingredient with empty unit fails validation."""
+        update_data = {
+            "unit": "",
+        }
+
+        response = client.put(
+            f"/recipes/{test_recipe.id}/ingredients/{test_ingredient.id}",
+            json=update_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        assert any("unit" in str(error).lower() for error in detail)
+
+    def test_update_ingredient_whitespace_only_unit(self, client, auth_headers, test_recipe, test_ingredient):
+        """Test updating ingredient with whitespace-only unit fails validation."""
+        update_data = {
+            "unit": "   ",
+        }
+
+        response = client.put(
+            f"/recipes/{test_recipe.id}/ingredients/{test_ingredient.id}",
+            json=update_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        assert any("unit" in str(error).lower() or "empty" in str(error).lower() or "whitespace" in str(error).lower() for error in detail)
+
+    def test_update_ingredient_zero_quantity(self, client, auth_headers, test_recipe, test_ingredient):
+        """Test updating ingredient with zero quantity fails validation."""
+        update_data = {
+            "quantity": 0,
+        }
+
+        response = client.put(
+            f"/recipes/{test_recipe.id}/ingredients/{test_ingredient.id}",
+            json=update_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        assert any("quantity" in str(error).lower() for error in detail)
+
+    def test_update_ingredient_negative_quantity(self, client, auth_headers, test_recipe, test_ingredient):
+        """Test updating ingredient with negative quantity fails validation."""
+        update_data = {
+            "quantity": -2.0,
+        }
+
+        response = client.put(
+            f"/recipes/{test_recipe.id}/ingredients/{test_ingredient.id}",
+            json=update_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        assert any("quantity" in str(error).lower() for error in detail)


### PR DESCRIPTION
## Work in Progress

Closes #126

[Phase 1E] Implement recipe ingredient CRUD

**Time Estimate**: 1hr

**Description**:
Add nested endpoints for managing RecipeIngredient entries on existing recipes. This allows adding/updating/removing individual ingredients after recipe creation.

**Claude Context**:
Files to Read:
- src/routers/inventory.py (patterns for nested resource operations like available-stores)
- src/routers/recipes.py (existing recipe router to extend)
- src/db/models/recipe_ingredient.py (RecipeIngredient model)

Files to Modify:
- src/routers/recipes.py (add ingredient sub-endpoints)
- src/schemas/recipes.py (add RecipeIngredientUpdate schema if not present)
- tests/routers/test_recipes.py (add ingredient CRUD tests)

Related Issues: After CRUD issue

**Acceptance Criteria**:
- [ ] POST /recipes/{id}/ingredients adds new ingredient to recipe (returns 404 if recipe not found or not owned)
- [ ] PUT /recipes/{id}/ingredients/{ingredient_id} updates ingredient (returns 404 if recipe not owned or ingredient not found)
- [ ] DELETE /recipes/{id}/ingredients/{ingredient_id} removes ingredient (returns 404 if recipe not owned or ingredient not found)
- [ ] Variation group and variation_diet fields are properly handled (ingredient assigned to dietary fork)
- [ ] Cannot modify ingredients on system recipes (created_by is NULL)
- [ ] Tests cover CRUD operations and ownership enforcement: `pytest tests/routers/test_recipes.py::TestRecipeIngredientCRUD -v`

**Verification Commands**:
```bash
pytest tests/routers/test_recipes.py::TestRecipeIngredientCRUD -v
```

**Done Definition**: Done when individual ingredients can be added/updated/removed and ownership is enforced.

**Scope Boundary**:
- DO: Implement nested CRUD for ingredients within owned recipes
- DO: Handle variation_group and variation_diet fields
- DO NOT: Implement bulk ingredient replacement (full ingredient list update is via PUT /recipes/{id} with ingredients array)
- DO NOT: Validate variation_group values against recipe's variation_groups field (complex validation deferred)

**Dependencies**: After "[Phase 1E] Implement recipe CRUD endpoints" (can run in parallel with filtering issue)

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **2** commits (+0 added, ~3 modified, -0 deleted)
- `M` src/routers/recipes.py
- `M` src/schemas/recipe.py
- `M` tests/routers/test_recipes.py

### Commits
- 88db5cc feat: [Phase 1E] Implement recipe ingredient CRUD
- c054245 chore: initialize work on #126 [Phase 1E] Implement recipe ingredient CRUD
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues
Created: #138  Updated: #137 
**From assessment on 2026-03-19T23:29:49Z:**
- Created: #137 
- Updated: none