### PR TITLE
Add ad-hoc recipe creation from inventory

### DIFF
--- a/src/routers/recipes.py
+++ b/src/routers/recipes.py
@@ -24,6 +24,7 @@ from src.db.models.user import User
 from src.db.models.recipe import Recipe, SourceType
 from src.db.models.recipe_ingredient import RecipeIngredient
 from src.db.models.user_recipe import UserRecipeRating
+from src.db.models.inventory_item import InventoryItem
 from src.schemas.recipe import (
     RecipeCreate,
     RecipeUpdate,
@@ -35,6 +36,7 @@ from src.schemas.recipe import (
     UserRecipeRatingCreate,
     UserRecipeRatingResponse,
     RecipeAggregateRatingsResponse,
+    AdHocRecipeCreate,
 )
 from src.middleware.auth import get_current_user
 
@@ -101,6 +103,137 @@ def create_recipe(
     logger.info(
         f"Recipe created: user_id={current_user.id}, "
         f"recipe_id={new_recipe.id}"
+    )
+
+    return new_recipe
+
+
+@router.post("/ad-hoc", response_model=RecipeResponse, status_code=status.HTTP_201_CREATED)
+def create_ad_hoc_recipe(
+    recipe_data: AdHocRecipeCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Create an ad-hoc recipe from selected inventory items.
+
+    Users can create recipes directly from what they just cooked by selecting
+    ingredients from current inventory. Recipe ingredients are populated from
+    inventory item names (canonical names, not inventory IDs). Optionally
+    decrements inventory when the recipe is saved.
+
+    The entire operation is atomic — if any validation fails, no recipe is
+    created and no inventory is decremented. Validation occurs before any
+    mutations to ensure data consistency.
+
+    Args:
+        recipe_data: Ad-hoc recipe data (name, steps, notes, tags, inventory_items, decrement_inventory)
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        RecipeResponse: Created recipe with source_type="ad_hoc"
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If any inventory_item_id not found or not owned by current user
+        HTTPException(400): If decrement would result in negative quantity
+        HTTPException(422): If validation fails (empty inventory_items list, etc.)
+    """
+    # Phase 1: Validate inventory item ownership and existence
+    # Fetch all inventory items in a single query for efficiency
+    inventory_item_ids = [item.inventory_item_id for item in recipe_data.inventory_items]
+    inventory_items = (
+        db.query(InventoryItem)
+        .filter(
+            InventoryItem.id.in_(inventory_item_ids),
+            InventoryItem.added_by == current_user.id,
+        )
+        .all()
+    )
+
+    # Create a lookup map for quick access
+    inventory_map = {item.id: item for item in inventory_items}
+
+    # Validate all items exist and belong to current user
+    for item_usage in recipe_data.inventory_items:
+        if item_usage.inventory_item_id not in inventory_map:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Inventory item {item_usage.inventory_item_id} not found or not owned by user"
+            )
+
+    # Phase 2: Validate quantity sufficiency (if decrement is requested)
+    # This happens BEFORE any mutations to ensure atomicity
+    if recipe_data.decrement_inventory:
+        for item_usage in recipe_data.inventory_items:
+            inventory_item = inventory_map[item_usage.inventory_item_id]
+            new_quantity = inventory_item.quantity - item_usage.quantity_used
+
+            # Check if decrement would result in negative quantity
+            if new_quantity < 0:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Cannot use {item_usage.quantity_used} {item_usage.unit} of {inventory_item.name}. Only {inventory_item.quantity} {inventory_item.unit} available."
+                )
+
+    # Phase 3: Create recipe and optionally decrement inventory
+    # All validations passed — now perform mutations atomically
+    try:
+        # Create recipe with source_type="ad_hoc"
+        new_recipe = Recipe(
+            name=recipe_data.name,
+            source_type=SourceType.ad_hoc.value,
+            steps=recipe_data.steps,
+            notes=recipe_data.notes,
+            tags=recipe_data.tags,
+            created_by=current_user.id,
+        )
+        db.add(new_recipe)
+        db.flush()  # Generate recipe.id without committing
+
+        # Create recipe ingredients from inventory item names
+        for item_usage in recipe_data.inventory_items:
+            inventory_item = inventory_map[item_usage.inventory_item_id]
+
+            recipe_ingredient = RecipeIngredient(
+                recipe_id=new_recipe.id,
+                ingredient_name=inventory_item.name,  # Use canonical name from inventory
+                quantity=item_usage.quantity_used,
+                unit=item_usage.unit,
+            )
+            db.add(recipe_ingredient)
+
+        # Decrement inventory if requested
+        if recipe_data.decrement_inventory:
+            for item_usage in recipe_data.inventory_items:
+                inventory_item = inventory_map[item_usage.inventory_item_id]
+                inventory_item.quantity -= item_usage.quantity_used
+
+        # Commit all changes atomically
+        db.commit()
+        db.refresh(new_recipe)
+
+    except IntegrityError as e:
+        db.rollback()
+        logger.error(f"Integrity error during ad-hoc recipe creation for user {current_user.id}")
+        logger.debug(f"Integrity error occurred during ad-hoc recipe creation: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Ad-hoc recipe creation failed due to data integrity violation"
+        )
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during ad-hoc recipe creation for user {current_user.id}")
+        logger.debug(f"Database error occurred during ad-hoc recipe creation: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while creating the ad-hoc recipe"
+        )
+
+    logger.info(
+        f"Ad-hoc recipe created: user_id={current_user.id}, "
+        f"recipe_id={new_recipe.id}, decrement_inventory={recipe_data.decrement_inventory}"
     )
 
     return new_recipe

--- a/src/schemas/recipe.py
+++ b/src/schemas/recipe.py
@@ -252,3 +252,40 @@ class RecipeAggregateRatingsResponse(BaseModel):
     average_rating: Optional[float] = Field(default=None, description="Average rating across all users (null if no ratings)")
     rating_count: int = Field(..., description="Number of users who have rated this recipe")
     favorite_count: int = Field(..., description="Number of users who favorited this recipe")
+
+
+class InventoryItemUsage(BaseModel):
+    """Schema for inventory item usage in ad-hoc recipe creation."""
+
+    inventory_item_id: UUID = Field(..., description="ID of the inventory item to use")
+    quantity_used: float = Field(..., gt=0, description="Quantity to use from inventory (must be positive)")
+    unit: str = Field(..., min_length=1, max_length=50, description="Unit of measurement")
+
+    @field_validator('unit')
+    @classmethod
+    def strip_unit(cls, v: str) -> str:
+        """Strip whitespace from unit field."""
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("Unit cannot be empty or only whitespace")
+        return stripped
+
+
+class AdHocRecipeCreate(BaseModel):
+    """Request schema for creating an ad-hoc recipe from inventory items."""
+
+    name: str = Field(..., min_length=1, max_length=255, description="Recipe name")
+    steps: Optional[list] = Field(default_factory=list, description="Cooking steps (JSON array)")
+    notes: Optional[str] = Field(default=None, description="Recipe notes")
+    tags: Optional[list] = Field(default_factory=list, description="Recipe tags (JSON array)")
+    inventory_items: list[InventoryItemUsage] = Field(..., min_length=1, description="List of inventory items used in this recipe")
+    decrement_inventory: bool = Field(default=False, description="Whether to decrement inventory quantities")
+
+    @field_validator('name')
+    @classmethod
+    def strip_name(cls, v: str) -> str:
+        """Strip whitespace from name field."""
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("Name cannot be empty or only whitespace")
+        return stripped

--- a/src/schemas/recipe.py
+++ b/src/schemas/recipe.py
@@ -275,9 +275,9 @@ class AdHocRecipeCreate(BaseModel):
     """Request schema for creating an ad-hoc recipe from inventory items."""
 
     name: str = Field(..., min_length=1, max_length=255, description="Recipe name")
-    steps: Optional[list] = Field(default_factory=list, description="Cooking steps (JSON array)")
+    steps: Optional[list[str]] = Field(default_factory=list, description="Cooking steps (JSON array)")
     notes: Optional[str] = Field(default=None, description="Recipe notes")
-    tags: Optional[list] = Field(default_factory=list, description="Recipe tags (JSON array)")
+    tags: Optional[list[str]] = Field(default_factory=list, description="Recipe tags (JSON array)")
     inventory_items: list[InventoryItemUsage] = Field(..., min_length=1, description="List of inventory items used in this recipe")
     decrement_inventory: bool = Field(default=False, description="Whether to decrement inventory quantities")
 

--- a/tests/routers/test_recipes.py
+++ b/tests/routers/test_recipes.py
@@ -1650,3 +1650,363 @@ class TestRecipeRatings:
             UserRecipeRating.recipe_id == test_recipe.id
         ).all()
         assert len(ratings) == 2
+
+
+class TestAdHocRecipeCreation:
+    """Tests for POST /recipes/ad-hoc endpoint."""
+
+    def test_create_ad_hoc_recipe_without_decrement(self, client, db_session, auth_headers, test_user):
+        """Test creating an ad-hoc recipe from inventory items without decrementing inventory."""
+        from src.db.models.inventory_item import InventoryItem
+        from src.db.models.recipe_ingredient import RecipeIngredient
+
+        # Create inventory items
+        item1 = InventoryItem(
+            id=uuid4(),
+            name="Tomatoes",
+            quantity=10.0,
+            unit="oz",
+            category="produce",
+            storage_location="fridge",
+            added_by=test_user.id,
+        )
+        item2 = InventoryItem(
+            id=uuid4(),
+            name="Onions",
+            quantity=5.0,
+            unit="count",
+            category="produce",
+            storage_location="pantry",
+            added_by=test_user.id,
+        )
+        db_session.add_all([item1, item2])
+        db_session.commit()
+
+        # Create ad-hoc recipe
+        recipe_data = {
+            "name": "Quick Tomato Onion Soup",
+            "steps": ["Chop onions", "Dice tomatoes", "Simmer together"],
+            "notes": "Made this on the fly!",
+            "tags": ["quick", "soup"],
+            "inventory_items": [
+                {"inventory_item_id": str(item1.id), "quantity_used": 5.0, "unit": "oz"},
+                {"inventory_item_id": str(item2.id), "quantity_used": 2.0, "unit": "count"},
+            ],
+            "decrement_inventory": False,
+        }
+
+        response = client.post("/recipes/ad-hoc", json=recipe_data, headers=auth_headers)
+        assert response.status_code == 201
+        data = response.json()
+
+        # Verify recipe created with correct attributes
+        assert data["name"] == "Quick Tomato Onion Soup"
+        assert data["source_type"] == "ad_hoc"
+        assert data["created_by"] == str(test_user.id)
+        assert data["steps"] == ["Chop onions", "Dice tomatoes", "Simmer together"]
+        assert data["notes"] == "Made this on the fly!"
+        assert "quick" in data["tags"]
+        assert "soup" in data["tags"]
+
+        # Verify recipe ingredients were created with inventory item names
+        from uuid import UUID
+        recipe_id = UUID(data["id"])
+        ingredients = db_session.query(RecipeIngredient).filter(
+            RecipeIngredient.recipe_id == recipe_id
+        ).all()
+        assert len(ingredients) == 2
+
+        ingredient_names = {ing.ingredient_name for ing in ingredients}
+        assert "Tomatoes" in ingredient_names
+        assert "Onions" in ingredient_names
+
+        # Verify inventory NOT decremented (decrement_inventory=False)
+        db_session.refresh(item1)
+        db_session.refresh(item2)
+        assert item1.quantity == 10.0
+        assert item2.quantity == 5.0
+
+    def test_create_ad_hoc_recipe_with_decrement(self, client, db_session, auth_headers, test_user):
+        """Test creating an ad-hoc recipe with inventory decrement."""
+        from src.db.models.inventory_item import InventoryItem
+        from src.db.models.recipe_ingredient import RecipeIngredient
+
+        # Create inventory items
+        item1 = InventoryItem(
+            id=uuid4(),
+            name="Pasta",
+            quantity=16.0,
+            unit="oz",
+            category="grain",
+            storage_location="pantry",
+            added_by=test_user.id,
+        )
+        item2 = InventoryItem(
+            id=uuid4(),
+            name="Marinara Sauce",
+            quantity=24.0,
+            unit="oz",
+            category="condiment",
+            storage_location="pantry",
+            added_by=test_user.id,
+        )
+        db_session.add_all([item1, item2])
+        db_session.commit()
+
+        # Create ad-hoc recipe with decrement
+        recipe_data = {
+            "name": "Simple Pasta Marinara",
+            "steps": ["Boil pasta", "Heat sauce", "Combine"],
+            "inventory_items": [
+                {"inventory_item_id": str(item1.id), "quantity_used": 8.0, "unit": "oz"},
+                {"inventory_item_id": str(item2.id), "quantity_used": 12.0, "unit": "oz"},
+            ],
+            "decrement_inventory": True,
+        }
+
+        response = client.post("/recipes/ad-hoc", json=recipe_data, headers=auth_headers)
+        assert response.status_code == 201
+        data = response.json()
+
+        # Verify recipe created
+        assert data["name"] == "Simple Pasta Marinara"
+        assert data["source_type"] == "ad_hoc"
+
+        # Verify recipe ingredients created
+        from uuid import UUID
+        recipe_id = UUID(data["id"])
+        ingredients = db_session.query(RecipeIngredient).filter(
+            RecipeIngredient.recipe_id == recipe_id
+        ).all()
+        assert len(ingredients) == 2
+
+        # Verify inventory WAS decremented (decrement_inventory=True)
+        db_session.refresh(item1)
+        db_session.refresh(item2)
+        assert item1.quantity == 8.0  # 16.0 - 8.0
+        assert item2.quantity == 12.0  # 24.0 - 12.0
+
+    def test_create_ad_hoc_recipe_invalid_inventory_id(self, client, auth_headers):
+        """Test creating ad-hoc recipe with invalid inventory item ID returns 404."""
+        fake_id = uuid4()
+
+        recipe_data = {
+            "name": "Ghost Recipe",
+            "inventory_items": [
+                {"inventory_item_id": str(fake_id), "quantity_used": 1.0, "unit": "oz"},
+            ],
+            "decrement_inventory": False,
+        }
+
+        response = client.post("/recipes/ad-hoc", json=recipe_data, headers=auth_headers)
+        assert response.status_code == 404
+        assert "not found or not owned by user" in response.json()["detail"]
+
+    def test_create_ad_hoc_recipe_cross_user_inventory_access_blocked(
+        self, client, db_session, auth_headers, test_user
+    ):
+        """Test that users cannot create ad-hoc recipes from other users' inventory items."""
+        from src.db.models.inventory_item import InventoryItem
+
+        # Create another user
+        other_user = User(
+            id=uuid4(),
+            name="Other User",
+            email="other@example.com",
+            hashed_password=hash_password("password123"),
+            role=UserRole.member.value,
+        )
+        db_session.add(other_user)
+
+        # Create inventory item owned by other user
+        other_item = InventoryItem(
+            id=uuid4(),
+            name="Secret Ingredient",
+            quantity=10.0,
+            unit="oz",
+            category="other",
+            storage_location="pantry",
+            added_by=other_user.id,
+        )
+        db_session.add(other_item)
+        db_session.commit()
+
+        # Try to create ad-hoc recipe using other user's inventory
+        recipe_data = {
+            "name": "Stolen Recipe",
+            "inventory_items": [
+                {"inventory_item_id": str(other_item.id), "quantity_used": 5.0, "unit": "oz"},
+            ],
+            "decrement_inventory": False,
+        }
+
+        response = client.post("/recipes/ad-hoc", json=recipe_data, headers=auth_headers)
+        assert response.status_code == 404
+        assert "not found or not owned by user" in response.json()["detail"]
+
+    def test_create_ad_hoc_recipe_insufficient_quantity(self, client, db_session, auth_headers, test_user):
+        """Test creating ad-hoc recipe with insufficient inventory quantity returns 400."""
+        from src.db.models.inventory_item import InventoryItem
+
+        # Create inventory item with limited quantity
+        item = InventoryItem(
+            id=uuid4(),
+            name="Rare Spice",
+            quantity=2.0,
+            unit="tsp",
+            category="spice",
+            storage_location="pantry",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        # Try to use more than available
+        recipe_data = {
+            "name": "Spicy Disaster",
+            "inventory_items": [
+                {"inventory_item_id": str(item.id), "quantity_used": 5.0, "unit": "tsp"},
+            ],
+            "decrement_inventory": True,  # Decrement is required to trigger validation
+        }
+
+        response = client.post("/recipes/ad-hoc", json=recipe_data, headers=auth_headers)
+        assert response.status_code == 400
+        assert "Only 2.0 tsp available" in response.json()["detail"]
+
+        # Verify inventory was NOT decremented (atomic rollback)
+        db_session.refresh(item)
+        assert item.quantity == 2.0
+
+    def test_create_ad_hoc_recipe_atomic_rollback_on_error(
+        self, client, db_session, auth_headers, test_user
+    ):
+        """Test that ad-hoc recipe creation is atomic - if validation fails, nothing is created."""
+        from src.db.models.inventory_item import InventoryItem
+        from src.db.models.recipe import Recipe
+        from src.db.models.recipe_ingredient import RecipeIngredient
+
+        # Create two inventory items
+        item1 = InventoryItem(
+            id=uuid4(),
+            name="Item A",
+            quantity=10.0,
+            unit="oz",
+            category="other",
+            storage_location="pantry",
+            added_by=test_user.id,
+        )
+        item2 = InventoryItem(
+            id=uuid4(),
+            name="Item B",
+            quantity=2.0,  # Intentionally low
+            unit="oz",
+            category="other",
+            storage_location="pantry",
+            added_by=test_user.id,
+        )
+        db_session.add_all([item1, item2])
+        db_session.commit()
+
+        # Count recipes and ingredients before
+        recipe_count_before = db_session.query(Recipe).count()
+        ingredient_count_before = db_session.query(RecipeIngredient).count()
+
+        # Try to create recipe that will fail on second item quantity check
+        recipe_data = {
+            "name": "Atomic Test Recipe",
+            "inventory_items": [
+                {"inventory_item_id": str(item1.id), "quantity_used": 5.0, "unit": "oz"},
+                {"inventory_item_id": str(item2.id), "quantity_used": 10.0, "unit": "oz"},  # Too much!
+            ],
+            "decrement_inventory": True,
+        }
+
+        response = client.post("/recipes/ad-hoc", json=recipe_data, headers=auth_headers)
+        assert response.status_code == 400
+
+        # Verify NO recipe was created
+        recipe_count_after = db_session.query(Recipe).count()
+        assert recipe_count_after == recipe_count_before
+
+        # Verify NO ingredients were created
+        ingredient_count_after = db_session.query(RecipeIngredient).count()
+        assert ingredient_count_after == ingredient_count_before
+
+        # Verify NO inventory was decremented
+        db_session.refresh(item1)
+        db_session.refresh(item2)
+        assert item1.quantity == 10.0
+        assert item2.quantity == 2.0
+
+    def test_create_ad_hoc_recipe_empty_inventory_items_validation(self, client, auth_headers):
+        """Test that empty inventory_items list is rejected by validation."""
+        recipe_data = {
+            "name": "Empty Recipe",
+            "inventory_items": [],  # Empty list
+            "decrement_inventory": False,
+        }
+
+        response = client.post("/recipes/ad-hoc", json=recipe_data, headers=auth_headers)
+        assert response.status_code == 422  # Validation error
+        assert "inventory_items" in response.json()["detail"][0]["loc"]
+
+    def test_create_ad_hoc_recipe_unauthenticated(self, client):
+        """Test that unauthenticated requests are rejected."""
+        recipe_data = {
+            "name": "Unauthorized Recipe",
+            "inventory_items": [
+                {"inventory_item_id": str(uuid4()), "quantity_used": 1.0, "unit": "oz"},
+            ],
+        }
+
+        response = client.post("/recipes/ad-hoc", json=recipe_data)
+        assert response.status_code == 401
+
+    def test_create_ad_hoc_recipe_with_multiple_items(self, client, db_session, auth_headers, test_user):
+        """Test creating ad-hoc recipe with multiple inventory items."""
+        from src.db.models.inventory_item import InventoryItem
+        from src.db.models.recipe_ingredient import RecipeIngredient
+
+        # Create multiple inventory items
+        items = [
+            InventoryItem(
+                id=uuid4(),
+                name=f"Ingredient {i}",
+                quantity=100.0,
+                unit="g",
+                category="other",
+                storage_location="pantry",
+                added_by=test_user.id,
+            )
+            for i in range(5)
+        ]
+        db_session.add_all(items)
+        db_session.commit()
+
+        # Create recipe using all items
+        recipe_data = {
+            "name": "Complex Multi-Ingredient Recipe",
+            "inventory_items": [
+                {"inventory_item_id": str(item.id), "quantity_used": 20.0, "unit": "g"}
+                for item in items
+            ],
+            "decrement_inventory": True,
+        }
+
+        response = client.post("/recipes/ad-hoc", json=recipe_data, headers=auth_headers)
+        assert response.status_code == 201
+        data = response.json()
+
+        # Verify all ingredients were added
+        from uuid import UUID
+        recipe_id = UUID(data["id"])
+        ingredients = db_session.query(RecipeIngredient).filter(
+            RecipeIngredient.recipe_id == recipe_id
+        ).all()
+        assert len(ingredients) == 5
+
+        # Verify all inventory was decremented correctly
+        for item in items:
+            db_session.refresh(item)
+            assert item.quantity == 80.0  # 100.0 - 20.0


### PR DESCRIPTION
## Work in Progress

Closes #128

Add ad-hoc recipe creation from inventory

**Time Estimate**: 2hr

**Description**:
[CROSS-DOMAIN] Implement the ad-hoc recipe creation flow where users can create a recipe from selected inventory items, optionally decrementing inventory when the recipe is saved. This touches both inventory and recipe domains.

**Claude Context**:
Files to Read:
- src/routers/recipes.py (recipe creation pattern)
- src/routers/inventory.py (inventory decrement pattern from consume endpoint)
- src/db/models/inventory_item.py (InventoryItem model)
- src/db/models/recipe.py (Recipe model — source_type: ad_hoc)
- docs/FreshUp-ADR.md (Section 5.5: Ad-Hoc Recipe Creation from Inventory)

Files to Modify:
- src/routers/recipes.py (add POST /recipes/ad-hoc endpoint)
- src/schemas/recipes.py (add AdHocRecipeCreate schema)
- tests/routers/test_recipes.py (add ad-hoc creation tests)

Related Issues: After CRUD issue

**Acceptance Criteria**:
- [ ] AdHocRecipeCreate schema: name, steps, notes, tags, inventory_items (list of {inventory_item_id, quantity_used, unit}), decrement_inventory (bool, default: false)
- [ ] POST /recipes/ad-hoc creates recipe with source_type="ad_hoc" and created_by=current_user
- [ ] Recipe ingredients are populated from inventory item names (not inventory IDs — ingredients are canonical names)
- [ ] If decrement_inventory=true, each referenced inventory item's quantity is decremented by quantity_used
- [ ] Returns 404 if any inventory_item_id not found or not owned by current user
- [ ] Returns 400 if decrement would result in negative quantity (validate before any mutations)
- [ ] Entire operation is atomic — if any validation fails, no recipe created and no inventory decremented
- [ ] Tests cover: happy path, invalid inventory ID, insufficient quantity, atomic rollback: `pytest tests/routers/test_recipes.py::TestAdHocRecipeCreation -v`

**Verification Commands**:
```bash
pytest tests/routers/test_recipes.py::TestAdHocRecipeCreation -v
```

**Done Definition**: Done when ad-hoc recipes can be created from inventory with optional decrement and atomicity is enforced.

**Scope Boundary**:
- DO: Create POST /recipes/ad-hoc with inventory integration
- DO: Implement atomic transaction for recipe creation + inventory decrement
- DO: Validate inventory ownership and quantity before mutations
- DO NOT: Auto-suggest ingredients based on inventory (Phase 3A)
- DO NOT: Match inventory items to existing recipes (Phase 3A)
- DO NOT: Support external ingredients in ad-hoc flow (keep simple — all ingredients from inventory)

**Dependencies**: After "[Phase 1E] Implement recipe CRUD endpoints" (can run in parallel with filtering, ingredients, and ratings issues)

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **2** commits (+0 added, ~3 modified, -0 deleted)
- `M` src/routers/recipes.py
- `M` src/schemas/recipe.py
- `M` tests/routers/test_recipes.py

### Commits
- 665dffb feat: Add ad-hoc recipe creation from inventory
- 9fefb2a chore: initialize work on #128 Add ad-hoc recipe creation from inventory
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues
Created: #141 
**From assessment on 2026-03-20T00:18:42Z:**
- Created: none
- Updated: #134 