### PR TITLE
Consider adding Unicode normalization to

### DIFF
--- a/src/schemas/recipe.py
+++ b/src/schemas/recipe.py
@@ -9,7 +9,7 @@ from typing import Optional
 from pydantic import BaseModel, Field, field_validator, ConfigDict
 
 from src.db.models.recipe import SourceType
-from src.schemas.validators import validate_enum_value, validate_non_negative
+from src.schemas.validators import validate_enum_value, validate_non_negative, validate_name_not_empty
 
 
 class RecipeCreate(BaseModel):
@@ -30,6 +30,13 @@ class RecipeCreate(BaseModel):
     nutritional_info: Optional[dict] = Field(default=None, description="Nutritional information (JSON)")
     notes: Optional[str] = Field(default=None, description="Recipe notes")
     created_by: Optional[UUID] = Field(default=None, description="User ID who created the recipe")
+
+    @field_validator('name')
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        """Ensure name is not empty and apply Unicode normalization."""
+        result = validate_name_not_empty(v)
+        return result  # type: ignore
 
     @field_validator('source_type')
     @classmethod
@@ -74,6 +81,12 @@ class RecipeUpdate(BaseModel):
     tags: Optional[list] = Field(default=None, description="Recipe tags (JSON array)")
     nutritional_info: Optional[dict] = Field(default=None, description="Nutritional information (JSON)")
     notes: Optional[str] = Field(default=None, description="Recipe notes")
