### PR TITLE
[Phase 1F] Add purchase check-off endpoints

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -8,7 +8,7 @@ from slowapi.errors import RateLimitExceeded
 
 from src.config import get_settings
 from src.db.database import Base, init_engine, get_engine, get_session_factory
-from src.routers import auth_router, users_router, substitutions_router, inventory_router, recipes_router
+from src.routers import auth_router, users_router, substitutions_router, inventory_router, recipes_router, grocery_router
 from src.middleware.rate_limit import limiter
 
 settings = get_settings()
@@ -76,6 +76,7 @@ app.include_router(users_router)
 app.include_router(substitutions_router)
 app.include_router(inventory_router)
 app.include_router(recipes_router)
+app.include_router(grocery_router)
 
 
 @app.get("/health")

--- a/src/routers/__init__.py
+++ b/src/routers/__init__.py
@@ -11,5 +11,6 @@ from src.routers.users import router as users_router
 from src.routers.substitutions import router as substitutions_router
 from src.routers.inventory import router as inventory_router
 from src.routers.recipes import router as recipes_router
+from src.routers.grocery import router as grocery_router
 
-__all__ = ["auth_router", "users_router", "substitutions_router", "inventory_router", "recipes_router"]
+__all__ = ["auth_router", "users_router", "substitutions_router", "inventory_router", "recipes_router", "grocery_router"]

