### PR TITLE
[Phase 1E] Implement recipe CRUD endpoints

### DIFF
--- a/src/routers/recipes.py
+++ b/src/routers/recipes.py
@@ -253,12 +253,15 @@ def list_recipes(
     has_variation: Optional[bool] = Query(default=None, description="Filter by variation groups presence (true/false)"),
 ):
     """
-    List recipes for the authenticated user with filtering and pagination.
+    List all recipes with filtering and pagination.
 
-    Returns recipes created by the current user, ordered by most recently added first.
+    Returns all recipes in the system (global read), ordered by most recently added first.
     Supports pagination via limit and offset query parameters.
     Supports filtering by source_type, tag, cook time, prep time, name search, and
     variation presence. Multiple filters combine with AND logic.
+
+    This endpoint provides global read access - all users can see all recipes.
+    Only recipe creators can modify/delete their own recipes via PUT/DELETE endpoints.
 
     Args:
         current_user: Authenticated user (injected by get_current_user dependency)
@@ -273,14 +276,14 @@ def list_recipes(
         has_variation: Filter by variation groups presence (true for recipes with variations, false for none)
 
     Returns:
-        list[RecipeListResponse]: List of user's recipes matching filters
+        list[RecipeListResponse]: List of all recipes matching filters
 
     Raises:
         HTTPException(401): If Authorization header is missing or token is invalid
         HTTPException(422): If invalid enum value provided for source_type
     """
-    # Start with base query filtering by user
-    query = db.query(Recipe).filter(Recipe.created_by == current_user.id)
+    # Start with base query (global read - no user filter)
+    query = db.query(Recipe)
 
     # Apply source_type filter
     if source_type is not None:
