### PR TITLE
[Phase 1E] Implement recipe ratings endpoints

### DIFF
--- a/src/db/models/user_recipe.py
+++ b/src/db/models/user_recipe.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from uuid import UUID, uuid4
 from typing import Optional
 
-from sqlalchemy import String, Float, Boolean, ForeignKey, Text
+from sqlalchemy import String, Float, Boolean, ForeignKey, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.db.database import Base
@@ -11,6 +11,9 @@ from src.db.database import Base
 
 class UserRecipeRating(Base):
     __tablename__ = "user_recipe_ratings"
+    __table_args__ = (
+        UniqueConstraint('user_id', 'recipe_id', name='uq_user_recipe_rating'),
+    )
 
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
     user_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"))

--- a/src/routers/recipes.py
+++ b/src/routers/recipes.py
@@ -976,9 +976,10 @@ def get_recipe_ratings(
     )
 
     # Extract values (handle None for average when no ratings)
+    # Note: count() always returns an integer (0 if no matches), never None
     average_rating = stats.average_rating if stats.average_rating is not None else None
-    rating_count = stats.rating_count if stats.rating_count is not None else 0
-    favorite_count = stats.favorite_count if stats.favorite_count is not None else 0
+    rating_count = stats.rating_count
+    favorite_count = stats.favorite_count
 
     return RecipeAggregateRatingsResponse(
         average_rating=average_rating,

--- a/src/routers/recipes.py
+++ b/src/routers/recipes.py
@@ -969,7 +969,7 @@ def get_recipe_ratings(
         db.query(
             func.avg(UserRecipeRating.rating).label('average_rating'),
             func.count(UserRecipeRating.id).filter(UserRecipeRating.rating.isnot(None)).label('rating_count'),
-            func.count(UserRecipeRating.id).filter(UserRecipeRating.is_favorite == True).label('favorite_count'),
+            func.count(UserRecipeRating.id).filter(UserRecipeRating.is_favorite.is_(True)).label('favorite_count'),
         )
         .filter(UserRecipeRating.recipe_id == recipe_id)
         .first()

--- a/src/routers/recipes.py
+++ b/src/routers/recipes.py
@@ -23,6 +23,7 @@ from src.db.database import get_db
 from src.db.models.user import User
 from src.db.models.recipe import Recipe, SourceType
 from src.db.models.recipe_ingredient import RecipeIngredient
+from src.db.models.user_recipe import UserRecipeRating
 from src.schemas.recipe import (
     RecipeCreate,
     RecipeUpdate,
@@ -31,6 +32,9 @@ from src.schemas.recipe import (
     RecipeIngredientCreate,
     RecipeIngredientUpdate,
     RecipeIngredientResponse,
+    UserRecipeRatingCreate,
+    UserRecipeRatingResponse,
+    RecipeAggregateRatingsResponse,
 )
 from src.middleware.auth import get_current_user
 
@@ -703,3 +707,281 @@ def delete_recipe_ingredient(
     )
 
     return None
+
+
+@router.post("/{recipe_id}/rate", response_model=UserRecipeRatingResponse, status_code=status.HTTP_200_OK)
+def rate_recipe(
+    recipe_id: UUID,
+    rating_data: UserRecipeRatingCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Create or update a rating for a recipe (upsert behavior).
+
+    Each user can have only one rating per recipe. If a rating already exists,
+    this endpoint will update it. Otherwise, it creates a new rating.
+
+    Args:
+        recipe_id: UUID of the recipe to rate
+        rating_data: Rating data (rating value, is_favorite, notes)
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        UserRecipeRatingResponse: Created or updated rating
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If recipe doesn't exist
+        HTTPException(422): If rating value is out of range (0.0-5.0)
+    """
+    # Verify recipe exists (no ownership check - any user can rate any recipe)
+    recipe = db.query(Recipe).filter(Recipe.id == recipe_id).first()
+    if not recipe:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Recipe not found"
+        )
+
+    # Check if user already has a rating for this recipe
+    existing_rating = (
+        db.query(UserRecipeRating)
+        .filter(
+            UserRecipeRating.user_id == current_user.id,
+            UserRecipeRating.recipe_id == recipe_id,
+        )
+        .first()
+    )
+
+    if existing_rating:
+        # Update existing rating
+        update_dict = rating_data.model_dump()
+        for field, value in update_dict.items():
+            setattr(existing_rating, field, value)
+
+        try:
+            db.commit()
+            db.refresh(existing_rating)
+        except SQLAlchemyError as e:
+            db.rollback()
+            logger.error(f"Database error during rating update for user {current_user.id}")
+            logger.debug(f"Database error occurred during rating update: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="An error occurred while updating the rating"
+            )
+
+        logger.info(
+            f"Recipe rating updated: user_id={current_user.id}, "
+            f"recipe_id={recipe_id}, rating_id={existing_rating.id}"
+        )
+        return existing_rating
+    else:
+        # Create new rating
+        new_rating = UserRecipeRating(
+            user_id=current_user.id,
+            recipe_id=recipe_id,
+            **rating_data.model_dump()
+        )
+        db.add(new_rating)
+
+        try:
+            db.commit()
+            db.refresh(new_rating)
+        except IntegrityError as e:
+            db.rollback()
+            logger.error(f"Integrity error during rating creation for user {current_user.id}")
+            logger.debug(f"Integrity error occurred during rating creation: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Rating creation failed due to data integrity violation"
+            )
+        except SQLAlchemyError as e:
+            db.rollback()
+            logger.error(f"Database error during rating creation for user {current_user.id}")
+            logger.debug(f"Database error occurred during rating creation: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="An error occurred while creating the rating"
+            )
+
+        logger.info(
+            f"Recipe rating created: user_id={current_user.id}, "
+            f"recipe_id={recipe_id}, rating_id={new_rating.id}"
+        )
+        return new_rating
+
+
+@router.get("/{recipe_id}/my-rating", response_model=UserRecipeRatingResponse)
+def get_my_rating(
+    recipe_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Get the current user's rating for a recipe.
+
+    Returns the authenticated user's rating for the specified recipe.
+    Returns 404 if the user hasn't rated this recipe yet.
+
+    Args:
+        recipe_id: UUID of the recipe
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        UserRecipeRatingResponse: User's rating for this recipe
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If recipe doesn't exist or user hasn't rated it
+    """
+    # Verify recipe exists
+    recipe = db.query(Recipe).filter(Recipe.id == recipe_id).first()
+    if not recipe:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Recipe not found"
+        )
+
+    # Get user's rating
+    rating = (
+        db.query(UserRecipeRating)
+        .filter(
+            UserRecipeRating.user_id == current_user.id,
+            UserRecipeRating.recipe_id == recipe_id,
+        )
+        .first()
+    )
+
+    if not rating:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Rating not found"
+        )
+
+    return rating
+
+
+@router.delete("/{recipe_id}/my-rating", status_code=status.HTTP_204_NO_CONTENT)
+def delete_my_rating(
+    recipe_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Delete the current user's rating for a recipe.
+
+    Removes the authenticated user's rating for the specified recipe.
+    Returns 204 even if no rating exists (idempotent behavior).
+
+    Args:
+        recipe_id: UUID of the recipe
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        None (204 No Content on success)
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If recipe doesn't exist
+    """
+    # Verify recipe exists
+    recipe = db.query(Recipe).filter(Recipe.id == recipe_id).first()
+    if not recipe:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Recipe not found"
+        )
+
+    # Get user's rating (if exists)
+    rating = (
+        db.query(UserRecipeRating)
+        .filter(
+            UserRecipeRating.user_id == current_user.id,
+            UserRecipeRating.recipe_id == recipe_id,
+        )
+        .first()
+    )
+
+    if rating:
+        try:
+            db.delete(rating)
+            db.commit()
+        except SQLAlchemyError as e:
+            db.rollback()
+            logger.error(f"Database error during rating deletion for user {current_user.id}")
+            logger.debug(f"Database error occurred during rating deletion: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="An error occurred while deleting the rating"
+            )
+
+        logger.info(
+            f"Recipe rating deleted: user_id={current_user.id}, "
+            f"recipe_id={recipe_id}"
+        )
+
+    return None
+
+
+@router.get("/{recipe_id}/ratings", response_model=RecipeAggregateRatingsResponse)
+def get_recipe_ratings(
+    recipe_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Get aggregate rating statistics for a recipe.
+
+    Returns the average rating, total rating count, and favorite count
+    across all users who have rated this recipe. This is a shared read
+    endpoint - all users can see aggregate stats for any recipe.
+
+    Args:
+        recipe_id: UUID of the recipe
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        RecipeAggregateRatingsResponse: Aggregate rating statistics
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If recipe doesn't exist
+    """
+    # Verify recipe exists
+    recipe = db.query(Recipe).filter(Recipe.id == recipe_id).first()
+    if not recipe:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Recipe not found"
+        )
+
+    # Calculate aggregate statistics across all users
+    # - average_rating: Average of all non-null rating values (func.avg automatically excludes nulls)
+    # - rating_count: Count of rows where rating is not None (users who provided numeric ratings)
+    # - favorite_count: Count of rows where is_favorite is True (users who favorited)
+    # Note: Users can favorite without rating (rating=None), so favorite_count may exceed rating_count
+    stats = (
+        db.query(
+            func.avg(UserRecipeRating.rating).label('average_rating'),
+            func.count(UserRecipeRating.id).filter(UserRecipeRating.rating.isnot(None)).label('rating_count'),
+            func.count(UserRecipeRating.id).filter(UserRecipeRating.is_favorite == True).label('favorite_count'),
+        )
+        .filter(UserRecipeRating.recipe_id == recipe_id)
+        .first()
+    )
+
+    # Extract values (handle None for average when no ratings)
+    average_rating = stats.average_rating if stats.average_rating is not None else None
+    rating_count = stats.rating_count if stats.rating_count is not None else 0
+    favorite_count = stats.favorite_count if stats.favorite_count is not None else 0
+
+    return RecipeAggregateRatingsResponse(
+        average_rating=average_rating,
+        rating_count=rating_count,
+        favorite_count=favorite_count,
+    )

--- a/src/schemas/recipe.py
+++ b/src/schemas/recipe.py
@@ -214,3 +214,41 @@ class RecipeIngredientResponse(BaseModel):
     variation_group: Optional[str]
     variation_diet: Optional[str]
     is_optional: bool
+
+
+class UserRecipeRatingCreate(BaseModel):
+    """Request schema for creating or updating a recipe rating."""
+
+    rating: Optional[float] = Field(default=None, description="Rating value (0.0-5.0)")
+    is_favorite: bool = Field(default=False, description="Whether recipe is favorited")
+    notes: Optional[str] = Field(default=None, max_length=1000, description="Personal notes about the recipe")
+
+    @field_validator('rating')
+    @classmethod
+    def validate_rating_range(cls, v: Optional[float]) -> Optional[float]:
+        """Ensure rating is between 0.0 and 5.0 if provided."""
+        if v is not None:
+            if v < 0.0 or v > 5.0:
+                raise ValueError("Rating must be between 0.0 and 5.0")
+        return v
+
+
+class UserRecipeRatingResponse(BaseModel):
+    """Response schema for user recipe rating data."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    user_id: UUID
+    recipe_id: UUID
+    rating: Optional[float]
+    is_favorite: bool
+    notes: Optional[str]
+
+
+class RecipeAggregateRatingsResponse(BaseModel):
+    """Response schema for aggregate recipe ratings."""
+
+    average_rating: Optional[float] = Field(default=None, description="Average rating across all users (null if no ratings)")
+    rating_count: int = Field(..., description="Number of users who have rated this recipe")
+    favorite_count: int = Field(..., description="Number of users who favorited this recipe")

--- a/tests/routers/test_recipes.py
+++ b/tests/routers/test_recipes.py
@@ -1142,3 +1142,511 @@ class TestRecipeIngredientCRUD:
         assert response.status_code == 422
         detail = response.json()["detail"]
         assert any("quantity" in str(error).lower() for error in detail)
+
+
+class TestRecipeRatings:
+    """Test recipe rating endpoints."""
+
+    @pytest.fixture
+    def test_recipe(self, db_session, test_user):
+        """Create a test recipe for rating tests."""
+        recipe = Recipe(
+            id=uuid4(),
+            name="Test Recipe for Ratings",
+            source_type="manual",
+            created_by=test_user.id,
+            tags=[],
+            steps=[],
+        )
+        db_session.add(recipe)
+        db_session.commit()
+        db_session.refresh(recipe)
+        return recipe
+
+    def test_create_rating_success(self, client, auth_headers, test_recipe, test_user, db_session):
+        """Test creating a new rating for a recipe."""
+        rating_data = {
+            "rating": 4.5,
+            "is_favorite": True,
+            "notes": "Delicious recipe!",
+        }
+
+        response = client.post(
+            f"/recipes/{test_recipe.id}/rate",
+            json=rating_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["rating"] == 4.5
+        assert data["is_favorite"] is True
+        assert data["notes"] == "Delicious recipe!"
+        assert data["user_id"] == str(test_user.id)
+        assert data["recipe_id"] == str(test_recipe.id)
+        assert "id" in data
+
+    def test_create_rating_minimal_fields(self, client, auth_headers, test_recipe, test_user):
+        """Test creating rating with only is_favorite (no rating value or notes)."""
+        rating_data = {
+            "is_favorite": True,
+        }
+
+        response = client.post(
+            f"/recipes/{test_recipe.id}/rate",
+            json=rating_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["rating"] is None
+        assert data["is_favorite"] is True
+        assert data["notes"] is None
+
+    def test_update_rating_upsert(self, client, auth_headers, test_recipe, test_user, db_session):
+        """Test updating an existing rating (upsert behavior)."""
+        # Create initial rating
+        rating_data = {
+            "rating": 3.0,
+            "is_favorite": False,
+            "notes": "Initial note",
+        }
+
+        response = client.post(
+            f"/recipes/{test_recipe.id}/rate",
+            json=rating_data,
+            headers=auth_headers
+        )
+        assert response.status_code == 200
+        initial_id = response.json()["id"]
+
+        # Update the rating (same endpoint, different data)
+        update_data = {
+            "rating": 5.0,
+            "is_favorite": True,
+            "notes": "Updated note - much better!",
+        }
+
+        response = client.post(
+            f"/recipes/{test_recipe.id}/rate",
+            json=update_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == initial_id  # Same ID (updated, not created)
+        assert data["rating"] == 5.0
+        assert data["is_favorite"] is True
+        assert data["notes"] == "Updated note - much better!"
+
+        # Verify only one rating exists in database
+        from src.db.models.user_recipe import UserRecipeRating
+        ratings = db_session.query(UserRecipeRating).filter(
+            UserRecipeRating.user_id == test_user.id,
+            UserRecipeRating.recipe_id == test_recipe.id,
+        ).all()
+        assert len(ratings) == 1
+
+    def test_create_rating_recipe_not_found(self, client, auth_headers):
+        """Test creating rating for non-existent recipe returns 404."""
+        rating_data = {
+            "rating": 4.0,
+            "is_favorite": False,
+        }
+
+        fake_recipe_id = uuid4()
+        response = client.post(
+            f"/recipes/{fake_recipe_id}/rate",
+            json=rating_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Recipe not found"
+
+    def test_create_rating_unauthenticated(self, client, test_recipe):
+        """Test creating rating without auth returns 401."""
+        rating_data = {
+            "rating": 4.0,
+            "is_favorite": False,
+        }
+
+        response = client.post(
+            f"/recipes/{test_recipe.id}/rate",
+            json=rating_data
+        )
+
+        assert response.status_code == 401
+
+    def test_create_rating_out_of_range_high(self, client, auth_headers, test_recipe):
+        """Test creating rating with value > 5.0 fails validation."""
+        rating_data = {
+            "rating": 5.5,
+            "is_favorite": False,
+        }
+
+        response = client.post(
+            f"/recipes/{test_recipe.id}/rate",
+            json=rating_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        # Should fail validation with message about range
+        assert any("rating" in str(error).lower() or "0.0" in str(error) or "5.0" in str(error) for error in detail)
+
+    def test_create_rating_out_of_range_low(self, client, auth_headers, test_recipe):
+        """Test creating rating with value < 0.0 fails validation."""
+        rating_data = {
+            "rating": -1.0,
+            "is_favorite": False,
+        }
+
+        response = client.post(
+            f"/recipes/{test_recipe.id}/rate",
+            json=rating_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        assert any("rating" in str(error).lower() or "0.0" in str(error) or "5.0" in str(error) for error in detail)
+
+    def test_create_rating_boundary_values(self, client, auth_headers, test_recipe, db_session):
+        """Test creating ratings with boundary values (0.0 and 5.0)."""
+        # Test 0.0 (minimum valid)
+        rating_data = {"rating": 0.0, "is_favorite": False}
+        response = client.post(
+            f"/recipes/{test_recipe.id}/rate",
+            json=rating_data,
+            headers=auth_headers
+        )
+        assert response.status_code == 200
+        assert response.json()["rating"] == 0.0
+
+        # Test 5.0 (maximum valid) - updates existing rating
+        rating_data = {"rating": 5.0, "is_favorite": True}
+        response = client.post(
+            f"/recipes/{test_recipe.id}/rate",
+            json=rating_data,
+            headers=auth_headers
+        )
+        assert response.status_code == 200
+        assert response.json()["rating"] == 5.0
+
+    def test_get_my_rating_success(self, client, auth_headers, test_recipe, test_user, db_session):
+        """Test getting user's own rating for a recipe."""
+        # Create a rating first
+        from src.db.models.user_recipe import UserRecipeRating
+        rating = UserRecipeRating(
+            id=uuid4(),
+            user_id=test_user.id,
+            recipe_id=test_recipe.id,
+            rating=4.0,
+            is_favorite=True,
+            notes="My rating",
+        )
+        db_session.add(rating)
+        db_session.commit()
+
+        response = client.get(
+            f"/recipes/{test_recipe.id}/my-rating",
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["rating"] == 4.0
+        assert data["is_favorite"] is True
+        assert data["notes"] == "My rating"
+        assert data["user_id"] == str(test_user.id)
+
+    def test_get_my_rating_not_found(self, client, auth_headers, test_recipe):
+        """Test getting rating when user hasn't rated returns 404."""
+        response = client.get(
+            f"/recipes/{test_recipe.id}/my-rating",
+            headers=auth_headers
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Rating not found"
+
+    def test_get_my_rating_recipe_not_found(self, client, auth_headers):
+        """Test getting rating for non-existent recipe returns 404."""
+        fake_recipe_id = uuid4()
+        response = client.get(
+            f"/recipes/{fake_recipe_id}/my-rating",
+            headers=auth_headers
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Recipe not found"
+
+    def test_get_my_rating_unauthenticated(self, client, test_recipe):
+        """Test getting rating without auth returns 401."""
+        response = client.get(f"/recipes/{test_recipe.id}/my-rating")
+
+        assert response.status_code == 401
+
+    def test_delete_my_rating_success(self, client, auth_headers, test_recipe, test_user, db_session):
+        """Test deleting user's rating successfully."""
+        # Create a rating first
+        from src.db.models.user_recipe import UserRecipeRating
+        rating = UserRecipeRating(
+            id=uuid4(),
+            user_id=test_user.id,
+            recipe_id=test_recipe.id,
+            rating=3.5,
+            is_favorite=False,
+        )
+        db_session.add(rating)
+        db_session.commit()
+        rating_id = rating.id
+
+        response = client.delete(
+            f"/recipes/{test_recipe.id}/my-rating",
+            headers=auth_headers
+        )
+
+        assert response.status_code == 204
+
+        # Verify rating is deleted
+        deleted_rating = db_session.query(UserRecipeRating).filter(
+            UserRecipeRating.id == rating_id
+        ).first()
+        assert deleted_rating is None
+
+    def test_delete_my_rating_idempotent(self, client, auth_headers, test_recipe):
+        """Test deleting non-existent rating returns 204 (idempotent)."""
+        response = client.delete(
+            f"/recipes/{test_recipe.id}/my-rating",
+            headers=auth_headers
+        )
+
+        assert response.status_code == 204
+
+    def test_delete_my_rating_recipe_not_found(self, client, auth_headers):
+        """Test deleting rating for non-existent recipe returns 404."""
+        fake_recipe_id = uuid4()
+        response = client.delete(
+            f"/recipes/{fake_recipe_id}/my-rating",
+            headers=auth_headers
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Recipe not found"
+
+    def test_delete_my_rating_unauthenticated(self, client, test_recipe):
+        """Test deleting rating without auth returns 401."""
+        response = client.delete(f"/recipes/{test_recipe.id}/my-rating")
+
+        assert response.status_code == 401
+
+    def test_get_aggregate_ratings_no_ratings(self, client, auth_headers, test_recipe):
+        """Test aggregate ratings with no ratings returns zeros/null."""
+        response = client.get(
+            f"/recipes/{test_recipe.id}/ratings",
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["average_rating"] is None
+        assert data["rating_count"] == 0
+        assert data["favorite_count"] == 0
+
+    def test_get_aggregate_ratings_single_rating(self, client, auth_headers, test_recipe, test_user, db_session):
+        """Test aggregate ratings with one rating."""
+        from src.db.models.user_recipe import UserRecipeRating
+        rating = UserRecipeRating(
+            id=uuid4(),
+            user_id=test_user.id,
+            recipe_id=test_recipe.id,
+            rating=4.0,
+            is_favorite=True,
+        )
+        db_session.add(rating)
+        db_session.commit()
+
+        response = client.get(
+            f"/recipes/{test_recipe.id}/ratings",
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["average_rating"] == 4.0
+        assert data["rating_count"] == 1
+        assert data["favorite_count"] == 1
+
+    def test_get_aggregate_ratings_multiple_ratings(self, client, auth_headers, test_recipe, test_user, test_user2, db_session):
+        """Test aggregate ratings with multiple users' ratings."""
+        from src.db.models.user_recipe import UserRecipeRating
+
+        # User 1 rating
+        rating1 = UserRecipeRating(
+            id=uuid4(),
+            user_id=test_user.id,
+            recipe_id=test_recipe.id,
+            rating=4.0,
+            is_favorite=True,
+        )
+
+        # User 2 rating
+        rating2 = UserRecipeRating(
+            id=uuid4(),
+            user_id=test_user2.id,
+            recipe_id=test_recipe.id,
+            rating=5.0,
+            is_favorite=False,
+        )
+
+        db_session.add_all([rating1, rating2])
+        db_session.commit()
+
+        response = client.get(
+            f"/recipes/{test_recipe.id}/ratings",
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["average_rating"] == 4.5  # (4.0 + 5.0) / 2
+        assert data["rating_count"] == 2
+        assert data["favorite_count"] == 1  # Only user1 favorited
+
+    def test_get_aggregate_ratings_favorite_only(self, client, auth_headers, test_recipe, test_user, db_session):
+        """Test aggregate ratings when user only favorited (no rating value)."""
+        from src.db.models.user_recipe import UserRecipeRating
+        rating = UserRecipeRating(
+            id=uuid4(),
+            user_id=test_user.id,
+            recipe_id=test_recipe.id,
+            rating=None,  # No rating value
+            is_favorite=True,
+        )
+        db_session.add(rating)
+        db_session.commit()
+
+        response = client.get(
+            f"/recipes/{test_recipe.id}/ratings",
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["average_rating"] is None  # No numeric ratings
+        assert data["rating_count"] == 0  # Count only rows with rating values
+        assert data["favorite_count"] == 1
+
+    def test_get_aggregate_ratings_mixed_null_ratings(self, client, auth_headers, test_recipe, test_user, test_user2, db_session):
+        """Test aggregate ratings with mix of null and numeric ratings."""
+        from src.db.models.user_recipe import UserRecipeRating
+
+        # User 1: numeric rating
+        rating1 = UserRecipeRating(
+            id=uuid4(),
+            user_id=test_user.id,
+            recipe_id=test_recipe.id,
+            rating=4.0,
+            is_favorite=False,
+        )
+
+        # User 2: favorite only (no rating)
+        rating2 = UserRecipeRating(
+            id=uuid4(),
+            user_id=test_user2.id,
+            recipe_id=test_recipe.id,
+            rating=None,
+            is_favorite=True,
+        )
+
+        db_session.add_all([rating1, rating2])
+        db_session.commit()
+
+        response = client.get(
+            f"/recipes/{test_recipe.id}/ratings",
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["average_rating"] == 4.0  # Only counts numeric ratings
+        assert data["rating_count"] == 1  # Only counts rows with rating values
+        assert data["favorite_count"] == 1  # User 2 favorited
+
+    def test_get_aggregate_ratings_recipe_not_found(self, client, auth_headers):
+        """Test aggregate ratings for non-existent recipe returns 404."""
+        fake_recipe_id = uuid4()
+        response = client.get(
+            f"/recipes/{fake_recipe_id}/ratings",
+            headers=auth_headers
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Recipe not found"
+
+    def test_get_aggregate_ratings_unauthenticated(self, client, test_recipe):
+        """Test aggregate ratings without auth returns 401."""
+        response = client.get(f"/recipes/{test_recipe.id}/ratings")
+
+        assert response.status_code == 401
+
+    def test_ratings_cross_user_isolation(self, client, auth_headers, auth_headers2, test_recipe, test_user, test_user2, db_session):
+        """Test that each user has separate ratings for the same recipe."""
+        from src.db.models.user_recipe import UserRecipeRating
+
+        # User 1 creates rating
+        rating_data = {
+            "rating": 3.0,
+            "is_favorite": False,
+            "notes": "User 1 note",
+        }
+        response = client.post(
+            f"/recipes/{test_recipe.id}/rate",
+            json=rating_data,
+            headers=auth_headers
+        )
+        assert response.status_code == 200
+
+        # User 2 creates different rating
+        rating_data2 = {
+            "rating": 5.0,
+            "is_favorite": True,
+            "notes": "User 2 note",
+        }
+        response = client.post(
+            f"/recipes/{test_recipe.id}/rate",
+            json=rating_data2,
+            headers=auth_headers2
+        )
+        assert response.status_code == 200
+
+        # User 1 gets their rating
+        response = client.get(
+            f"/recipes/{test_recipe.id}/my-rating",
+            headers=auth_headers
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["rating"] == 3.0
+        assert data["notes"] == "User 1 note"
+
+        # User 2 gets their rating
+        response = client.get(
+            f"/recipes/{test_recipe.id}/my-rating",
+            headers=auth_headers2
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["rating"] == 5.0
+        assert data["notes"] == "User 2 note"
+
+        # Verify two separate ratings exist in database
+        ratings = db_session.query(UserRecipeRating).filter(
+            UserRecipeRating.recipe_id == test_recipe.id
+        ).all()
+        assert len(ratings) == 2


### PR DESCRIPTION
## Work in Progress

Closes #127

[Phase 1E] Implement recipe ratings endpoints

**Time Estimate**: 1hr30min

**Description**:
[MULTI-USER] Add endpoints for per-user recipe ratings and favorites. Each user has their own rating/favorite status per recipe (user-scoped write), plus an aggregate endpoint to get average rating across all users (shared read).

**Claude Context**:
Files to Read:
- src/db/models/user_recipe.py (UserRecipeRating model)
- src/routers/recipes.py (recipes router to extend)
- src/schemas/inventory.py (pattern for Response schemas)

Files to Modify:
- src/routers/recipes.py (add rating endpoints)
- src/schemas/recipes.py (add UserRecipeRatingCreate/Response schemas)
- tests/routers/test_recipes.py (add rating tests)

Related Issues: After CRUD issue

**Acceptance Criteria**:
- [ ] UserRecipeRatingCreate schema: rating (Optional[float], 0-5), is_favorite (bool), notes (Optional[str])
- [ ] UserRecipeRatingResponse schema with all fields including id, user_id, recipe_id
- [ ] POST /recipes/{id}/rate creates or updates rating for current user (upsert behavior — one rating per user per recipe)
- [ ] GET /recipes/{id}/my-rating returns current user's rating for this recipe (404 if none exists)
- [ ] DELETE /recipes/{id}/my-rating removes current user's rating
- [ ] GET /recipes/{id}/ratings returns aggregate: average_rating, rating_count, favorite_count (shared read — visible to all)
- [ ] Rating value validated: 0.0 <= rating <= 5.0 (returns 422 if out of range)
- [ ] Aggregate endpoint handles recipes with no ratings (returns nulls or zeros appropriately)
- [ ] Tests cover: create rating, update existing rating (upsert), delete, aggregate calculation: `pytest tests/routers/test_recipes.py::TestRecipeRatings -v`

**Verification Commands**:
```bash
pytest tests/routers/test_recipes.py::TestRecipeRatings -v
```

**Done Definition**: Done when users can rate/favorite recipes and aggregate stats are available.

**Scope Boundary**:
- DO: Implement per-user rating CRUD (user-scoped writes)
- DO: Implement aggregate rating endpoint (average, counts)
- DO: Use upsert pattern for POST (create if not exists, update if exists)
- DO NOT: Include ratings in recipe list response (optimization deferred)
- DO NOT: Sort recipes by rating (Phase 3A suggestion engine)

**Dependencies**: After "[Phase 1E] Implement recipe CRUD endpoints" (can run in parallel with filtering and ingredients issues)

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**4** files, **2** commits (+0 added, ~4 modified, -0 deleted)
- `M` src/db/models/user_recipe.py
- `M` src/routers/recipes.py
- `M` src/schemas/recipe.py
- `M` tests/routers/test_recipes.py

### Commits
- d61eda6 feat: [Phase 1E] Implement recipe ratings endpoints
- 5c1b9e9 chore: initialize work on #127 [Phase 1E] Implement recipe ratings endpoints
<!-- /sharkrite-changes-summary -->