--- a/src/routers/grocery.py
+++ b/src/routers/grocery.py
@@ -1,0 +1,144 @@
+"""
+Grocery list CRUD endpoints for FreshUp.
+
+Provides endpoints for users to manage their household grocery list,
+including adding items, checking off purchases, and optionally creating
+inventory items from purchased groceries.
+
+Per ADR, any authenticated user can purchase/unpurchase any item —
+this is a household coordination action, not owner-restricted.
+
+Logging Policy:
+    User-provided item names are NOT logged as they may contain sensitive
+    health information (e.g., prescription names, dietary restrictions).
+    Logs include operational metadata (user_id, item_id, timestamps) for
+    debugging while protecting user privacy per OWASP recommendations.
+"""
+
+import logging
+from uuid import UUID
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.orm import Session
+
+from src.db.database import get_db
+from src.db.models.user import User
+from src.schemas.grocery import (
+    GroceryItemResponse,
+    BulkPurchaseRequest,
+    BulkPurchaseResponse,
+)
+from src.middleware.auth import get_current_user
+from src.services import grocery_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/grocery", tags=["grocery"])
+
+
+@router.put("/{item_id}/purchase", response_model=GroceryItemResponse)
+def purchase_item(
+    item_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Mark a grocery item as purchased.
+
+    Sets purchased=True, purchased_by=current_user, purchased_date=now.
+    Any authenticated user can purchase any item (household coordination).
+
+    Args:
+        item_id: UUID of the grocery item to mark as purchased
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        GroceryItemResponse: Updated grocery item
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If item doesn't exist
+        HTTPException(500): If database error occurs
+    """
+    return grocery_service.mark_purchased(item_id, current_user, db)
+
+
+@router.put("/{item_id}/unpurchase", response_model=GroceryItemResponse)
+def unpurchase_item(
+    item_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Reverse a grocery item purchase (mark as unpurchased).
+
+    Sets purchased=False, purchased_by=None, purchased_date=None.
+    Any authenticated user can unpurchase any item (household coordination).
+
+    Args:
+        item_id: UUID of the grocery item to mark as unpurchased
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        GroceryItemResponse: Updated grocery item
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If item doesn't exist
+        HTTPException(500): If database error occurs
+    """
+    return grocery_service.mark_unpurchased(item_id, current_user, db)
+
+
+@router.post("/bulk-purchase", response_model=BulkPurchaseResponse)
+def bulk_purchase_items(
+    request_data: BulkPurchaseRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Mark multiple grocery items as purchased in a single atomic transaction.
+
+    Optionally creates inventory items from purchased groceries when
+    create_inventory_item=True. If any item_id is not found, the entire
+    transaction is rolled back (all-or-nothing semantics).
+
+    When create_inventory_item=True, storage_location and category are REQUIRED
+    (enforced by schema validation - returns 422 if missing).
+
+    Inventory items created with:
+    - name = grocery item_name
+    - quantity = grocery quantity
+    - unit = grocery unit
+    - storage_location = request storage_location
+    - category = request category
+    - added_by = current_user
+
+    Args:
+        request_data: Bulk purchase request with item IDs and optional inventory creation params
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        BulkPurchaseResponse: List of updated grocery items and count of inventory items created
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If any item_id is not found (entire batch fails)
+        HTTPException(422): If create_inventory_item=True but storage_location or category missing
+        HTTPException(500): If database error occurs
+    """
+    updated_items, inventory_count = grocery_service.bulk_purchase(
+        item_ids=request_data.item_ids,
+        current_user=current_user,
+        db=db,
+        create_inventory_item=request_data.create_inventory_item,
+        storage_location=request_data.storage_location,
+        category=request_data.category,
+    )
+
+    return BulkPurchaseResponse(
+        items=updated_items,
+        inventory_items_created=inventory_count
+    )

--- a/src/schemas/grocery.py
+++ b/src/schemas/grocery.py
@@ -8,7 +8,7 @@ store-grouped responses for the by-store endpoint.
 from uuid import UUID
 from datetime import datetime
 from typing import Optional
-from pydantic import BaseModel, Field, field_validator, ConfigDict
+from pydantic import BaseModel, Field, field_validator, model_validator, ConfigDict
 
 from src.db.models.grocery_list import GrocerySource
 from src.db.models.inventory_item import Category, UnitType, StorageLocation
@@ -146,3 +146,20 @@ class BulkPurchaseRequest(BaseModel):
     def validate_category_field(cls, v: Optional[str]) -> Optional[str]:
         """Ensure category is a valid Category enum value if provided."""
         return validate_enum_value('Category', v, Category, allow_none=True)
+
+    @model_validator(mode='after')
+    def validate_conditional_fields(self):
+        """Ensure storage_location and category are required when create_inventory_item is true."""
+        if self.create_inventory_item:
+            if self.storage_location is None:
+                raise ValueError('storage_location is required when create_inventory_item is true')
+            if self.category is None:
+                raise ValueError('category is required when create_inventory_item is true')
+        return self
+
+
+class BulkPurchaseResponse(BaseModel):
+    """Response schema for bulk purchase endpoint."""
+
+    items: list[GroceryItemResponse] = Field(..., description="List of updated grocery items")
+    inventory_items_created: int = Field(default=0, description="Number of inventory items created")

--- a/src/schemas/grocery.py
+++ b/src/schemas/grocery.py
@@ -130,7 +130,7 @@ class StoreGroupedGroceryResponse(BaseModel):
 class BulkPurchaseRequest(BaseModel):
     """Request schema for bulk purchasing grocery items."""
 
-    item_ids: list[UUID] = Field(..., min_length=1, description="List of grocery item IDs to mark as purchased")
+    item_ids: list[UUID] = Field(..., min_length=1, max_length=100, description="List of grocery item IDs to mark as purchased")
     create_inventory_item: bool = Field(default=False, description="Whether to create inventory items from purchased groceries")
     storage_location: Optional[str] = Field(default=None, description="Storage location for created inventory items")
     category: Optional[str] = Field(default=None, description="Category for created inventory items")

--- a/src/services/grocery_service.py
+++ b/src/services/grocery_service.py
@@ -183,14 +183,17 @@ def bulk_purchase(
 
         # Mark all items as purchased
         for item in items:
+            # Track if item was already purchased (to prevent duplicate inventory creation)
+            was_already_purchased = item.purchased
+
             item.purchased = True
             item.purchased_by = current_user.id
             item.purchased_date = purchase_time
 
             updated_items.append(item)
 
-            # Optionally create inventory item
-            if create_inventory_item:
+            # Optionally create inventory item (only if not already purchased)
+            if create_inventory_item and not was_already_purchased:
                 # Create inventory item from grocery item
                 inventory_item = InventoryItem(
                     name=item.item_name,

--- a/src/services/grocery_service.py
+++ b/src/services/grocery_service.py
@@ -1,0 +1,230 @@
+"""
+Grocery list service for FreshUp.
+
+Provides business logic for grocery list purchase operations,
+including single item and bulk purchase actions with optional
+inventory item creation.
+"""
+
+import logging
+from uuid import UUID
+from datetime import datetime, timezone
+from typing import Optional
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError
+from fastapi import HTTPException, status
+
+from src.db.models.user import User
+from src.db.models.grocery_list import GroceryListItem
+from src.db.models.inventory_item import InventoryItem
+
+logger = logging.getLogger(__name__)
+
+
+def mark_purchased(
+    item_id: UUID,
+    current_user: User,
+    db: Session,
+) -> GroceryListItem:
+    """
+    Mark a grocery item as purchased.
+
+    Sets purchased=True, purchased_by=current_user, purchased_date=now.
+    Any authenticated user can purchase any item (household coordination).
+
+    Args:
+        item_id: UUID of the grocery item to mark as purchased
+        current_user: Authenticated user performing the purchase
+        db: Database session
+
+    Returns:
+        GroceryListItem: Updated grocery item
+
+    Raises:
+        HTTPException(404): If item doesn't exist
+        HTTPException(500): If database error occurs
+    """
+    item = db.query(GroceryListItem).filter(GroceryListItem.id == item_id).first()
+
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Grocery item not found"
+        )
+
+    # Update purchase fields
+    item.purchased = True
+    item.purchased_by = current_user.id
+    item.purchased_date = datetime.now(timezone.utc)
+
+    try:
+        db.commit()
+        db.refresh(item)
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during grocery item purchase for user {current_user.id}")
+        logger.debug(f"Database error occurred during grocery item purchase: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while marking the item as purchased"
+        )
+
+    logger.info(
+        f"Grocery item purchased: user_id={current_user.id}, "
+        f"item_id={item_id}"
+    )
+
+    return item
+
+
+def mark_unpurchased(
+    item_id: UUID,
+    current_user: User,
+    db: Session,
+) -> GroceryListItem:
+    """
+    Reverse a grocery item purchase (mark as unpurchased).
+
+    Sets purchased=False, purchased_by=None, purchased_date=None.
+    Any authenticated user can unpurchase any item (household coordination).
+
+    Args:
+        item_id: UUID of the grocery item to mark as unpurchased
+        current_user: Authenticated user performing the unpurchase
+        db: Database session
+
+    Returns:
+        GroceryListItem: Updated grocery item
+
+    Raises:
+        HTTPException(404): If item doesn't exist
+        HTTPException(500): If database error occurs
+    """
+    item = db.query(GroceryListItem).filter(GroceryListItem.id == item_id).first()
+
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Grocery item not found"
+        )
+
+    # Clear purchase fields
+    item.purchased = False
+    item.purchased_by = None
+    item.purchased_date = None
+
+    try:
+        db.commit()
+        db.refresh(item)
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during grocery item unpurchase for user {current_user.id}")
+        logger.debug(f"Database error occurred during grocery item unpurchase: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while marking the item as unpurchased"
+        )
+
+    logger.info(
+        f"Grocery item unpurchased: user_id={current_user.id}, "
+        f"item_id={item_id}"
+    )
+
+    return item
+
+
+def bulk_purchase(
+    item_ids: list[UUID],
+    current_user: User,
+    db: Session,
+    create_inventory_item: bool = False,
+    storage_location: Optional[str] = None,
+    category: Optional[str] = None,
+) -> tuple[list[GroceryListItem], int]:
+    """
+    Mark multiple grocery items as purchased in a single atomic transaction.
+
+    Optionally creates inventory items from purchased groceries when
+    create_inventory_item=True. If any item_id is not found, the entire
+    transaction is rolled back.
+
+    Args:
+        item_ids: List of grocery item UUIDs to mark as purchased
+        current_user: Authenticated user performing the bulk purchase
+        db: Database session
+        create_inventory_item: Whether to create inventory items (default: False)
+        storage_location: Storage location for inventory items (required if create_inventory_item=True)
+        category: Category for inventory items (required if create_inventory_item=True)
+
+    Returns:
+        tuple[list[GroceryListItem], int]: Updated grocery items and count of inventory items created
+
+    Raises:
+        HTTPException(404): If any item_id is not found (entire batch fails)
+        HTTPException(500): If database error occurs
+    """
+    updated_items = []
+    inventory_count = 0
+    purchase_time = datetime.now(timezone.utc)
+
+    try:
+        # Atomic transaction: fetch all items first, fail entire batch if any not found
+        # This ensures all-or-nothing semantics - either all items are purchased or none are
+        for item_id in item_ids:
+            item = db.query(GroceryListItem).filter(GroceryListItem.id == item_id).first()
+
+            if not item:
+                # Rollback and fail entire batch
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Grocery item not found: {item_id}"
+                )
+
+            # Mark as purchased
+            item.purchased = True
+            item.purchased_by = current_user.id
+            item.purchased_date = purchase_time
+
+            updated_items.append(item)
+
+            # Optionally create inventory item
+            if create_inventory_item:
+                # Create inventory item from grocery item
+                inventory_item = InventoryItem(
+                    name=item.item_name,
+                    quantity=item.quantity,
+                    unit=item.unit,
+                    storage_location=storage_location,  # type: ignore - validated by schema
+                    category=category,  # type: ignore - validated by schema
+                    added_by=current_user.id,
+                )
+                db.add(inventory_item)
+                inventory_count += 1
+
+        # Commit all changes atomically
+        db.commit()
+
+        # Refresh all items to get updated data
+        for item in updated_items:
+            db.refresh(item)
+
+    except HTTPException:
+        # Re-raise HTTP exceptions (404s)
+        db.rollback()
+        raise
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during bulk grocery purchase for user {current_user.id}")
+        logger.debug(f"Database error occurred during bulk grocery purchase: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while processing the bulk purchase"
+        )
+
+    logger.info(
+        f"Bulk grocery purchase: user_id={current_user.id}, "
+        f"items_purchased={len(updated_items)}, "
+        f"inventory_items_created={inventory_count}"
+    )
+
+    return updated_items, inventory_count

--- a/src/services/grocery_service.py
+++ b/src/services/grocery_service.py
@@ -168,19 +168,21 @@ def bulk_purchase(
     purchase_time = datetime.now(timezone.utc)
 
     try:
-        # Atomic transaction: fetch all items first, fail entire batch if any not found
+        # Atomic transaction: fetch all items in a single query
         # This ensures all-or-nothing semantics - either all items are purchased or none are
-        for item_id in item_ids:
-            item = db.query(GroceryListItem).filter(GroceryListItem.id == item_id).first()
+        items = db.query(GroceryListItem).filter(GroceryListItem.id.in_(item_ids)).all()
 
-            if not item:
-                # Rollback and fail entire batch
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=f"Grocery item not found: {item_id}"
-                )
+        # Verify all requested items were found
+        if len(items) != len(item_ids):
+            found_ids = {item.id for item in items}
+            missing_ids = [item_id for item_id in item_ids if item_id not in found_ids]
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Grocery item not found: {missing_ids[0]}"
+            )
 
-            # Mark as purchased
+        # Mark all items as purchased
+        for item in items:
             item.purchased = True
             item.purchased_by = current_user.id
             item.purchased_date = purchase_time

--- a/tests/routers/test_grocery.py
+++ b/tests/routers/test_grocery.py
@@ -547,3 +547,15 @@ class TestBulkPurchase:
         response = client.post("/grocery/bulk-purchase", json=payload)
 
         assert response.status_code == 401
+
+    def test_bulk_purchase_exceeds_max_batch_size(self, client, auth_headers):
+        """Should return 422 if item_ids list exceeds maximum batch size of 100."""
+        # Create a list with 101 items (exceeds max_length=100)
+        payload = {
+            "item_ids": [str(uuid4()) for _ in range(101)],
+            "create_inventory_item": False,
+        }
+
+        response = client.post("/grocery/bulk-purchase", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422

--- a/tests/routers/test_grocery.py
+++ b/tests/routers/test_grocery.py
@@ -1,0 +1,549 @@
+"""
+Integration tests for grocery list purchase endpoints.
+
+Tests cover:
+- PUT /grocery/{id}/purchase: mark single item as purchased
+- PUT /grocery/{id}/unpurchase: reverse purchase
+- POST /grocery/bulk-purchase: bulk purchase with optional inventory creation
+- Cross-user purchase allowed (household coordination)
+- Conditional validation (storage_location and category required when create_inventory_item=true)
+- Atomic transactions for bulk operations
+- 404 handling for missing items
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from uuid import uuid4
+from datetime import datetime, timezone
+
+from src.db.database import Base, get_db
+from src.db import models
+from src.db.models.user import User, UserRole
+from src.db.models.grocery_list import GroceryListItem, GrocerySource
+from src.db.models.inventory_item import InventoryItem
+from src.services.auth_service import hash_password, create_access_token
+
+from fastapi import FastAPI
+from src.routers import grocery_router
+
+# Create a test app without lifespan
+app = FastAPI(
+    title="FreshUp",
+    description="Privacy-first kitchen management system",
+    version="0.1.0",
+)
+
+# Register the grocery router
+app.include_router(grocery_router)
+
+# Create an in-memory SQLite database for testing
+TEST_DATABASE_URL = "sqlite:///:memory:"
+
+
+@pytest.fixture(autouse=True)
+def setup_test_env(monkeypatch):
+    """Set up test environment variables."""
+    from src.config import get_settings
+    get_settings.cache_clear()
+
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars")
+    monkeypatch.setenv("JWT_ALGORITHM", "HS256")
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    monkeypatch.setenv("ACCESS_TOKEN_EXPIRE_MINUTES", "43200")
+
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def db_session():
+    """Create a fresh database session for each test."""
+    from sqlalchemy.pool import StaticPool
+
+    # Import models to ensure all SQLAlchemy model classes are registered
+    # with Base.metadata before create_all() is called
+    _ = models
+
+    engine = create_engine(
+        TEST_DATABASE_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+@pytest.fixture
+def client(db_session):
+    """Create a test client with database dependency override."""
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def test_user(db_session):
+    """Create a test user."""
+    user = User(
+        id=uuid4(),
+        email="test@example.com",
+        hashed_password=hash_password("testpassword123"),
+        name="Test User",
+        role=UserRole.member.value,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def test_user2(db_session):
+    """Create a second test user for cross-user purchase tests."""
+    user = User(
+        id=uuid4(),
+        email="test2@example.com",
+        hashed_password=hash_password("testpassword123"),
+        name="Test User 2",
+        role=UserRole.member.value,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def auth_headers(test_user):
+    """Generate authorization headers for test user."""
+    access_token = create_access_token({"sub": str(test_user.id)})
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+@pytest.fixture
+def auth_headers2(test_user2):
+    """Generate authorization headers for test user 2."""
+    access_token = create_access_token({"sub": str(test_user2.id)})
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+@pytest.fixture
+def test_grocery_item(db_session, test_user):
+    """Create a test grocery item."""
+    item = GroceryListItem(
+        id=uuid4(),
+        item_name="Milk",
+        quantity=1.0,
+        unit="gallon",
+        source=GrocerySource.manual.value,
+        added_by=test_user.id,
+        purchased=False,
+    )
+    db_session.add(item)
+    db_session.commit()
+    db_session.refresh(item)
+    return item
+
+
+@pytest.fixture
+def test_grocery_item_purchased(db_session, test_user):
+    """Create a test grocery item that's already purchased."""
+    purchase_time = datetime.now(timezone.utc)
+    item = GroceryListItem(
+        id=uuid4(),
+        item_name="Bread",
+        quantity=2.0,
+        unit="count",
+        source=GrocerySource.manual.value,
+        added_by=test_user.id,
+        purchased=True,
+        purchased_by=test_user.id,
+        purchased_date=purchase_time,
+    )
+    db_session.add(item)
+    db_session.commit()
+    db_session.refresh(item)
+    return item
+
+
+class TestPurchaseItem:
+    """Tests for PUT /grocery/{id}/purchase (mark single item as purchased)."""
+
+    def test_purchase_success(self, client, auth_headers, test_grocery_item, test_user, db_session):
+        """Should mark item as purchased with current user and timestamp."""
+        response = client.put(
+            f"/grocery/{test_grocery_item.id}/purchase",
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == str(test_grocery_item.id)
+        assert data["purchased"] is True
+        assert data["purchased_by"] == str(test_user.id)
+        assert data["purchased_date"] is not None
+
+        # Verify in database
+        db_session.refresh(test_grocery_item)
+        assert test_grocery_item.purchased is True
+        assert test_grocery_item.purchased_by == test_user.id
+        assert test_grocery_item.purchased_date is not None
+
+    def test_purchase_cross_user_allowed(self, client, auth_headers2, test_grocery_item, test_user2, db_session):
+        """Should allow any authenticated user to purchase any item (household coordination)."""
+        # test_grocery_item was added by test_user, but test_user2 should be able to purchase it
+        response = client.put(
+            f"/grocery/{test_grocery_item.id}/purchase",
+            headers=auth_headers2
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["purchased"] is True
+        assert data["purchased_by"] == str(test_user2.id)  # Purchased by user2, not owner
+
+    def test_purchase_already_purchased(self, client, auth_headers, test_grocery_item_purchased):
+        """Should allow re-purchasing an already purchased item (updates timestamp)."""
+        original_date = test_grocery_item_purchased.purchased_date
+
+        response = client.put(
+            f"/grocery/{test_grocery_item_purchased.id}/purchase",
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["purchased"] is True
+        # Timestamp should be updated (newer than original)
+
+    def test_purchase_not_found(self, client, auth_headers):
+        """Should return 404 if item doesn't exist."""
+        fake_id = uuid4()
+        response = client.put(
+            f"/grocery/{fake_id}/purchase",
+            headers=auth_headers
+        )
+
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+    def test_purchase_unauthenticated(self, client, test_grocery_item):
+        """Should return 401 if no auth token provided."""
+        response = client.put(f"/grocery/{test_grocery_item.id}/purchase")
+
+        assert response.status_code == 401
+
+
+class TestUnpurchaseItem:
+    """Tests for PUT /grocery/{id}/unpurchase (reverse purchase)."""
+
+    def test_unpurchase_success(self, client, auth_headers, test_grocery_item_purchased, db_session):
+        """Should mark item as unpurchased and clear purchase fields."""
+        response = client.put(
+            f"/grocery/{test_grocery_item_purchased.id}/unpurchase",
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == str(test_grocery_item_purchased.id)
+        assert data["purchased"] is False
+        assert data["purchased_by"] is None
+        assert data["purchased_date"] is None
+
+        # Verify in database
+        db_session.refresh(test_grocery_item_purchased)
+        assert test_grocery_item_purchased.purchased is False
+        assert test_grocery_item_purchased.purchased_by is None
+        assert test_grocery_item_purchased.purchased_date is None
+
+    def test_unpurchase_cross_user_allowed(self, client, auth_headers2, test_grocery_item_purchased):
+        """Should allow any authenticated user to unpurchase any item (household coordination)."""
+        # test_grocery_item_purchased was purchased by test_user, but test_user2 should be able to unpurchase it
+        response = client.put(
+            f"/grocery/{test_grocery_item_purchased.id}/unpurchase",
+            headers=auth_headers2
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["purchased"] is False
+
+    def test_unpurchase_already_unpurchased(self, client, auth_headers, test_grocery_item):
+        """Should allow unpurchasing an already unpurchased item (idempotent)."""
+        response = client.put(
+            f"/grocery/{test_grocery_item.id}/unpurchase",
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["purchased"] is False
+
+    def test_unpurchase_not_found(self, client, auth_headers):
+        """Should return 404 if item doesn't exist."""
+        fake_id = uuid4()
+        response = client.put(
+            f"/grocery/{fake_id}/unpurchase",
+            headers=auth_headers
+        )
+
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+    def test_unpurchase_unauthenticated(self, client, test_grocery_item_purchased):
+        """Should return 401 if no auth token provided."""
+        response = client.put(f"/grocery/{test_grocery_item_purchased.id}/unpurchase")
+
+        assert response.status_code == 401
+
+
+class TestBulkPurchase:
+    """Tests for POST /grocery/bulk-purchase (bulk purchase with optional inventory creation)."""
+
+    def test_bulk_purchase_success(self, client, auth_headers, test_user, db_session):
+        """Should mark multiple items as purchased atomically."""
+        # Create multiple grocery items
+        item1 = GroceryListItem(
+            id=uuid4(),
+            item_name="Apples",
+            quantity=5.0,
+            unit="count",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            purchased=False,
+        )
+        item2 = GroceryListItem(
+            id=uuid4(),
+            item_name="Bananas",
+            quantity=3.0,
+            unit="bunch",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            purchased=False,
+        )
+        db_session.add_all([item1, item2])
+        db_session.commit()
+
+        payload = {
+            "item_ids": [str(item1.id), str(item2.id)],
+            "create_inventory_item": False,
+        }
+
+        response = client.post("/grocery/bulk-purchase", json=payload, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["items"]) == 2
+        assert data["inventory_items_created"] == 0
+
+        # Verify all items are purchased
+        for item_data in data["items"]:
+            assert item_data["purchased"] is True
+            assert item_data["purchased_by"] == str(test_user.id)
+            assert item_data["purchased_date"] is not None
+
+    def test_bulk_purchase_with_inventory_creation(self, client, auth_headers, test_user, db_session):
+        """Should create inventory items from purchased groceries when flag is true."""
+        # Create grocery items
+        item1 = GroceryListItem(
+            id=uuid4(),
+            item_name="Cheese",
+            quantity=1.0,
+            unit="lb",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            purchased=False,
+        )
+        item2 = GroceryListItem(
+            id=uuid4(),
+            item_name="Yogurt",
+            quantity=2.0,
+            unit="count",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            purchased=False,
+        )
+        db_session.add_all([item1, item2])
+        db_session.commit()
+
+        payload = {
+            "item_ids": [str(item1.id), str(item2.id)],
+            "create_inventory_item": True,
+            "storage_location": "fridge",
+            "category": "dairy",
+        }
+
+        response = client.post("/grocery/bulk-purchase", json=payload, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["items"]) == 2
+        assert data["inventory_items_created"] == 2
+
+        # Verify inventory items were created
+        inventory_items = db_session.query(InventoryItem).filter(
+            InventoryItem.added_by == test_user.id
+        ).all()
+        assert len(inventory_items) == 2
+
+        # Check inventory item properties
+        cheese_inv = [i for i in inventory_items if i.name == "Cheese"][0]
+        assert cheese_inv.quantity == 1.0
+        assert cheese_inv.unit == "lb"
+        assert cheese_inv.storage_location == "fridge"
+        assert cheese_inv.category == "dairy"
+        assert cheese_inv.added_by == test_user.id
+
+    def test_bulk_purchase_conditional_validation_missing_storage(self, client, auth_headers, test_user, db_session):
+        """Should return 422 when create_inventory_item=true but storage_location is missing."""
+        item = GroceryListItem(
+            id=uuid4(),
+            item_name="Eggs",
+            quantity=12.0,
+            unit="count",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            purchased=False,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        payload = {
+            "item_ids": [str(item.id)],
+            "create_inventory_item": True,
+            "category": "protein",
+            # storage_location missing - should fail
+        }
+
+        response = client.post("/grocery/bulk-purchase", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+        # Verify item was NOT purchased (transaction rolled back)
+        db_session.refresh(item)
+        assert item.purchased is False
+
+    def test_bulk_purchase_conditional_validation_missing_category(self, client, auth_headers, test_user, db_session):
+        """Should return 422 when create_inventory_item=true but category is missing."""
+        item = GroceryListItem(
+            id=uuid4(),
+            item_name="Butter",
+            quantity=1.0,
+            unit="lb",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            purchased=False,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        payload = {
+            "item_ids": [str(item.id)],
+            "create_inventory_item": True,
+            "storage_location": "fridge",
+            # category missing - should fail
+        }
+
+        response = client.post("/grocery/bulk-purchase", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+        # Verify item was NOT purchased (transaction rolled back)
+        db_session.refresh(item)
+        assert item.purchased is False
+
+    def test_bulk_purchase_item_not_found(self, client, auth_headers, test_user, db_session):
+        """Should return 404 and rollback entire batch if any item not found."""
+        # Create one valid item
+        item1 = GroceryListItem(
+            id=uuid4(),
+            item_name="Valid Item",
+            quantity=1.0,
+            unit="count",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            purchased=False,
+        )
+        db_session.add(item1)
+        db_session.commit()
+
+        # Include one fake ID
+        fake_id = uuid4()
+        payload = {
+            "item_ids": [str(item1.id), str(fake_id)],
+            "create_inventory_item": False,
+        }
+
+        response = client.post("/grocery/bulk-purchase", json=payload, headers=auth_headers)
+
+        assert response.status_code == 404
+        assert str(fake_id) in response.json()["detail"]
+
+        # Verify the valid item was NOT purchased (entire batch rolled back)
+        db_session.refresh(item1)
+        assert item1.purchased is False
+
+    def test_bulk_purchase_cross_user_allowed(self, client, auth_headers2, test_user, test_user2, db_session):
+        """Should allow any authenticated user to bulk purchase items added by others."""
+        # Create items added by test_user
+        item = GroceryListItem(
+            id=uuid4(),
+            item_name="Rice",
+            quantity=2.0,
+            unit="lb",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            purchased=False,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        # test_user2 purchases items added by test_user
+        payload = {
+            "item_ids": [str(item.id)],
+            "create_inventory_item": False,
+        }
+
+        response = client.post("/grocery/bulk-purchase", json=payload, headers=auth_headers2)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["items"][0]["purchased_by"] == str(test_user2.id)  # Purchased by user2
+
+    def test_bulk_purchase_empty_list(self, client, auth_headers):
+        """Should return 422 if item_ids list is empty."""
+        payload = {
+            "item_ids": [],
+            "create_inventory_item": False,
+        }
+
+        response = client.post("/grocery/bulk-purchase", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+
+    def test_bulk_purchase_unauthenticated(self, client, test_grocery_item):
+        """Should return 401 if no auth token provided."""
+        payload = {
+            "item_ids": [str(test_grocery_item.id)],
+            "create_inventory_item": False,
+        }
+
+        response = client.post("/grocery/bulk-purchase", json=payload)
+
+        assert response.status_code == 401


### PR DESCRIPTION
## Work in Progress

Closes #170

[Phase 1F] Add purchase check-off endpoints

**Time Estimate**: 1hr 30min

**Description**:
Add endpoints to mark grocery items as purchased (or unpurchase), including a bulk variant for checking off multiple items after a shopping trip. Per the ADR, any authenticated user can purchase/unpurchase any item — this is a household coordination action, not owner-restricted. Optionally create an inventory item on purchase via create_inventory_item flag with conditional validation.

**Claude Context**:
Files to Read:
- src/db/models/grocery_list.py (purchased, purchased_by, purchased_date fields)
- src/db/models/inventory_item.py (InventoryItem model, Category, StorageLocation enums)
- src/routers/inventory.py (cross-model transaction patterns)
- src/schemas/inventory.py (InventoryItemCreate reference)

Files to Modify:
- src/services/grocery_service.py (add purchase logic)
- src/routers/grocery.py (add purchase endpoints)
- tests/routers/test_grocery.py (add purchase tests)

Related Issues: Depends on #168 (CRUD must exist), Uses schemas from #167

**Acceptance Criteria**:
- [ ] PUT /grocery/{id}/purchase marks item purchased: sets purchased=true, purchased_by=current_user, purchased_date=now
- [ ] PUT /grocery/{id}/unpurchase reverses purchase: purchased=false, purchased_by=null, purchased_date=null
- [ ] Any authenticated user can purchase/unpurchase ANY item regardless of who added it (household coordination, not owner-restricted)
- [ ] POST /grocery/bulk-purchase accepts BulkPurchaseRequest with list of item_ids, marks all as purchased atomically
- [ ] Bulk purchase with create_inventory_item=true creates InventoryItem for each item (cross-domain bridge)
- [ ] When create_inventory_item=true, storage_location and category are REQUIRED (422 if missing): validate these fields only when flag is true
- [ ] Inventory items created with: name=item_name, quantity=grocery quantity, unit=grocery unit, added_by=current_user, storage_location and category from request
- [ ] Response reuses GroceryItemResponse schema (no separate MarkPurchasedResponse)
- [ ] Bulk response returns list of updated items + count of inventory items created
- [ ] 404 if item_id not found (fail entire batch for bulk)
- [ ] Tests cover: single purchase, unpurchase, bulk purchase, inventory creation, conditional validation (422 when flag=true but fields missing), cross-user purchase allowed

**Verification Commands**:
```bash
pytest tests/routers/test_grocery.py::test_purchase -v
pytest tests/routers/test_grocery.py::test_bulk_purchase -v
curl -X PUT localhost:8000/grocery/{id}/purchase -H "Authorization: Bearer $TOKEN"
curl -X POST localhost:8000/grocery/bulk-purchase -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d '{"item_ids":["uuid1","uuid2"],"create_inventory_item":true,"storage_location":"fridge","category":"dairy"}'
```

**Done Definition**: Done when purchase/unpurchase/bulk-purchase work with any-user access and optional inventory creation passes all tests.

**Scope Boundary**:
- DO: Add PUT /grocery/{id}/purchase and /unpurchase endpoints
- DO: Add POST /grocery/bulk-purchase endpoint
- DO: Allow any authenticated user to purchase/unpurchase any item
- DO: Implement optional inventory creation with conditional field validation
- DO: Atomic transaction for bulk operations (rollback on any failure)
- DO NOT: Add consumption pattern tracking (deferred to Phase 4C)
- DO NOT: Auto-add to grocery list from meal plan (deferred to Phase 3B)

**Dependencies**: After #168 (CRUD endpoints)

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**12** files, **2** commits (+3 added, ~8 modified, -1 deleted)
- `D` alembic/versions/f9d8c7b6a5e4_add_timestamps_to_recipe_models.py
- `M` src/db/models/recipe.py
- `M` src/db/models/recipe_ingredient.py
- `M` src/db/models/user_recipe.py
- `M` src/main.py
- `M` src/routers/__init__.py
- `A` src/routers/grocery.py
- `M` src/routers/recipes.py
- `M` src/schemas/grocery.py
- `A` src/services/grocery_service.py
- `A` tests/routers/test_grocery.py
- `M` tests/routers/test_recipes.py

### Commits
- 0f78b82 feat: [Phase 1F] Add purchase check-off endpoints
- 3b43e9a chore: initialize work on #170 [Phase 1F] Add purchase check-off endpoints
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues
 Updated: #183 Created: #183 
**From assessment on 2026-03-21T08:13:25Z:**
- Created: #181 
- Updated: none