### PR TITLE
Code Duplication in Recipe Ownership Verification

### DIFF
--- a/src/routers/recipe_helpers.py
+++ b/src/routers/recipe_helpers.py
@@ -1,0 +1,112 @@
+"""
+Helper functions for recipe ownership verification.
+
+Centralizes ownership validation logic to reduce code duplication across
+recipe CRUD endpoints and maintain consistent error handling.
+"""
+
+from uuid import UUID
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from src.db.models.user import User
+from src.db.models.recipe import Recipe
+
+
+def verify_recipe_ownership(
+    recipe_id: UUID,
+    current_user: User,
+    db: Session,
+) -> Recipe:
+    """
+    Verify that a recipe exists and belongs to the current user.
+
+    Used by update and delete endpoints that enforce ownership at the
+    database query level for efficiency.
+
+    Args:
+        recipe_id: UUID of the recipe to verify
+        current_user: Authenticated user making the request
+        db: Database session
+
+    Returns:
+        Recipe: The recipe if it exists and belongs to current user
+
+    Raises:
+        HTTPException(404): If recipe doesn't exist or belongs to another user
+    """
+    recipe = (
+        db.query(Recipe)
+        .filter(
+            Recipe.id == recipe_id,
+            Recipe.created_by == current_user.id,
+        )
+        .first()
+    )
+
+    if not recipe:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Recipe not found"
+        )
+
+    return recipe
+
+
+def verify_recipe_ownership_with_system_check(
+    recipe_id: UUID,
+    current_user: User,
+    db: Session,
+) -> Recipe:
+    """
+    Verify recipe ownership with explicit system recipe protection.
+
+    Used by ingredient endpoints that need to distinguish between:
+    - System recipes (created_by is NULL) → 403 Forbidden
+    - Other users' recipes → 404 Not Found
+    - Missing recipes → 404 Not Found
+
+    This three-way distinction is important for security: we don't want to
+    leak the existence of recipes by returning different status codes for
+    "recipe exists but you can't modify it" vs "recipe doesn't exist".
+
+    Args:
+        recipe_id: UUID of the recipe to verify
+        current_user: Authenticated user making the request
+        db: Database session
+
+    Returns:
+        Recipe: The recipe if it exists, is not a system recipe, and belongs to current user
+
+    Raises:
+        HTTPException(404): If recipe doesn't exist or belongs to another user
+        HTTPException(403): If recipe is a system recipe (created_by is NULL)
+    """
+    # Fetch recipe without ownership filter to distinguish error cases
+    recipe = (
+        db.query(Recipe)
+        .filter(Recipe.id == recipe_id)
+        .first()
+    )
+
+    if not recipe:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Recipe not found"
+        )
+
+    # Check if recipe is a system recipe (cannot be modified)
+    if recipe.created_by is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Cannot modify system recipes"
+        )
+
+    # Check if recipe belongs to current user
+    if recipe.created_by != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Recipe not found"
+        )
+
+    return recipe

--- a/src/routers/recipes.py
+++ b/src/routers/recipes.py
@@ -39,6 +39,10 @@ from src.schemas.recipe import (
     AdHocRecipeCreate,
 )
 from src.middleware.auth import get_current_user
