### PR TITLE
Add timestamps to Recipe models

### DIFF
--- a/alembic/versions/f9d8c7b6a5e4_add_timestamps_to_recipe_models.py
+++ b/alembic/versions/f9d8c7b6a5e4_add_timestamps_to_recipe_models.py
@@ -23,6 +23,7 @@ def upgrade() -> None:
     with op.batch_alter_table('recipes', schema=None) as batch_op:
         batch_op.add_column(sa.Column('created_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False))
         batch_op.add_column(sa.Column('updated_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False))
+        batch_op.create_index('ix_recipes_created_at', ['created_at'])
 
     # Add created_at to recipe_ingredients table
     with op.batch_alter_table('recipe_ingredients', schema=None) as batch_op:
@@ -46,5 +47,6 @@ def downgrade() -> None:
 
     # Remove timestamps from recipes table
     with op.batch_alter_table('recipes', schema=None) as batch_op:
+        batch_op.drop_index('ix_recipes_created_at')
         batch_op.drop_column('updated_at')
         batch_op.drop_column('created_at')

--- a/alembic/versions/f9d8c7b6a5e4_add_timestamps_to_recipe_models.py
+++ b/alembic/versions/f9d8c7b6a5e4_add_timestamps_to_recipe_models.py
@@ -1,0 +1,50 @@
+"""add_timestamps_to_recipe_models
+
+Revision ID: f9d8c7b6a5e4
+Revises: 2e3ac317ae24
+Create Date: 2026-03-21 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f9d8c7b6a5e4'
+down_revision: Union[str, None] = '2e3ac317ae24'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add created_at and updated_at to recipes table
+    with op.batch_alter_table('recipes', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('created_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False))
+        batch_op.add_column(sa.Column('updated_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False))
+
+    # Add created_at to recipe_ingredients table
+    with op.batch_alter_table('recipe_ingredients', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('created_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False))
+
+    # Add created_at and updated_at to user_recipe_ratings table
+    with op.batch_alter_table('user_recipe_ratings', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('created_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False))
+        batch_op.add_column(sa.Column('updated_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False))
+
+
+def downgrade() -> None:
+    # Remove timestamps from user_recipe_ratings table
+    with op.batch_alter_table('user_recipe_ratings', schema=None) as batch_op:
+        batch_op.drop_column('updated_at')
+        batch_op.drop_column('created_at')
+
+    # Remove created_at from recipe_ingredients table
+    with op.batch_alter_table('recipe_ingredients', schema=None) as batch_op:
+        batch_op.drop_column('created_at')
+
+    # Remove timestamps from recipes table
+    with op.batch_alter_table('recipes', schema=None) as batch_op:
+        batch_op.drop_column('updated_at')
+        batch_op.drop_column('created_at')

--- a/src/db/models/recipe.py
+++ b/src/db/models/recipe.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from enum import Enum as PyEnum
 from uuid import UUID, uuid4
+from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import String, Integer, JSON, ForeignKey
+from sqlalchemy import String, Integer, JSON, ForeignKey, DateTime, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.db.database import Base
@@ -38,6 +39,8 @@ class Recipe(Base):
     times_cooked: Mapped[int] = mapped_column(Integer, default=0)
     created_by: Mapped[Optional[UUID]] = mapped_column(ForeignKey("users.id"), nullable=True)
     notes: Mapped[Optional[str]] = mapped_column(String(10000), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), onupdate=func.now())
 
     # Relationships
     created_by_user: Mapped[Optional["User"]] = relationship(back_populates="recipes_created")

--- a/src/db/models/recipe_ingredient.py
+++ b/src/db/models/recipe_ingredient.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from uuid import UUID, uuid4
+from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import String, Float, Boolean, ForeignKey
+from sqlalchemy import String, Float, Boolean, ForeignKey, DateTime, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.db.database import Base
@@ -20,6 +21,7 @@ class RecipeIngredient(Base):
     variation_group: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
     variation_diet: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
     is_optional: Mapped[bool] = mapped_column(Boolean, default=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
 
     # Relationships
     recipe_rel: Mapped["Recipe"] = relationship(back_populates="ingredients")

--- a/src/db/models/user_recipe.py
+++ b/src/db/models/user_recipe.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from uuid import UUID, uuid4
+from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import String, Float, Boolean, ForeignKey, UniqueConstraint
+from sqlalchemy import String, Float, Boolean, ForeignKey, UniqueConstraint, DateTime, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.db.database import Base
@@ -21,6 +22,8 @@ class UserRecipeRating(Base):
     rating: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     is_favorite: Mapped[bool] = mapped_column(Boolean, default=False)
     notes: Mapped[Optional[str]] = mapped_column(String(1000), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), onupdate=func.now())
 
     # Relationships
     user_rel: Mapped["User"] = relationship(back_populates="recipe_ratings")

--- a/src/routers/recipes.py
+++ b/src/routers/recipes.py
@@ -370,10 +370,10 @@ def list_recipes(
             )
 
     # Apply ordering and pagination
-    # Note: Recipe model doesn't have date_added, so we order by id (chronological proxy)
+    # Order by created_at to show most recently added recipes first
     recipes = (
         query
-        .order_by(Recipe.id.desc())
+        .order_by(Recipe.created_at.desc())
         .limit(limit)
         .offset(offset)
         .all()


### PR DESCRIPTION
## Work in Progress

Closes #164

Add timestamps to Recipe models

## Description

Recipe, RecipeIngredient, and UserRecipeRating models have no temporal tracking fields. The list endpoint orders by `Recipe.id.desc()` with the comment "Recipe model doesn't have date_added, so we order by id (chronological proxy)" — but `uuid4` is not chronologically sortable, so this ordering is silently incorrect.

## Claude Context
Files to Read:
- `src/db/models/recipe.py` (Recipe model — no timestamps)
- `src/db/models/recipe_ingredient.py` (RecipeIngredient model — no timestamps)
- `src/db/models/user_recipe.py` (UserRecipeRating model — no timestamps)
- `src/routers/recipes.py` (line 354 — ordering by id comment)
- `src/db/models/inventory_item.py` (reference for how other models handle timestamps, if applicable)

Files to Modify:
- `src/db/models/recipe.py` — add `created_at`, `updated_at`
- `src/db/models/recipe_ingredient.py` — add `created_at`
- `src/db/models/user_recipe.py` — add `created_at`, `updated_at`
- `src/routers/recipes.py` — replace `order_by(Recipe.id.desc())` with `order_by(Recipe.created_at.desc())`
- Alembic migration for new columns

Related Issues: None

## Acceptance Criteria
- [ ] Recipe model has `created_at` (server default) and `updated_at` (on update) columns: verify in migration
- [ ] RecipeIngredient model has `created_at` column: verify in migration
- [ ] UserRecipeRating model has `created_at` and `updated_at` columns: verify in migration
- [ ] Recipe list endpoint orders by `created_at` instead of `id`: `pytest tests/routers/test_recipes.py -k list -v`
- [ ] Migration is reversible: `alembic downgrade` succeeds
- [ ] Existing rows get a sensible default (e.g., `server_default=func.now()`): verify with migration on seeded DB
- [ ] All existing tests pass: `pytest tests/ -v`

## Verification Commands
```bash
alembic upgrade head
pytest tests/routers/test_recipes.py -v
python -c "from src.db.models.recipe import Recipe; print(Recipe.created_at)"
```

## Done Definition
Done when all three models have timestamp columns, the recipe list endpoint orders by `created_at`, and all tests pass.

## Scope Boundary
- DO: Add timestamp columns to Recipe, RecipeIngredient, UserRecipeRating
- DO: Update recipe list ordering to use `created_at`
- DO: Create Alembic migration with sensible defaults for existing rows
- DO NOT: Add timestamps to other models (separate issue if needed)
- DO NOT: Change any API response schemas (timestamps can be added to responses in a follow-up)

## Dependencies
None

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**5** files, **2** commits (+1 added, ~4 modified, -0 deleted)
- `A` alembic/versions/f9d8c7b6a5e4_add_timestamps_to_recipe_models.py
- `M` src/db/models/recipe.py
- `M` src/db/models/recipe_ingredient.py
- `M` src/db/models/user_recipe.py
- `M` src/routers/recipes.py

### Commits
- b896443 feat: Add timestamps to Recipe models
- ad8223e chore: initialize work on #164 Add timestamps to Recipe models
<!-- /sharkrite-changes-summary -->