### PR TITLE
Validate tags and steps list contents

### DIFF
--- a/src/schemas/recipe.py
+++ b/src/schemas/recipe.py
@@ -9,7 +9,7 @@ from typing import Optional
 from pydantic import BaseModel, Field, field_validator, ConfigDict
 
 from src.db.models.recipe import SourceType
-from src.schemas.validators import validate_enum_value, validate_non_negative, validate_name_not_empty
+from src.schemas.validators import validate_enum_value, validate_non_negative, validate_name_not_empty, validate_string_list
 
 
 class RecipeCreate(BaseModel):
@@ -22,11 +22,11 @@ class RecipeCreate(BaseModel):
     source_url: Optional[str] = Field(default=None, max_length=2048, description="Source URL")
     source_image: Optional[str] = Field(default=None, max_length=2048, description="Source image URL")
     variation_groups: Optional[dict] = Field(default=None, description="Variation groups (JSON)")
-    steps: Optional[list] = Field(default_factory=list, description="Cooking steps (JSON)")
+    steps: Optional[list[str]] = Field(default_factory=list, description="Cooking steps (JSON array)")
     prep_time_minutes: Optional[int] = Field(default=None, description="Preparation time in minutes")
     cook_time_minutes: Optional[int] = Field(default=None, description="Cooking time in minutes")
     base_servings: Optional[int] = Field(default=4, description="Base number of servings")
-    tags: Optional[list] = Field(default_factory=list, description="Recipe tags (JSON array)")
+    tags: Optional[list[str]] = Field(default_factory=list, description="Recipe tags (JSON array)")
     nutritional_info: Optional[dict] = Field(default=None, description="Nutritional information (JSON)")
     notes: Optional[str] = Field(default=None, max_length=10000, description="Recipe notes")
     created_by: Optional[UUID] = Field(default=None, description="User ID who created the recipe")
@@ -65,6 +65,22 @@ class RecipeCreate(BaseModel):
             raise ValueError("base_servings must be positive")
         return v
 
+    @field_validator('tags', 'steps')
+    @classmethod
+    def validate_string_lists(cls, v: Optional[list[str]], info) -> Optional[list[str]]:
+        """
+        Validate tags and steps lists for length and character constraints.
+
+        Ensures data quality by enforcing maximum item length, maximum list size,
+        and allowed character constraints. Uses validate_string_list which:
+        - Strips whitespace and filters out empty strings
+        - Normalizes Unicode to NFC form
+        - Blocks dangerous Unicode characters
+        - Allows letters, numbers, and common punctuation
+        """
+        field_name = info.field_name
+        return validate_string_list(field_name, v)
+
 
 class RecipeUpdate(BaseModel):
     """Request schema for updating a recipe (partial updates allowed)."""
@@ -74,11 +90,11 @@ class RecipeUpdate(BaseModel):
     source_url: Optional[str] = Field(default=None, max_length=2048, description="Source URL")
     source_image: Optional[str] = Field(default=None, max_length=2048, description="Source image URL")
     variation_groups: Optional[dict] = Field(default=None, description="Variation groups (JSON)")
-    steps: Optional[list] = Field(default=None, description="Cooking steps (JSON)")
+    steps: Optional[list[str]] = Field(default=None, description="Cooking steps (JSON array)")
     prep_time_minutes: Optional[int] = Field(default=None, description="Preparation time in minutes")
     cook_time_minutes: Optional[int] = Field(default=None, description="Cooking time in minutes")
     base_servings: Optional[int] = Field(default=None, description="Base number of servings")
-    tags: Optional[list] = Field(default=None, description="Recipe tags (JSON array)")
+    tags: Optional[list[str]] = Field(default=None, description="Recipe tags (JSON array)")
     nutritional_info: Optional[dict] = Field(default=None, description="Nutritional information (JSON)")
     notes: Optional[str] = Field(default=None, max_length=10000, description="Recipe notes")
 
@@ -113,6 +129,22 @@ class RecipeUpdate(BaseModel):
         if v is not None and v <= 0:
             raise ValueError("base_servings must be positive")
         return v