+from src.routers.recipe_helpers import (
+    verify_recipe_ownership,
+    verify_recipe_ownership_with_system_check,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -433,21 +437,8 @@ def update_recipe(
         HTTPException(404): If recipe doesn't exist or belongs to another user
         HTTPException(422): If validation fails (invalid source_type, etc.)
     """
-    # Query recipe with user ownership check
-    recipe = (
-        db.query(Recipe)
-        .filter(
-            Recipe.id == recipe_id,
-            Recipe.created_by == current_user.id,
-        )
-        .first()
-    )
-
-    if not recipe:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Recipe not found"
-        )
+    # Verify recipe exists and belongs to current user
+    recipe = verify_recipe_ownership(recipe_id, current_user, db)
 
     # Update only the fields that were provided
     update_dict = update_data.model_dump(exclude_unset=True)
@@ -508,21 +499,8 @@ def delete_recipe(
         HTTPException(401): If Authorization header is missing or token is invalid
         HTTPException(404): If recipe doesn't exist or belongs to another user
     """
-    # Query recipe with user ownership check
-    recipe = (
-        db.query(Recipe)
-        .filter(
-            Recipe.id == recipe_id,
-            Recipe.created_by == current_user.id,
-        )
-        .first()
-    )
-
-    if not recipe:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Recipe not found"
-        )
+    # Verify recipe exists and belongs to current user
+    recipe = verify_recipe_ownership(recipe_id, current_user, db)
 
     try:
         db.delete(recipe)
@@ -573,34 +551,8 @@ def add_recipe_ingredient(
         HTTPException(404): If recipe doesn't exist or belongs to another user
         HTTPException(400): If data integrity violation occurs
     """
-    # Query recipe with user ownership check
-    recipe = (
-        db.query(Recipe)
-        .filter(
-            Recipe.id == recipe_id,
-        )
-        .first()
-    )
-
-    if not recipe:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Recipe not found"
-        )
-
-    # Check if recipe is a system recipe (cannot be modified)
-    if recipe.created_by is None:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Cannot modify system recipes"
-        )
-
-    # Check if recipe belongs to current user
-    if recipe.created_by != current_user.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Recipe not found"
-        )
+    # Verify recipe exists, is not a system recipe, and belongs to current user
+    recipe = verify_recipe_ownership_with_system_check(recipe_id, current_user, db)
 
     # Create new ingredient
     ingredient_dict = ingredient_data.model_dump()
@@ -670,34 +622,8 @@ def update_recipe_ingredient(
         HTTPException(404): If recipe doesn't exist, belongs to another user, or ingredient not found
         HTTPException(400): If data integrity violation occurs
     """
-    # Query recipe with user ownership check
-    recipe = (
-        db.query(Recipe)
-        .filter(
-            Recipe.id == recipe_id,
-        )
-        .first()
-    )
-
-    if not recipe:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Recipe not found"
-        )
-
-    # Check if recipe is a system recipe (cannot be modified)
-    if recipe.created_by is None:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Cannot modify system recipes"
-        )
-
-    # Check if recipe belongs to current user
-    if recipe.created_by != current_user.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Recipe not found"
-        )
+    # Verify recipe exists, is not a system recipe, and belongs to current user
+    recipe = verify_recipe_ownership_with_system_check(recipe_id, current_user, db)
 
     # Query ingredient and verify it belongs to the recipe
     ingredient = (
@@ -778,34 +704,8 @@ def delete_recipe_ingredient(
         HTTPException(403): If recipe is a system recipe (created_by is NULL)
         HTTPException(404): If recipe doesn't exist, belongs to another user, or ingredient not found
     """
-    # Query recipe with user ownership check
-    recipe = (
-        db.query(Recipe)
-        .filter(
-            Recipe.id == recipe_id,
-        )
-        .first()
-    )
-
-    if not recipe:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Recipe not found"
-        )
-
-    # Check if recipe is a system recipe (cannot be modified)
-    if recipe.created_by is None:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Cannot modify system recipes"
-        )
-
-    # Check if recipe belongs to current user
-    if recipe.created_by != current_user.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Recipe not found"
-        )
+    # Verify recipe exists, is not a system recipe, and belongs to current user
+    recipe = verify_recipe_ownership_with_system_check(recipe_id, current_user, db)
 
     # Query ingredient and verify it belongs to the recipe
     ingredient = (

--- a/tests/routers/test_recipe_helpers.py
+++ b/tests/routers/test_recipe_helpers.py
@@ -1,0 +1,338 @@
+"""
+Unit tests for recipe_helpers module.
+
+Tests cover:
+- verify_recipe_ownership: Basic ownership verification
+- verify_recipe_ownership_with_system_check: Enhanced verification with system recipe protection
+- Error cases: missing recipes, wrong owner, system recipes
+- Security: prevents leaking recipe existence through different error codes
+"""
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from uuid import uuid4
+
+from src.db.database import Base
+from src.db import models
+from src.db.models.user import User, UserRole
+from src.db.models.recipe import Recipe
+from src.services.auth_service import hash_password
+from src.routers.recipe_helpers import (
+    verify_recipe_ownership,
+    verify_recipe_ownership_with_system_check,
+)
+
+
+# Create an in-memory SQLite database for testing
+TEST_DATABASE_URL = "sqlite:///:memory:"
+
+
+@pytest.fixture(autouse=True)
+def setup_test_env(monkeypatch):
+    """Set up test environment variables."""
+    from src.config import get_settings
+    get_settings.cache_clear()
+
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars")
+    monkeypatch.setenv("JWT_ALGORITHM", "HS256")
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    monkeypatch.setenv("ACCESS_TOKEN_EXPIRE_MINUTES", "43200")
+
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def db_session():
+    """Create a fresh database session for each test."""
+    from sqlalchemy.pool import StaticPool
+
+    # Import models to ensure all SQLAlchemy model classes are registered
+    # with Base.metadata before create_all() is called
+    _ = models
+
+    engine = create_engine(
+        TEST_DATABASE_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+@pytest.fixture
+def test_user(db_session):
+    """Create a test user."""
+    user = User(
+        id=uuid4(),
+        email="test@example.com",
+        hashed_password=hash_password("testpassword123"),
+        name="Test User",
+        role=UserRole.member.value,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def test_user2(db_session):
+    """Create a second test user for cross-user access tests."""
+    user = User(
+        id=uuid4(),
+        email="test2@example.com",
+        hashed_password=hash_password("testpassword123"),
+        name="Test User 2",
+        role=UserRole.member.value,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def user_recipe(db_session, test_user):
+    """Create a recipe owned by test_user."""
+    recipe = Recipe(
+        id=uuid4(),
+        name="User's Recipe",
+        source_type="manual",
+        created_by=test_user.id,
+    )
+    db_session.add(recipe)
+    db_session.commit()
+    db_session.refresh(recipe)
+    return recipe
+
+
+@pytest.fixture
+def user2_recipe(db_session, test_user2):
+    """Create a recipe owned by test_user2."""
+    recipe = Recipe(
+        id=uuid4(),
+        name="User 2's Recipe",
+        source_type="manual",
+        created_by=test_user2.id,
+    )
+    db_session.add(recipe)
+    db_session.commit()
+    db_session.refresh(recipe)
+    return recipe
+
+
+@pytest.fixture
+def system_recipe(db_session):
+    """Create a system recipe (created_by is NULL)."""
+    recipe = Recipe(
+        id=uuid4(),
+        name="System Recipe",
+        source_type="manual",
+        created_by=None,
+    )
+    db_session.add(recipe)
+    db_session.commit()
+    db_session.refresh(recipe)
+    return recipe
+
+
+class TestVerifyRecipeOwnership:
+    """Test verify_recipe_ownership function."""
+
+    def test_verify_ownership_success(self, db_session, test_user, user_recipe):
+        """Test successful ownership verification."""
+        result = verify_recipe_ownership(user_recipe.id, test_user, db_session)
+
+        assert result is not None
+        assert result.id == user_recipe.id
+        assert result.created_by == test_user.id
+
+    def test_verify_ownership_recipe_not_found(self, db_session, test_user):
+        """Test verification fails when recipe doesn't exist."""
+        non_existent_id = uuid4()
+
+        with pytest.raises(HTTPException) as exc_info:
+            verify_recipe_ownership(non_existent_id, test_user, db_session)
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Recipe not found"
+
+    def test_verify_ownership_wrong_owner(self, db_session, test_user, test_user2, user2_recipe):
+        """Test verification fails when recipe belongs to another user."""
+        # test_user tries to access user2_recipe
+        with pytest.raises(HTTPException) as exc_info:
+            verify_recipe_ownership(user2_recipe.id, test_user, db_session)
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Recipe not found"
+
+    def test_verify_ownership_system_recipe_returns_404(self, db_session, test_user, system_recipe):
+        """Test that system recipes return 404 (not accessible, no owner match)."""
+        with pytest.raises(HTTPException) as exc_info:
+            verify_recipe_ownership(system_recipe.id, test_user, db_session)
+
+        # System recipe has created_by=NULL, so ownership filter fails -> 404
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Recipe not found"
+
+    def test_verify_ownership_consistent_error_for_security(self, db_session, test_user, test_user2, user2_recipe):
+        """Test that wrong owner and non-existent recipes return same error (prevents info leak)."""
+        non_existent_id = uuid4()
+
+        # Get error for non-existent recipe
+        with pytest.raises(HTTPException) as exc_info_1:
+            verify_recipe_ownership(non_existent_id, test_user, db_session)
+
+        # Get error for recipe owned by another user
+        with pytest.raises(HTTPException) as exc_info_2:
+            verify_recipe_ownership(user2_recipe.id, test_user, db_session)
+
+        # Both should return identical errors to prevent leaking recipe existence
+        assert exc_info_1.value.status_code == exc_info_2.value.status_code == 404
+        assert exc_info_1.value.detail == exc_info_2.value.detail == "Recipe not found"
+
+
+class TestVerifyRecipeOwnershipWithSystemCheck:
+    """Test verify_recipe_ownership_with_system_check function."""
+
+    def test_verify_with_system_check_success(self, db_session, test_user, user_recipe):
+        """Test successful ownership verification with system check."""
+        result = verify_recipe_ownership_with_system_check(user_recipe.id, test_user, db_session)
+
+        assert result is not None
+        assert result.id == user_recipe.id
+        assert result.created_by == test_user.id
+
+    def test_verify_with_system_check_recipe_not_found(self, db_session, test_user):
+        """Test verification fails when recipe doesn't exist."""
+        non_existent_id = uuid4()
+
+        with pytest.raises(HTTPException) as exc_info:
+            verify_recipe_ownership_with_system_check(non_existent_id, test_user, db_session)
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Recipe not found"
+
+    def test_verify_with_system_check_system_recipe_returns_403(self, db_session, test_user, system_recipe):
+        """Test that system recipes return 403 Forbidden."""
+        with pytest.raises(HTTPException) as exc_info:
+            verify_recipe_ownership_with_system_check(system_recipe.id, test_user, db_session)
+
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail == "Cannot modify system recipes"
+
+    def test_verify_with_system_check_wrong_owner(self, db_session, test_user, test_user2, user2_recipe):
+        """Test verification fails when recipe belongs to another user."""
+        # test_user tries to access user2_recipe
+        with pytest.raises(HTTPException) as exc_info:
+            verify_recipe_ownership_with_system_check(user2_recipe.id, test_user, db_session)
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Recipe not found"
+
+    def test_verify_with_system_check_three_way_distinction(
+        self, db_session, test_user, test_user2, user2_recipe, system_recipe
+    ):
+        """Test that function properly distinguishes between three error cases."""
+        # Case 1: Recipe doesn't exist -> 404
+        non_existent_id = uuid4()
+        with pytest.raises(HTTPException) as exc_info_1:
+            verify_recipe_ownership_with_system_check(non_existent_id, test_user, db_session)
+        assert exc_info_1.value.status_code == 404
+        assert exc_info_1.value.detail == "Recipe not found"
+
+        # Case 2: System recipe (created_by is NULL) -> 403
+        with pytest.raises(HTTPException) as exc_info_2:
+            verify_recipe_ownership_with_system_check(system_recipe.id, test_user, db_session)
+        assert exc_info_2.value.status_code == 403
+        assert exc_info_2.value.detail == "Cannot modify system recipes"
+
+        # Case 3: Recipe belongs to another user -> 404
+        with pytest.raises(HTTPException) as exc_info_3:
+            verify_recipe_ownership_with_system_check(user2_recipe.id, test_user, db_session)
+        assert exc_info_3.value.status_code == 404
+        assert exc_info_3.value.detail == "Recipe not found"
+
+    def test_verify_with_system_check_security_no_leak_for_other_users(
+        self, db_session, test_user, test_user2, user2_recipe
+    ):
+        """Test that wrong owner and non-existent recipes return same error (prevents info leak)."""
+        non_existent_id = uuid4()
+
+        # Get error for non-existent recipe
+        with pytest.raises(HTTPException) as exc_info_1:
+            verify_recipe_ownership_with_system_check(non_existent_id, test_user, db_session)
+
+        # Get error for recipe owned by another user
+        with pytest.raises(HTTPException) as exc_info_2:
+            verify_recipe_ownership_with_system_check(user2_recipe.id, test_user, db_session)
+
+        # Both should return identical 404 errors to prevent leaking recipe existence
+        assert exc_info_1.value.status_code == exc_info_2.value.status_code == 404
+        assert exc_info_1.value.detail == exc_info_2.value.detail == "Recipe not found"
+
+    def test_verify_with_system_check_multiple_users_same_recipe(
+        self, db_session, test_user, test_user2, user_recipe
+    ):
+        """Test that only the actual owner can access the recipe."""
+        # Owner should succeed
+        result = verify_recipe_ownership_with_system_check(user_recipe.id, test_user, db_session)
+        assert result.id == user_recipe.id
+
+        # Non-owner should get 404
+        with pytest.raises(HTTPException) as exc_info:
+            verify_recipe_ownership_with_system_check(user_recipe.id, test_user2, db_session)
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Recipe not found"
+
+
+class TestSecurityConsistency:
+    """Test security-critical behavior across both functions."""
+
+    def test_both_functions_prevent_info_leak(self, db_session, test_user, test_user2, user2_recipe):
+        """Test that both functions don't leak recipe existence to unauthorized users."""
+        non_existent_id = uuid4()
+
+        # Test verify_recipe_ownership
+        with pytest.raises(HTTPException) as exc_info_1a:
+            verify_recipe_ownership(non_existent_id, test_user, db_session)
+        with pytest.raises(HTTPException) as exc_info_1b:
+            verify_recipe_ownership(user2_recipe.id, test_user, db_session)
+
+        # Both should return same error
+        assert exc_info_1a.value.status_code == exc_info_1b.value.status_code == 404
+        assert exc_info_1a.value.detail == exc_info_1b.value.detail
+
+        # Test verify_recipe_ownership_with_system_check
+        with pytest.raises(HTTPException) as exc_info_2a:
+            verify_recipe_ownership_with_system_check(non_existent_id, test_user, db_session)
+        with pytest.raises(HTTPException) as exc_info_2b:
+            verify_recipe_ownership_with_system_check(user2_recipe.id, test_user, db_session)
+
+        # Both should return same error
+        assert exc_info_2a.value.status_code == exc_info_2b.value.status_code == 404
+        assert exc_info_2a.value.detail == exc_info_2b.value.detail
+
+    def test_system_recipe_handling_difference(self, db_session, test_user, system_recipe):
+        """Test that the two functions handle system recipes differently."""
+        # verify_recipe_ownership: system recipe returns 404 (no owner match)
+        with pytest.raises(HTTPException) as exc_info_1:
+            verify_recipe_ownership(system_recipe.id, test_user, db_session)
+        assert exc_info_1.value.status_code == 404
+
+        # verify_recipe_ownership_with_system_check: system recipe returns 403
+        with pytest.raises(HTTPException) as exc_info_2:
+            verify_recipe_ownership_with_system_check(system_recipe.id, test_user, db_session)
+        assert exc_info_2.value.status_code == 403
+        assert exc_info_2.value.detail == "Cannot modify system recipes"


### PR DESCRIPTION
## Work in Progress

Closes #137

Code Duplication in Recipe Ownership Verification

<!-- sharkrite-source-issue:126 -->## From PR #136 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
This is a valid DRY principle violation, but extracting a helper function is a refactoring task that doesn't affect the correctness of the feature. The current implementation works correctly and is fully tested.

## Context
The original issue scope focuses on implementing CRUD endpoints with proper ownership enforcement. The endpoints correctly enforce ownership - the duplication is a maintainability concern for future changes, not a bug or security issue.

## Defer Reason
Scope exceeds time budget - refactoring to extract a helper function is a code quality improvement that can be addressed in a follow-up cleanup PR.

---
_Created by Sharkrite assessment on 2026-03-19T23:29:49Z_
_Parent PR: #136_

---

## Additional Assessment (PR #136)

**Severity:** MEDIUM
**Reasoning:** This is the same finding as previously classified. The only file changed since the prior decision is `src/schemas/recipe.py`, which does not contain the ownership validation logic in `src/routers/recipes.py`. No concrete change addresses this concern.
**Context:** Extracting a helper function is a valid DRY improvement but is a refactoring task that doesn't affect correctness. The current implementation works and is tested.
**Defer Reason:** Scope exceeds time budget

_Added by Sharkrite on 2026-03-19T23:31:41Z_

---

## Additional Assessment (PR #147)

**Severity:** MEDIUM
**Reasoning:** This is a valid maintainability concern — 5 repeated instances of the same query pattern creates real maintenance burden. However, the duplication was introduced as part of correctly fixing the N+1 query issue, and extracting a helper function is a refactoring task that exceeds the original issue scope.
**Context:** The original issue was to investigate and fix the N+1 query in available_at_stores. The PR correctly applies selectinload to all relevant endpoints. Consolidating the pattern is a follow-up improvement, not a requirement for the fix to be correct and complete.
**Defer Reason:** Scope exceeds time budget

_Added by Sharkrite on 2026-03-21T00:44:44Z_

---

## Additional Assessment (PR #154)

**Severity:** MEDIUM
**Reasoning:** The duplicated validator across three classes is a real maintainability concern that could lead to inconsistencies if modified in one place but not others. However, refactoring to a mixin is a structural change that exceeds the scope of adding validation.
**Context:** The original issue scope is adding validation for tags and steps list contents. The validation is correctly implemented in all three places. Consolidating them is a separate refactoring effort.
**Defer Reason:** Needs separate focused PR - architectural refactor to introduce mixin pattern should be its own change

_Added by Sharkrite on 2026-03-21T03:57:11Z_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+1 added, ~1 modified, -0 deleted)
- `A` src/routers/recipe_helpers.py
- `M` src/routers/recipes.py

### Commits
- 0cb0ca5 feat: Code Duplication in Recipe Ownership Verification
- 82c0c7a chore: initialize work on #137 Code Duplication in Recipe Ownership Verification
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-03-21T04:15:26Z:**
- Created: #157 
- Updated: none