### PR TITLE
Add cross-domain inventory unit validation

### DIFF
--- a/src/services/grocery_service.py
+++ b/src/services/grocery_service.py
@@ -20,6 +20,9 @@ from src.db.models.inventory_item import InventoryItem, UnitType
 
 logger = logging.getLogger(__name__)
 
+# Pre-computed set of valid inventory units for cross-domain validation
+_VALID_INVENTORY_UNITS = {unit_type.value for unit_type in UnitType}
+
 
 def _validate_unit_for_inventory(unit: str, item_name: str) -> None:
     """
@@ -36,11 +39,10 @@ def _validate_unit_for_inventory(unit: str, item_name: str) -> None:
     Raises:
         HTTPException(422): If the unit is not a valid UnitType enum value
     """
-    valid_units = {unit_type.value for unit_type in UnitType}
-    if unit not in valid_units:
+    if unit not in _VALID_INVENTORY_UNITS:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Cannot create inventory item for '{item_name}': unit '{unit}' is not valid for inventory. Valid units: {', '.join(sorted(valid_units))}"
+            detail=f"Cannot create inventory item for '{item_name}': unit '{unit}' is not valid for inventory. Valid units: {', '.join(sorted(_VALID_INVENTORY_UNITS))}"
         )
 
 

--- a/src/services/grocery_service.py
+++ b/src/services/grocery_service.py
@@ -206,6 +206,13 @@ def bulk_purchase(
                 detail=f"Grocery item not found: {missing_ids[0]}"
             )
 
+        # Pre-validate all units before making any modifications (ensures atomic all-or-nothing)
+        if create_inventory_item:
+            for item in items:
+                # Only validate items that will actually create inventory (not already purchased)
+                if not item.purchased:
+                    _validate_unit_for_inventory(item.unit, item.item_name)
+
         # Mark all items as purchased
         for item in items:
             # Track if item was already purchased (to prevent duplicate inventory creation)