+
+    @field_validator('tags', 'steps')
+    @classmethod
+    def validate_string_lists(cls, v: Optional[list[str]], info) -> Optional[list[str]]:
+        """
+        Validate tags and steps lists for length and character constraints.
+
+        Ensures data quality by enforcing maximum item length, maximum list size,
+        and allowed character constraints. Uses validate_string_list which:
+        - Strips whitespace and filters out empty strings
+        - Normalizes Unicode to NFC form
+        - Blocks dangerous Unicode characters
+        - Allows letters, numbers, and common punctuation
+        """
+        field_name = info.field_name
+        return validate_string_list(field_name, v)
 
 
 class RecipeResponse(BaseModel):
@@ -300,3 +332,19 @@ class AdHocRecipeCreate(BaseModel):
         """Ensure name is not empty and apply Unicode normalization."""
         result = validate_name_not_empty(v)
         return result  # type: ignore
+
+    @field_validator('tags', 'steps')
+    @classmethod
+    def validate_string_lists(cls, v: Optional[list[str]], info) -> Optional[list[str]]:
+        """
+        Validate tags and steps lists for length and character constraints.
+
+        Ensures data quality by enforcing maximum item length, maximum list size,
+        and allowed character constraints. Uses validate_string_list which:
+        - Strips whitespace and filters out empty strings
+        - Normalizes Unicode to NFC form
+        - Blocks dangerous Unicode characters
+        - Allows letters, numbers, and common punctuation
+        """
+        field_name = info.field_name
+        return validate_string_list(field_name, v)

--- a/tests/schemas/test_recipe.py
+++ b/tests/schemas/test_recipe.py
@@ -260,3 +260,227 @@ class TestNotesValidationConsistency:
         assert create_max == 10000, f"RecipeCreate notes max_length should be 10000, got {create_max}"
         assert update_max == 10000, f"RecipeUpdate notes max_length should be 10000, got {update_max}"
         assert adhoc_max == 10000, f"AdHocRecipeCreate notes max_length should be 10000, got {adhoc_max}"