+
+    @field_validator('name')
+    @classmethod
+    def validate_name(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure name is not empty and apply Unicode normalization if provided."""
+        return validate_name_not_empty(v)
 
     @field_validator('source_type')
     @classmethod
@@ -283,9 +296,7 @@ class AdHocRecipeCreate(BaseModel):
 
     @field_validator('name')
     @classmethod
-    def strip_name(cls, v: str) -> str:
-        """Strip whitespace from name field."""
-        stripped = v.strip()
-        if not stripped:
-            raise ValueError("Name cannot be empty or only whitespace")
-        return stripped
+    def validate_name(cls, v: str) -> str:
+        """Ensure name is not empty and apply Unicode normalization."""
+        result = validate_name_not_empty(v)
+        return result  # type: ignore

--- a/src/schemas/validators.py
+++ b/src/schemas/validators.py
@@ -201,9 +201,9 @@ def validate_name_not_empty(value: Optional[str], strip: bool = True) -> Optiona
         raise ValueError('Name cannot be empty')
 
     # Normalize to NFC form for consistent Unicode representation
-    normalized = unicodedata.normalize('NFC', value.strip())
-
-    return normalized if strip else unicodedata.normalize('NFC', value)
+    # Strip whitespace only if requested
+    to_normalize = value.strip() if strip else value
+    return unicodedata.normalize('NFC', to_normalize)
 
 
 def validate_enum_value(

--- a/src/schemas/validators.py
+++ b/src/schemas/validators.py
@@ -181,12 +181,15 @@ def validate_name_not_empty(value: Optional[str], strip: bool = True) -> Optiona
     """
     Validate that a name field is not empty or whitespace-only.
 
+    Normalizes Unicode to NFC form to prevent duplicate names with different
+    Unicode representations (e.g., "café" with composed vs decomposed accents).
+
     Args:
         value: The name to validate
         strip: Whether to strip whitespace from the result (default: True)
 
     Returns:
-        Stripped name if valid, or None if input was None
+        Stripped and NFC-normalized name if valid, or None if input was None
 
     Raises:
         ValueError: If name is empty or whitespace-only
@@ -197,7 +200,10 @@ def validate_name_not_empty(value: Optional[str], strip: bool = True) -> Optiona
     if not value or not value.strip():
         raise ValueError('Name cannot be empty')
 
-    return value.strip() if strip else value
+    # Normalize to NFC form for consistent Unicode representation
+    normalized = unicodedata.normalize('NFC', value.strip())
+
+    return normalized if strip else unicodedata.normalize('NFC', value)
 
 
 def validate_enum_value(

--- a/tests/schemas/test_validators.py
+++ b/tests/schemas/test_validators.py
@@ -53,6 +53,52 @@ class TestValidateNameNotEmpty:
         result = validate_name_not_empty("A")
         assert result == "A"
 
+    def test_unicode_normalization_nfc(self):
+        """Test that Unicode is normalized to NFC form."""
+        # "café" with decomposed é (U+0065 U+0301)
+        decomposed = "cafe\u0301"
+        # "café" with composed é (U+00E9)
+        composed = "caf\u00e9"
+
+        result = validate_name_not_empty(decomposed)
+        # Result should be normalized to composed form (NFC)
+        assert result == composed
+        assert result == "café"
+
+    def test_unicode_normalization_with_multiple_accents(self):
+        """Test normalization with multiple accented characters."""
+        # "crème fraîche" with decomposed accents
+        decomposed = "cre\u0300me frai\u0302che"
+        # "crème fraîche" with composed accents
+        composed = "cr\u00e8me fra\u00eeche"
+
+        result = validate_name_not_empty(decomposed)
+        assert result == composed
+        assert result == "crème fraîche"
+
+    def test_unicode_normalization_preserves_non_latin(self):
+        """Test that normalization works with non-Latin scripts."""
+        # Japanese characters (should be unaffected by NFC as they're already normalized)
+        japanese = "寿司"
+        result = validate_name_not_empty(japanese)
+        assert result == japanese
+
+        # Arabic characters
+        arabic = "مرحبا"
+        result = validate_name_not_empty(arabic)
+        assert result == arabic
+
+    def test_unicode_normalization_without_strip(self):
+        """Test that normalization works when strip=False."""
+        # "café" with decomposed é and surrounding whitespace
+        decomposed = "  cafe\u0301  "
+        composed = "caf\u00e9"
+
+        result = validate_name_not_empty(decomposed, strip=False)
+        # Should normalize but preserve original spacing (not strip)
+        assert result == f"  {composed}  "
+        assert result == "  café  "
+
 
 class TestValidateEnumValue:
     """Tests for validate_enum_value function."""


### PR DESCRIPTION
## Work in Progress

Closes #122

Consider adding Unicode normalization to

<!-- sharkrite-source-issue:86 -->## From PR #115 Assessment

**Severity:** LOW
**Category:** CodeQuality

## Issue
This is a real functional inconsistency where `validate_ingredient_name` applies NFC normalization but `validate_name_not_empty` does not. This could lead to duplicate name issues with different Unicode representations. However, adding Unicode normalization is a behavioral change that could affect existing data.

## Context
The original scope was consolidating duplicate logic, not adding new normalization behavior. This is a valid improvement for consistency but requires careful consideration of existing data.

## Defer Reason
Scope exceeds time budget - adding normalization is a behavioral change requiring data impact analysis

---
_Created by Sharkrite assessment on 2026-03-19T21:27:41Z_
_Parent PR: #115_

---

## Additional Assessment (PR #120)

**Severity:** LOW
**Reasoning:** This is a valid operational improvement but is outside the original issue scope of adding rate limiting to the switch-user endpoint. It requires designing a new endpoint/API surface.
**Context:** The original issue was to add rate limiting, not to add observability infrastructure. This is a real, useful enhancement that should be tracked separately.
**Defer Reason:** Scope exceeds time budget - requires designing new health check endpoint pattern

_Added by Sharkrite on 2026-03-19T22:42:50Z_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **2** commits (+0 added, ~3 modified, -0 deleted)
- `M` src/schemas/recipe.py
- `M` src/schemas/validators.py
- `M` tests/schemas/test_validators.py

### Commits
- bd40a38 feat: Consider adding Unicode normalization to
- baa1558 chore: initialize work on #122 Consider adding Unicode normalization to
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues
 Updated: #148 
**From assessment on 2026-03-21T00:57:39Z:**
- Created: #148 
- Updated: none