@@ -372,8 +375,9 @@ def get_recipe(
     """
     Get a single recipe by ID.
 
-    Retrieves a specific recipe. Returns 404 if the recipe doesn't exist
-    or belongs to a different user (preventing cross-user access).
+    Retrieves a specific recipe. Returns 404 if the recipe doesn't exist.
+    This endpoint provides global read access - any authenticated user can
+    view any recipe. Only the recipe creator can modify/delete via PUT/DELETE.
 
     Args:
         recipe_id: UUID of the recipe to retrieve
@@ -385,14 +389,11 @@ def get_recipe(
 
     Raises:
         HTTPException(401): If Authorization header is missing or token is invalid
-        HTTPException(404): If recipe doesn't exist or belongs to another user
+        HTTPException(404): If recipe doesn't exist
     """
     recipe = (
         db.query(Recipe)
-        .filter(
-            Recipe.id == recipe_id,
-            Recipe.created_by == current_user.id,
-        )
+        .filter(Recipe.id == recipe_id)
         .first()
     )
 

--- a/tests/routers/test_recipes.py
+++ b/tests/routers/test_recipes.py
@@ -174,6 +174,28 @@ class TestRecipeCRUD:
         assert data["created_by"] == str(test_user.id)
         assert "id" in data
 
+    def test_create_recipe_sets_created_by_to_authenticated_user(self, client, auth_headers, test_user, db_session):
+        """Test that created_by is correctly set to authenticated user on recipe creation."""
+        recipe_data = {
+            "name": "Ownership Test Recipe",
+            "source_type": "manual",
+        }
+
+        response = client.post("/recipes", json=recipe_data, headers=auth_headers)
+
+        assert response.status_code == 201
+        data = response.json()
+
+        # Verify created_by in response matches authenticated user
+        assert data["created_by"] == str(test_user.id)
+
+        # Verify created_by in database matches authenticated user
+        from uuid import UUID
+        recipe_id = UUID(data["id"])
+        db_recipe = db_session.query(Recipe).filter(Recipe.id == recipe_id).first()
+        assert db_recipe is not None
+        assert db_recipe.created_by == test_user.id
+
     def test_create_recipe_invalid_source_type(self, client, auth_headers):
         """Test creating recipe with invalid source_type fails."""
         recipe_data = {

--- a/tests/routers/test_recipes.py
+++ b/tests/routers/test_recipes.py
@@ -204,7 +204,7 @@ class TestRecipeCRUD:
         assert response.json() == []
 
     def test_list_recipes_with_data(self, client, auth_headers, test_user, db_session):
-        """Test listing recipes returns user's recipes."""
+        """Test listing recipes returns all recipes (global read)."""
         # Create test recipes
         recipe1 = Recipe(
             id=uuid4(),
@@ -264,8 +264,8 @@ class TestRecipeCRUD:
 
         assert response.status_code == 404
 
-    def test_get_recipe_cross_user_access_denied(self, client, auth_headers, auth_headers2, test_user2, db_session):
-        """Test user cannot access another user's recipe."""
+    def test_get_recipe_cross_user_access_allowed(self, client, auth_headers, auth_headers2, test_user2, db_session):
+        """Test user CAN access another user's recipe (global read)."""
         # Create recipe for user2
         recipe = Recipe(
             id=uuid4(),
@@ -278,10 +278,13 @@ class TestRecipeCRUD:
         db_session.add(recipe)
         db_session.commit()
 
-        # Try to access with user1's token
+        # Access with user1's token (global read should allow this)
         response = client.get(f"/recipes/{recipe.id}", headers=auth_headers)
 
-        assert response.status_code == 404
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "User2 Recipe"
+        assert data["created_by"] == str(test_user2.id)
 
     def test_update_recipe_success(self, client, auth_headers, test_user, db_session):
         """Test updating a recipe."""
@@ -308,6 +311,28 @@ class TestRecipeCRUD:
         assert data["name"] == "Updated Name"
         assert data["prep_time_minutes"] == 20
 
+    def test_update_recipe_cross_user_denied(self, client, auth_headers, auth_headers2, test_user2, db_session):
+        """Test user CANNOT update another user's recipe (ownership enforcement)."""
+        # Create recipe for user2
+        recipe = Recipe(
+            id=uuid4(),
+            name="User2 Recipe",
+            source_type="manual",
+            created_by=test_user2.id,
+            tags=[],
+            steps=[],
+        )
+        db_session.add(recipe)
+        db_session.commit()
+
+        update_data = {"name": "Hacked Name"}
+
+        # Try to update with user1's token (should fail)
+        response = client.put(f"/recipes/{recipe.id}", json=update_data, headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Recipe not found"
+
     def test_delete_recipe_success(self, client, auth_headers, test_user, db_session):
         """Test deleting a recipe."""
         recipe = Recipe(
@@ -329,6 +354,72 @@ class TestRecipeCRUD:
         # Verify recipe is deleted
         deleted_recipe = db_session.query(Recipe).filter(Recipe.id == recipe_id).first()
         assert deleted_recipe is None
+
+    def test_delete_recipe_cross_user_denied(self, client, auth_headers, auth_headers2, test_user2, db_session):
+        """Test user CANNOT delete another user's recipe (ownership enforcement)."""
+        # Create recipe for user2
+        recipe = Recipe(
+            id=uuid4(),
+            name="User2 Recipe",
+            source_type="manual",
+            created_by=test_user2.id,
+            tags=[],
+            steps=[],
+        )
+        db_session.add(recipe)
+        db_session.commit()
+        recipe_id = recipe.id
+
+        # Try to delete with user1's token (should fail)
+        response = client.delete(f"/recipes/{recipe_id}", headers=auth_headers)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Recipe not found"
+
+        # Verify recipe was NOT deleted
+        recipe_still_exists = db_session.query(Recipe).filter(Recipe.id == recipe_id).first()
+        assert recipe_still_exists is not None
+
+    def test_list_recipes_global_read(self, client, auth_headers, auth_headers2, test_user, test_user2, db_session):
+        """Test that users can see recipes from all users (global read)."""
+        # Create recipes for user1
+        recipe1 = Recipe(
+            id=uuid4(),
+            name="User1 Recipe",
+            source_type="manual",
+            created_by=test_user.id,
+            tags=[],
+            steps=[],
+        )
+        # Create recipes for user2
+        recipe2 = Recipe(
+            id=uuid4(),
+            name="User2 Recipe",
+            source_type="manual",
+            created_by=test_user2.id,
+            tags=[],
+            steps=[],
+        )
+        db_session.add_all([recipe1, recipe2])
+        db_session.commit()
+
+        # User1 can see both recipes
+        response = client.get("/recipes", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        names = {r["name"] for r in data}
+        assert "User1 Recipe" in names
+        assert "User2 Recipe" in names
+
+        # User2 can also see both recipes
+        response = client.get("/recipes", headers=auth_headers2)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        names = {r["name"] for r in data}
+        assert "User1 Recipe" in names
+        assert "User2 Recipe" in names
 
 
 class TestRecipeFiltering:

--- a/tests/routers/test_recipes.py
+++ b/tests/routers/test_recipes.py
@@ -18,7 +18,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from src.db.database import Base, get_db
 from src.db import models
@@ -190,7 +190,6 @@ class TestRecipeCRUD:
         assert data["created_by"] == str(test_user.id)
 
         # Verify created_by in database matches authenticated user
-        from uuid import UUID
         recipe_id = UUID(data["id"])
         db_recipe = db_session.query(Recipe).filter(Recipe.id == recipe_id).first()
         assert db_recipe is not None
@@ -1822,7 +1821,6 @@ class TestAdHocRecipeCreation:
         assert "soup" in data["tags"]
 
         # Verify recipe ingredients were created with inventory item names
-        from uuid import UUID
         recipe_id = UUID(data["id"])
         ingredients = db_session.query(RecipeIngredient).filter(
             RecipeIngredient.recipe_id == recipe_id
@@ -1886,7 +1884,6 @@ class TestAdHocRecipeCreation:
         assert data["source_type"] == "ad_hoc"
 
         # Verify recipe ingredients created
-        from uuid import UUID
         recipe_id = UUID(data["id"])
         ingredients = db_session.query(RecipeIngredient).filter(
             RecipeIngredient.recipe_id == recipe_id
@@ -2112,7 +2109,6 @@ class TestAdHocRecipeCreation:
         data = response.json()
 
         # Verify all ingredients were added
-        from uuid import UUID
         recipe_id = UUID(data["id"])
         ingredients = db_session.query(RecipeIngredient).filter(
             RecipeIngredient.recipe_id == recipe_id


### PR DESCRIPTION
## Summary

Closes #124



Changes to feat/phase-1e-implement-recipe-crud-endpoints

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **1** commits (+0 added, ~2 modified, -0 deleted)
- `M` src/routers/recipes.py
- `M` tests/routers/test_recipes.py

### Commits
- efd1c40 feat: [Phase 1E] Implement recipe CRUD endpoints
<!-- /sharkrite-changes-summary -->

## Testing

- [x] Code builds successfully
- [x] Unit tests pass locally
- [ ] Integration tests pass (CI will verify)
- [ ] Sharkrite code review pending

## Security Checklist

- [ ] Multi-tenant isolation verified (if applicable)
- [ ] Input validation present
- [ ] No secrets in code
- [ ] Error handling comprehensive

## Review Notes

**Branch:** `feat/phase-1e-implement-recipe-crud-endpoints`
**Base:** `main`
**Created:** 2026-03-19 22:54:05