+
+
+class TestRecipeCreateTagsAndStepsValidation:
+    """Test tags and steps field validation for RecipeCreate schema."""
+
+    def test_create_recipe_with_valid_tags(self):
+        """Test creating a recipe with valid tags."""
+        valid_data = {
+            "name": "Test Recipe",
+            "source_type": "manual",
+            "tags": ["vegetarian", "quick", "easy"]
+        }
+        recipe = RecipeCreate(**valid_data)
+        assert recipe.tags == ["vegetarian", "quick", "easy"]
+
+    def test_create_recipe_with_valid_steps(self):
+        """Test creating a recipe with valid steps."""
+        valid_data = {
+            "name": "Test Recipe",
+            "source_type": "manual",
+            "steps": ["Preheat oven to 350F", "Mix ingredients", "Bake for 30 minutes"]
+        }
+        recipe = RecipeCreate(**valid_data)
+        assert recipe.steps == ["Preheat oven to 350F", "Mix ingredients", "Bake for 30 minutes"]
+
+    def test_create_recipe_with_unicode_tags(self):
+        """Test that tags with Unicode characters are normalized and accepted."""
+        valid_data = {
+            "name": "Test Recipe",
+            "source_type": "manual",
+            "tags": ["café-style", "jalapeño", "crème fraîche"]
+        }
+        recipe = RecipeCreate(**valid_data)
+        assert "café-style" in recipe.tags
+        assert "jalapeño" in recipe.tags
+        assert "crème fraîche" in recipe.tags
+
+    def test_create_recipe_with_empty_tags_list(self):
+        """Test creating a recipe with an empty tags list."""
+        valid_data = {
+            "name": "Test Recipe",
+            "source_type": "manual",
+            "tags": []
+        }
+        recipe = RecipeCreate(**valid_data)
+        assert recipe.tags == []
+
+    def test_create_recipe_with_whitespace_in_tags(self):
+        """Test that whitespace is stripped from tags and empty strings are filtered."""
+        valid_data = {
+            "name": "Test Recipe",
+            "source_type": "manual",
+            "tags": ["  vegetarian  ", "quick", "  ", ""]
+        }
+        recipe = RecipeCreate(**valid_data)
+        # Empty strings and whitespace-only strings should be filtered out
+        assert recipe.tags == ["vegetarian", "quick"]
+
+    def test_create_recipe_with_tag_exceeding_max_length(self):
+        """Test that tags exceeding max item length raise a validation error."""
+        long_tag = "a" * 101  # Exceeds MAX_LIST_ITEM_LENGTH (100)
+        invalid_data = {
+            "name": "Test Recipe",
+            "source_type": "manual",
+            "tags": [long_tag]
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            RecipeCreate(**invalid_data)
+
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert errors[0]["loc"] == ("tags",)
+        assert "cannot exceed 100 characters" in str(errors[0]["msg"])
+
+    def test_create_recipe_with_too_many_tags(self):
+        """Test that tags list exceeding max size raises a validation error."""
+        invalid_data = {
+            "name": "Test Recipe",
+            "source_type": "manual",
+            "tags": [f"tag{i}" for i in range(101)]  # Exceeds MAX_LIST_SIZE (100)
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            RecipeCreate(**invalid_data)
+
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert errors[0]["loc"] == ("tags",)
+        assert "cannot contain more than 100 items" in str(errors[0]["msg"])
+
+    def test_create_recipe_with_invalid_characters_in_tags(self):
+        """Test that tags with invalid characters raise a validation error."""
+        invalid_data = {
+            "name": "Test Recipe",
+            "source_type": "manual",
+            "tags": ["valid-tag", "invalid@tag"]  # @ is not allowed
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            RecipeCreate(**invalid_data)
+
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert errors[0]["loc"] == ("tags",)
+        assert "can only contain letters, numbers, spaces, and common punctuation" in str(errors[0]["msg"])
+
+    def test_create_recipe_with_control_characters_in_steps(self):
+        """Test that steps with Unicode control characters are blocked."""
+        invalid_data = {
+            "name": "Test Recipe",
+            "source_type": "manual",
+            "steps": ["Valid step", "Step with\x00control char"]  # Null byte
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            RecipeCreate(**invalid_data)
+
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert errors[0]["loc"] == ("steps",)
+        assert "cannot contain control or format characters" in str(errors[0]["msg"])
+
+
+class TestRecipeUpdateTagsAndStepsValidation:
+    """Test tags and steps field validation for RecipeUpdate schema."""
+
+    def test_update_recipe_with_valid_tags(self):
+        """Test updating a recipe with valid tags."""
+        valid_data = {
+            "tags": ["vegan", "gluten-free"]
+        }
+        recipe = RecipeUpdate(**valid_data)
+        assert recipe.tags == ["vegan", "gluten-free"]
+
+    def test_update_recipe_with_valid_steps(self):
+        """Test updating a recipe with valid steps."""
+        valid_data = {
+            "steps": ["Step 1", "Step 2", "Step 3"]
+        }
+        recipe = RecipeUpdate(**valid_data)
+        assert recipe.steps == ["Step 1", "Step 2", "Step 3"]
+
+    def test_update_recipe_with_none_tags(self):
+        """Test updating a recipe with None tags (should be valid)."""
+        valid_data = {
+            "tags": None
+        }
+        recipe = RecipeUpdate(**valid_data)
+        assert recipe.tags is None
+
+    def test_update_recipe_with_tag_exceeding_max_length(self):
+        """Test that tags exceeding max item length raise a validation error."""
+        long_tag = "b" * 101
+        invalid_data = {
+            "tags": [long_tag]
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            RecipeUpdate(**invalid_data)
+
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert errors[0]["loc"] == ("tags",)
+        assert "cannot exceed 100 characters" in str(errors[0]["msg"])
+
+
+class TestAdHocRecipeCreateTagsAndStepsValidation:
+    """Test tags and steps field validation for AdHocRecipeCreate schema."""
+
+    def test_create_adhoc_recipe_with_valid_tags_and_steps(self):
+        """Test creating an ad-hoc recipe with valid tags and steps."""
+        inventory_item_id = uuid4()
+        valid_data = {
+            "name": "Ad-Hoc Recipe",
+            "tags": ["leftover", "quick"],
+            "steps": ["Mix everything", "Cook"],
+            "inventory_items": [
+                {
+                    "inventory_item_id": inventory_item_id,
+                    "quantity_used": 2.0,
+                    "unit": "cups"
+                }
+            ]
+        }
+        recipe = AdHocRecipeCreate(**valid_data)
+        assert recipe.tags == ["leftover", "quick"]
+        assert recipe.steps == ["Mix everything", "Cook"]
+
+    def test_create_adhoc_recipe_with_empty_tags_and_steps(self):
+        """Test creating an ad-hoc recipe with empty tags and steps lists."""
+        inventory_item_id = uuid4()
+        valid_data = {
+            "name": "Ad-Hoc Recipe",
+            "tags": [],
+            "steps": [],
+            "inventory_items": [
+                {
+                    "inventory_item_id": inventory_item_id,
+                    "quantity_used": 1.0,
+                    "unit": "cup"
+                }
+            ]
+        }
+        recipe = AdHocRecipeCreate(**valid_data)
+        assert recipe.tags == []
+        assert recipe.steps == []
+
+    def test_create_adhoc_recipe_with_invalid_step(self):
+        """Test that steps with invalid characters raise a validation error."""
+        inventory_item_id = uuid4()
+        invalid_data = {
+            "name": "Ad-Hoc Recipe",
+            "steps": ["Valid step", "Invalid # step"],  # # is not allowed
+            "inventory_items": [
+                {
+                    "inventory_item_id": inventory_item_id,
+                    "quantity_used": 1.0,
+                    "unit": "cup"
+                }
+            ]
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            AdHocRecipeCreate(**invalid_data)
+
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert errors[0]["loc"] == ("steps",)
+        assert "can only contain letters, numbers, spaces, and common punctuation" in str(errors[0]["msg"])


### PR DESCRIPTION
## Work in Progress

Closes #134

Validate tags and steps list contents

<!-- sharkrite-source-issue:125 -->## From PR #132 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
This is a real inconsistency - the codebase has `validate_string_list` in `validators.py` but the schema doesn't use it. However, this applies to the schema definitions created in the prior CRUD issue, not the filtering work in this PR.

## Context
The filtering issue scope is query parameters, not request body schema validation. This is valid technical debt but belongs in a schema hardening follow-up.

## Defer Reason
Scope exceeds time budget - schema validation improvements are separate from filtering feature

---
_Created by Sharkrite assessment on 2026-03-19T23:10:59Z_
_Parent PR: #132_

---

## Additional Assessment (PR #140)

**Severity:** MEDIUM
**Reasoning:** This is a real data consistency issue where users could create recipes with units that don't match their inventory. However, unit conversion/validation is explicitly out of scope for this phase and requires design decisions about how to handle unit compatibility.
**Context:** The issue scope says "keep simple — all ingredients from inventory" but doesn't specify unit handling behavior. This is a valid edge case that needs product decision (warn? auto-convert? reject?) before implementing.
**Defer Reason:** Needs separate focused PR with product decision on unit handling strategy

_Added by Sharkrite on 2026-03-20T00:18:42Z_

---

## Additional Assessment (PR #151)

**Severity:** MEDIUM
**Reasoning:** Adding upper bound validation is a defensive configuration improvement, but the current implementation with `gt=0` is functional and matches redis-py defaults. This is a "nice to have" validation enhancement, not a bug or security issue.
**Context:** The original issue scope is adding connection pool configuration for Redis. The configuration is complete and working; upper bound validation is an incremental improvement that prevents hypothetical misconfiguration but has no measured impact on current functionality.
**Defer Reason:** Needs separate focused PR - validation bounds should be determined based on actual deployment constraints and possibly coordinated with other numeric field validations across the codebase.

_Added by Sharkrite on 2026-03-21T03:05:18Z_

---

## Additional Assessment (PR #151)

**Severity:** MEDIUM
**Reasoning:** Same rationale as the max_connections finding. The timeout fields work correctly with `gt=0` validation. Upper bounds would catch gross misconfigurations but the current implementation is functional and follows redis-py conventions.
**Context:** Timeout configuration is part of the connection pool feature being delivered. Adding upper bounds is a defensive enhancement but not required for the feature to work correctly. Large timeouts would be operator error, not a code defect.
**Defer Reason:** Needs separate focused PR - should be addressed together with other numeric field validation improvements for consistency.

_Added by Sharkrite on 2026-03-21T03:05:18Z_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+0 added, ~2 modified, -0 deleted)
- `M` src/schemas/recipe.py
- `M` tests/schemas/test_recipe.py

### Commits
- 275497e feat: Validate tags and steps list contents
- f14dd27 chore: initialize work on #134 Validate tags and steps list contents
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-03-21T03:57:11Z:**
- Created: none
- Updated: #137 