@@ -219,10 +226,8 @@ def bulk_purchase(
 
             # Optionally create inventory item (only if not already purchased)
             if create_inventory_item and not was_already_purchased:
-                # Validate unit compatibility at cross-domain boundary
-                _validate_unit_for_inventory(item.unit, item.item_name)
-
                 # Create inventory item from grocery item
+                # (unit already validated in pre-validation phase above)
                 inventory_item = InventoryItem(
                     name=item.item_name,
                     quantity=item.quantity,

--- a/src/services/grocery_service.py
+++ b/src/services/grocery_service.py
@@ -16,9 +16,32 @@ from fastapi import HTTPException, status
 
 from src.db.models.user import User
 from src.db.models.grocery_list import GroceryListItem
-from src.db.models.inventory_item import InventoryItem
+from src.db.models.inventory_item import InventoryItem, UnitType
 
 logger = logging.getLogger(__name__)
+
+
+def _validate_unit_for_inventory(unit: str, item_name: str) -> None:
+    """
+    Validate that a unit value is compatible with the inventory domain's UnitType enum.
+
+    This function provides cross-domain validation at the boundary between grocery
+    and inventory domains, ensuring data integrity when converting grocery items
+    to inventory items.
+
+    Args:
+        unit: The unit string to validate
+        item_name: Name of the item (for error messages)
+
+    Raises:
+        HTTPException(422): If the unit is not a valid UnitType enum value
+    """
+    valid_units = {unit_type.value for unit_type in UnitType}
+    if unit not in valid_units:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Cannot create inventory item for '{item_name}': unit '{unit}' is not valid for inventory. Valid units: {', '.join(sorted(valid_units))}"
+        )
 
 
 def mark_purchased(
@@ -194,6 +217,9 @@ def bulk_purchase(
 
             # Optionally create inventory item (only if not already purchased)
             if create_inventory_item and not was_already_purchased:
+                # Validate unit compatibility at cross-domain boundary
+                _validate_unit_for_inventory(item.unit, item.item_name)
+
                 # Create inventory item from grocery item
                 inventory_item = InventoryItem(
                     name=item.item_name,

--- a/tests/routers/test_grocery.py
+++ b/tests/routers/test_grocery.py
@@ -559,3 +559,84 @@ class TestBulkPurchase:
         response = client.post("/grocery/bulk-purchase", json=payload, headers=auth_headers)
 
         assert response.status_code == 422
+
+    def test_bulk_purchase_with_invalid_unit_for_inventory(self, client, auth_headers, test_user, db_session):
+        """Should return 422 when grocery item has invalid unit during inventory creation."""
+        # Create a grocery item with an invalid unit using SQLAlchemy Core
+        # to bypass Pydantic schema validation. This simulates data corruption
+        # or migration scenarios where invalid data might exist in the database.
+        from sqlalchemy import insert
+        from src.db.models.grocery_list import GroceryListItem as GroceryTable
+
+        invalid_item_id = uuid4()
+
+        # Use SQLAlchemy insert to bypass ORM validations
+        stmt = insert(GroceryTable.__table__).values(
+            id=invalid_item_id,
+            item_name="Test Item",
+            quantity=1.0,
+            unit="invalid_unit",
+            source="manual",
+            added_by=test_user.id,
+            purchased=False,
+        )
+        db_session.execute(stmt)
+        db_session.commit()
+
+        payload = {
+            "item_ids": [str(invalid_item_id)],
+            "create_inventory_item": True,
+            "storage_location": "pantry",
+            "category": "other",
+        }
+
+        response = client.post("/grocery/bulk-purchase", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+        assert "unit 'invalid_unit' is not valid for inventory" in response.json()["detail"]
+        assert "Valid units:" in response.json()["detail"]
+
+    def test_bulk_purchase_valid_units_accepted(self, client, auth_headers, test_user, db_session):
+        """Should accept all valid UnitType enum values when creating inventory items."""
+        from src.db.models.inventory_item import UnitType
+
+        # Test a sample of valid units
+        test_units = ["oz", "lb", "g", "kg", "count", "cup"]
+        item_ids = []
+
+        for unit in test_units:
+            item = GroceryListItem(
+                id=uuid4(),
+                item_name=f"Test {unit}",
+                quantity=1.0,
+                unit=unit,
+                source=GrocerySource.manual.value,
+                added_by=test_user.id,
+                purchased=False,
+            )
+            db_session.add(item)
+            item_ids.append(str(item.id))
+
+        db_session.commit()
+
+        payload = {
+            "item_ids": item_ids,
+            "create_inventory_item": True,
+            "storage_location": "pantry",
+            "category": "other",
+        }
+
+        response = client.post("/grocery/bulk-purchase", json=payload, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["inventory_items_created"] == len(test_units)
+
+        # Verify all inventory items were created with correct units
+        inventory_items = db_session.query(InventoryItem).filter(
+            InventoryItem.added_by == test_user.id
+        ).all()
+        assert len(inventory_items) == len(test_units)
+
+        created_units = {item.unit for item in inventory_items}
+        assert created_units == set(test_units)


### PR DESCRIPTION
## Work in Progress

Closes #181

Add cross-domain inventory unit validation

<!-- sharkrite-source-issue:170 -->## From PR #178 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
This concerns data integrity between grocery and inventory domains. While real, fixing it requires understanding the relationship between `GroceryListItem.unit` and `InventoryItem.unit`/`UnitType` enum—potentially touching schemas in both domains. This is a cross-module concern beyond the immediate feature.

## Context
The inventory creation is described as a "cross-domain bridge." The issue scope says to use the unit from the grocery item. If there's an enum mismatch, that's an architectural concern requiring design discussion about how the two domains relate.

## Defer Reason
Needs separate focused PR to address cross-domain type consistency

---
_Created by Sharkrite assessment on 2026-03-21T08:13:25Z_
_Parent PR: #178_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+0 added, ~2 modified, -0 deleted)
- `M` src/services/grocery_service.py
- `M` tests/routers/test_grocery.py

### Commits
- ce163ec feat: Add cross-domain inventory unit validation
- bb61591 chore: initialize work on #181 Add cross-domain inventory unit validation
<!-- /sharkrite-changes-summary -->