### PR TITLE
Thaw endpoint: unhardcode fridge, update expiry

### DIFF
--- a/src/routers/inventory.py
+++ b/src/routers/inventory.py
@@ -34,6 +34,7 @@ from src.schemas.inventory import (
     AddAvailableStoreRequest,
     UpdateShareabilityRequest,
     LowStockAlertItem,
+    ThawRequest,
     ConsumptionRequest,
     ConsumptionResponse,
     BulkInventoryItemCreate,
@@ -906,33 +907,40 @@ def freeze_inventory_item(
 @router.post("/{item_id}/thaw", response_model=InventoryItemResponse)
 def thaw_inventory_item(
     item_id: UUID,
+    thaw_data: ThawRequest = ThawRequest(),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
     """
     Thaw an inventory item (quick action).
 
-    Updates the item's storage location to "fridge" and clears the frozen_date.
-    This endpoint is idempotent - thawing a non-frozen item does not raise an error.
+    Updates the item's storage location to the specified destination (defaults to "fridge"),
+    clears the frozen_date, and clears the expiration_date (as thawed items have different
+    shelf life than frozen items). This endpoint is idempotent - thawing a non-frozen item
+    does not raise an error.
 
     Args:
         item_id: UUID of the inventory item to thaw
+        thaw_data: Thaw configuration (destination storage location)
         current_user: Authenticated user (injected by get_current_user dependency)
         db: Database session
 
     Returns:
-        InventoryItemResponse: Updated inventory item with fridge location and cleared frozen_date
+        InventoryItemResponse: Updated inventory item with specified destination, cleared frozen_date and expiration_date
 
     Raises:
         HTTPException(401): If Authorization header is missing or token is invalid
         HTTPException(404): If item doesn't exist or belongs to another user
+        HTTPException(422): If destination is "freezer" (invalid thaw destination)
     """
     # Verify item exists and belongs to current user
     item = verify_inventory_item_ownership(item_id, current_user, db)
 
-    # Update storage location and clear frozen date
-    item.storage_location = StorageLocation.fridge.value
+    # Update storage location to destination and clear frozen date
+    item.storage_location = thaw_data.destination
     item.frozen_date = None
+    # Clear expiration date - thawed items have different shelf life than frozen items
+    item.expiration_date = None
 
     try:
         db.commit()

--- a/src/schemas/inventory.py
+++ b/src/schemas/inventory.py
@@ -263,6 +263,30 @@ class LowStockAlertItem(BaseModel):
     deficit: float = Field(..., description="How many units below threshold (threshold - quantity)")
 
 
+class ThawRequest(BaseModel):
+    """Request schema for thawing inventory items."""
+
+    destination: str = Field(
+        default=StorageLocation.fridge.value,
+        description="Storage location after thawing (pantry or fridge, cannot be freezer)"
+    )
+
+    @field_validator('destination')
+    @classmethod
+    def validate_destination_field(cls, v: str) -> str:
+        """Ensure destination is a valid StorageLocation value and not freezer."""
+        # First validate it's a valid StorageLocation enum value
+        validated = validate_enum_value('Destination', v, StorageLocation, allow_none=False)
+        # validate_enum_value handles Optional, but this field is required so won't be None
+        assert validated is not None  # Type narrowing for mypy
+
+        # Check that destination is not freezer (thawing to freezer is nonsensical)
+        if validated == StorageLocation.freezer.value:
+            raise ValueError("Cannot thaw to freezer. Valid destinations: pantry, fridge")
+
+        return validated
+
+
 class ConsumptionRequest(BaseModel):
     """Request schema for consuming inventory items."""
 

--- a/tests/routers/test_inventory.py
+++ b/tests/routers/test_inventory.py
@@ -2329,6 +2329,33 @@ class TestFreezeThawActions:
         assert response.status_code == 422
         assert "freezer" in response.json()["detail"][0]["msg"].lower()
 
+    def test_thaw_invalid_destination_fails(self, client, auth_headers, test_user, db_session):
+        """Should return 422 when destination is not a valid enum value."""
+        from datetime import datetime, timezone
+        # Create frozen item
+        item = InventoryItem(
+            name="Frozen Fish",
+            quantity=1.5,
+            unit="lb",
+            category="protein",
+            storage_location="freezer",
+            frozen_date=datetime.now(timezone.utc),
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Try to thaw to invalid location
+        response = client.post(
+            f"/inventory/{item.id}/thaw",
+            headers=auth_headers,
+            json={"destination": "garage"}
+        )
+
+        assert response.status_code == 422
+        assert "garage" in response.json()["detail"][0]["msg"].lower()
+
     def test_thaw_clears_expiration_date(self, client, auth_headers, test_user, db_session):
         """Should clear expiration_date when thawing (thawed items have different shelf life)."""
         from datetime import datetime, timezone, timedelta

--- a/tests/routers/test_inventory.py
+++ b/tests/routers/test_inventory.py
@@ -2240,6 +2240,7 @@ class TestFreezeThawActions:
         thaw_data = thaw_response.json()
         assert thaw_data["storage_location"] == "fridge"
         assert thaw_data["frozen_date"] is None
+        assert thaw_data["expiration_date"] is None  # Expiration cleared on thaw
 
     def test_thaw_then_freeze_transition(self, client, auth_headers, test_user, db_session):
         """Should transition item from thaw to freeze correctly."""
@@ -2271,6 +2272,115 @@ class TestFreezeThawActions:
         freeze_data = freeze_response.json()
         assert freeze_data["storage_location"] == "freezer"
         assert freeze_data["frozen_date"] is not None
+
+    def test_thaw_to_custom_destination_pantry(self, client, auth_headers, test_user, db_session):
+        """Should thaw item to pantry when destination is specified."""
+        from datetime import datetime, timezone
+        # Create frozen item
+        item = InventoryItem(
+            name="Frozen Bread",
+            quantity=1.0,
+            unit="count",
+            category="grain",
+            storage_location="freezer",
+            frozen_date=datetime.now(timezone.utc),
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Thaw to pantry
+        response = client.post(
+            f"/inventory/{item.id}/thaw",
+            headers=auth_headers,
+            json={"destination": "pantry"}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["storage_location"] == "pantry"
+        assert data["frozen_date"] is None
+
+    def test_thaw_to_freezer_fails(self, client, auth_headers, test_user, db_session):
+        """Should return 422 when trying to thaw to freezer (nonsensical operation)."""
+        from datetime import datetime, timezone
+        # Create frozen item
+        item = InventoryItem(
+            name="Frozen Chicken",
+            quantity=2.0,
+            unit="lb",
+            category="protein",
+            storage_location="freezer",
+            frozen_date=datetime.now(timezone.utc),
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Try to thaw to freezer
+        response = client.post(
+            f"/inventory/{item.id}/thaw",
+            headers=auth_headers,
+            json={"destination": "freezer"}
+        )
+
+        assert response.status_code == 422
+        assert "freezer" in response.json()["detail"][0]["msg"].lower()
+
+    def test_thaw_clears_expiration_date(self, client, auth_headers, test_user, db_session):
+        """Should clear expiration_date when thawing (thawed items have different shelf life)."""
+        from datetime import datetime, timezone, timedelta
+        # Create frozen item with expiration date
+        expiration = datetime.now(timezone.utc) + timedelta(days=30)
+        item = InventoryItem(
+            name="Frozen Meat",
+            quantity=2.0,
+            unit="lb",
+            category="protein",
+            storage_location="freezer",
+            frozen_date=datetime.now(timezone.utc),
+            expiration_date=expiration,
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Thaw the item
+        response = client.post(f"/inventory/{item.id}/thaw", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["storage_location"] == "fridge"
+        assert data["frozen_date"] is None
+        assert data["expiration_date"] is None  # Expiration cleared
+
+    def test_thaw_default_destination_fridge_backwards_compatibility(self, client, auth_headers, test_user, db_session):
+        """Should default to fridge when no destination specified (backwards compatibility)."""
+        from datetime import datetime, timezone
+        # Create frozen item
+        item = InventoryItem(
+            name="Frozen Vegetables",
+            quantity=1.0,
+            unit="lb",
+            category="produce",
+            storage_location="freezer",
+            frozen_date=datetime.now(timezone.utc),
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        # Thaw without specifying destination (empty body)
+        response = client.post(f"/inventory/{item.id}/thaw", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["storage_location"] == "fridge"  # Default to fridge
+        assert data["frozen_date"] is None
 
 
 class TestLowStockAlerts:


### PR DESCRIPTION
## Work in Progress

Closes #165

Thaw endpoint: unhardcode fridge, update expiry

## Description

The thaw endpoint (`POST /inventory/{item_id}/thaw`) has two limitations flagged during 1D review:

1. **Hardcoded fridge destination** — Line 1011 of `src/routers/inventory.py` sets `storage_location = StorageLocation.fridge.value` unconditionally. Users may want to thaw to countertop or pantry (e.g., thawing bread to eat immediately). Issue #81's scope boundary explicitly marked this as "DO NOT: Track thaw expiration recommendations (future enhancement)."

2. **Expiration date not updated on thaw** — Frozen items preserve their pre-freeze expiration date. After thawing, the original expiration is stale — thawed items typically have a shorter shelf life than fresh ones. The endpoint currently only clears `frozen_date` and sets `storage_location`, leaving `expiration_date` untouched.

## Claude Context
Files to Read:
- `src/routers/inventory.py` (thaw endpoint, lines ~970-1031; freeze endpoint, lines ~905-967)
- `src/db/models/inventory_item.py` (storage_location, expiration_date, frozen_date fields)
- `tests/routers/test_inventory.py` (freeze/thaw tests, lines ~1958-2273)

Files to Modify:
- `src/routers/inventory.py` — accept optional `destination` param on thaw, add expiration recalculation
- `tests/routers/test_inventory.py` — add tests for custom destination and expiration update

Related Issues: #81 (closed — original freeze/thaw implementation)

## Acceptance Criteria
- [ ] Thaw endpoint accepts optional `destination` body param (defaults to "fridge" for backwards compatibility): `pytest tests/routers/test_inventory.py -k thaw -v`
- [ ] Valid destinations: any `StorageLocation` value except "freezer" (thawing to freezer is nonsensical): verify 422 on freezer destination
- [ ] Expiration date behavior is defined (options to consider: clear it, set a configurable post-thaw window, or require user input): document decision
- [ ] Existing thaw tests still pass (default behavior unchanged): `pytest tests/routers/test_inventory.py -k thaw -v`
- [ ] New tests for custom destination: `pytest tests/routers/test_inventory.py -k thaw_destination -v`
- [ ] New tests for expiration update behavior: `pytest tests/routers/test_inventory.py -k thaw_expiration -v`

## Verification Commands
```bash
pytest tests/routers/test_inventory.py -k thaw -v
```

## Done Definition
Done when thaw supports a configurable destination, expiration date handling is implemented and tested, and all existing tests pass.

## Scope Boundary
- DO: Add optional destination parameter to thaw endpoint
- DO: Implement expiration date update logic on thaw
- DO: Maintain backwards compatibility (no destination = fridge)
- DO NOT: Change freeze endpoint behavior
- DO NOT: Add category-specific thaw duration rules (future enhancement — would need a food category reference table)

## Dependencies
None

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **2** commits (+0 added, ~3 modified, -0 deleted)
- `M` src/routers/inventory.py
- `M` src/schemas/inventory.py
- `M` tests/routers/test_inventory.py

### Commits
- 5757766 feat: Thaw endpoint: unhardcode fridge, update expiry
- a7d33c3 chore: initialize work on #165 Thaw endpoint: unhardcode fridge, update expiry
<!-- /sharkrite-changes-summary -->