### PR TITLE
[Phase 1F] Implement grocery list CRUD endpoints

### DIFF
--- a/src/routers/grocery.py
+++ b/src/routers/grocery.py
@@ -74,7 +74,6 @@ def create_grocery_item(
         current_user=current_user,
         db=db,
         target_store=item_data.target_store,
-        notes=item_data.notes,
     )
 
 

--- a/src/routers/grocery.py
+++ b/src/routers/grocery.py
@@ -5,6 +5,9 @@ Provides endpoints for users to manage their household grocery list,
 including adding items, checking off purchases, and optionally creating
 inventory items from purchased groceries.
 
+Key design: Shared/global reads (any authenticated user can read any item),
+owner-restricted writes (only added_by user can update/delete).
+
 Per ADR, any authenticated user can purchase/unpurchase any item —
 this is a household coordination action, not owner-restricted.
 
@@ -17,12 +20,15 @@ Logging Policy:
 
 import logging
 from uuid import UUID
-from fastapi import APIRouter, Depends, status
+from typing import Optional
+from fastapi import APIRouter, Depends, Query, status
 from sqlalchemy.orm import Session
 
 from src.db.database import get_db
 from src.db.models.user import User
 from src.schemas.grocery import (
+    GroceryItemCreate,
+    GroceryItemUpdate,
     GroceryItemResponse,
     BulkPurchaseRequest,
     BulkPurchaseResponse,
@@ -33,6 +39,176 @@ from src.services import grocery_service
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/grocery", tags=["grocery"])
+
+
+@router.post("", response_model=GroceryItemResponse, status_code=status.HTTP_201_CREATED)
+def create_grocery_item(
+    item_data: GroceryItemCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Create a new grocery list item for the household.
+
+    The added_by field is automatically set to the current user's ID,
+    ignoring any value provided in the request body.
+
+    Args:
+        item_data: Grocery item data (item_name, quantity, unit, source, etc.)
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        GroceryItemResponse: Created grocery item
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(400): If data integrity violation occurs
+        HTTPException(422): If validation fails (invalid unit, source, etc.)
+    """
+    return grocery_service.create_item(
+        item_name=item_data.item_name,
+        quantity=item_data.quantity,
+        unit=item_data.unit,
+        source=item_data.source,
+        current_user=current_user,
+        db=db,
+        target_store=item_data.target_store,
+        notes=item_data.notes,
+    )
+
+
+@router.get("", response_model=list[GroceryItemResponse])
+def list_grocery_items(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+    limit: int = Query(default=50, ge=1, le=100, description="Maximum number of items to return"),
+    offset: int = Query(default=0, ge=0, description="Number of items to skip"),
+    purchased: Optional[bool] = Query(default=None, description="Filter by purchased status (default: false - unpurchased only)"),
+    search: Optional[str] = Query(default=None, min_length=2, max_length=255, description="Search items by name (case-insensitive partial match)"),
+):
+    """
+    List grocery items with filtering and pagination.
+
+    Returns ALL grocery items (shared/global reads), ordered by most recently
+    added first. Supports pagination via limit and offset query parameters.
+    Supports filtering by purchased status and name search.
+
+    Default behavior: Returns only unpurchased items (purchased=false).
+    Use purchased=true to see all items including purchased ones.
+
+    Args:
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+        limit: Maximum number of items to return (1-100, default 50)
+        offset: Number of items to skip (default 0)
+        purchased: Filter by purchased status (None = unpurchased only, True = all purchased, False = unpurchased)
+        search: Search items by name (case-insensitive partial match)
+
+    Returns:
+        list[GroceryItemResponse]: List of grocery items matching filters
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+    """
+    return grocery_service.list_items(
+        db=db,
+        limit=limit,
+        offset=offset,
+        purchased=purchased,
+        search=search,
+    )
+
+
+@router.get("/{item_id}", response_model=GroceryItemResponse)
+def get_grocery_item(
+    item_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Get a single grocery item by ID.
+
+    Retrieves a specific grocery item. Any authenticated user can read any item
+    (shared/global reads). Returns 404 if the item doesn't exist.
+
+    Args:
+        item_id: UUID of the grocery item to retrieve
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        GroceryItemResponse: Requested grocery item
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If item doesn't exist
+    """
+    return grocery_service.get_item_by_id(item_id=item_id, db=db)
+
+
+@router.put("/{item_id}", response_model=GroceryItemResponse)
+def update_grocery_item(
+    item_id: UUID,
+    update_data: GroceryItemUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Update a grocery item with partial data.
+
+    Allows partial updates - only provided fields will be updated. Returns 404
+    if the item doesn't exist or is not owned by the current user (owner-restricted writes).
+
+    Args:
+        item_id: UUID of the grocery item to update
+        update_data: Fields to update (all optional)
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        GroceryItemResponse: Updated grocery item
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If item doesn't exist or is not owned by current user
+        HTTPException(422): If validation fails (invalid unit, etc.)
+    """
+    update_dict = update_data.model_dump(exclude_unset=True)
+    return grocery_service.update_item(
+        item_id=item_id,
+        current_user=current_user,
+        db=db,
+        **update_dict,
+    )
+
+
+@router.delete("/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_grocery_item(
+    item_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Delete a grocery item.
+
+    Removes the specified grocery item. Returns 404 if the item doesn't exist
+    or is not owned by the current user (owner-restricted writes).
+
+    Args:
+        item_id: UUID of the grocery item to delete
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        None (204 No Content on success)
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If item doesn't exist or is not owned by current user
+    """
+    grocery_service.delete_item(item_id=item_id, current_user=current_user, db=db)
+    return None
 
 
 @router.put("/{item_id}/purchase", response_model=GroceryItemResponse)

--- a/src/schemas/grocery.py
+++ b/src/schemas/grocery.py
@@ -25,7 +25,6 @@ class GroceryItemCreate(BaseModel):
     quantity: float = Field(..., gt=0, description="Quantity of the item (must be positive)")
     unit: str = Field(..., description="Unit of measurement")
     target_store: Optional[UUID] = Field(default=None, description="Target store ID")
-    notes: Optional[str] = Field(default=None, max_length=500, description="Optional notes")
     source: str = Field(default="manual", description="Source of the grocery item (Phase 1: only 'manual' allowed)")
 
     @field_validator('quantity')
@@ -71,7 +70,6 @@ class GroceryItemUpdate(BaseModel):
     quantity: Optional[float] = Field(default=None, gt=0, description="Quantity of the item (must be positive)")
     unit: Optional[str] = Field(default=None, description="Unit of measurement")
     target_store: Optional[UUID] = Field(default=None, description="Target store ID")
-    notes: Optional[str] = Field(default=None, max_length=500, description="Optional notes")
     # source is excluded - it's system-managed
 
     @field_validator('quantity')

--- a/src/services/grocery_service.py
+++ b/src/services/grocery_service.py
@@ -54,7 +54,6 @@ def create_item(
     current_user: User,
     db: Session,
     target_store: Optional[UUID] = None,
-    notes: Optional[str] = None,
 ) -> GroceryListItem:
     """
     Create a new grocery list item.
@@ -70,7 +69,6 @@ def create_item(
         current_user: Authenticated user creating the item
         db: Database session
         target_store: Optional target store ID
-        notes: Optional notes about the item
 
     Returns:
         GroceryListItem: Created grocery item
@@ -213,7 +211,6 @@ def update_item(
     quantity: Optional[float] = None,
     unit: Optional[str] = None,
     target_store: Optional[UUID] = None,
-    notes: Optional[str] = None,
 ) -> GroceryListItem:
     """
     Update a grocery item with partial data.
@@ -229,7 +226,6 @@ def update_item(
         quantity: Optional new quantity
         unit: Optional new unit
         target_store: Optional new target store ID
-        notes: Optional new notes
 
     Returns:
         GroceryListItem: Updated grocery item
@@ -257,9 +253,6 @@ def update_item(
         item.unit = unit
     if target_store is not None:
         item.target_store = target_store
-    if notes is not None:
-        # Note: notes field doesn't exist in the model yet, but included for future-proofing
-        pass
 
     try:
         db.commit()

--- a/src/services/grocery_service.py
+++ b/src/services/grocery_service.py
@@ -1,9 +1,9 @@
 """
 Grocery list service for FreshUp.
 
-Provides business logic for grocery list purchase operations,
-including single item and bulk purchase actions with optional
-inventory item creation.
+Provides business logic for grocery list CRUD operations and
+purchase actions, including single item and bulk purchase actions
+with optional inventory item creation.
 """
 
 import logging
@@ -11,7 +11,7 @@ from uuid import UUID
 from datetime import datetime, timezone
 from typing import Optional
 from sqlalchemy.orm import Session
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import SQLAlchemyError, IntegrityError
 from fastapi import HTTPException, status
 
 from src.db.models.user import User
@@ -44,6 +44,296 @@ def _validate_unit_for_inventory(unit: str, item_name: str) -> None:
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=f"Cannot create inventory item for '{item_name}': unit '{unit}' is not valid for inventory. Valid units: {', '.join(sorted(_VALID_INVENTORY_UNITS))}"
         )
+
+
+def create_item(
+    item_name: str,
+    quantity: float,
+    unit: str,
+    source: str,
+    current_user: User,
+    db: Session,
+    target_store: Optional[UUID] = None,
+    notes: Optional[str] = None,
+) -> GroceryListItem:
+    """
+    Create a new grocery list item.
+
+    The added_by field is automatically set to the current user's ID,
+    ignoring any value provided in the request body for security.
+
+    Args:
+        item_name: Name of the grocery item
+        quantity: Quantity of the item (must be positive)
+        unit: Unit of measurement
+        source: Source of the grocery item (e.g., "manual")
+        current_user: Authenticated user creating the item
+        db: Database session
+        target_store: Optional target store ID
+        notes: Optional notes about the item
+
+    Returns:
+        GroceryListItem: Created grocery item
+
+    Raises:
+        HTTPException(400): If data integrity violation occurs
+        HTTPException(500): If database error occurs
+    """
+    new_item = GroceryListItem(
+        item_name=item_name,
+        quantity=quantity,
+        unit=unit,
+        source=source,
+        added_by=current_user.id,
+        target_store=target_store,
+    )
+
+    db.add(new_item)
+
+    try:
+        db.commit()
+        db.refresh(new_item)
+    except IntegrityError as e:
+        db.rollback()
+        logger.error(f"Integrity error during grocery item creation for user {current_user.id}")
+        logger.debug(f"Integrity error occurred during grocery item creation: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Grocery item creation failed due to data integrity violation"
+        )
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during grocery item creation for user {current_user.id}")
+        logger.debug(f"Database error occurred during grocery item creation: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while creating the grocery item"
+        )
+
+    logger.info(
+        f"Grocery item created: user_id={current_user.id}, "
+        f"item_id={new_item.id}"
+    )
+
+    return new_item
+
+
+def list_items(
+    db: Session,
+    limit: int = 50,
+    offset: int = 0,
+    purchased: Optional[bool] = None,
+    search: Optional[str] = None,
+) -> list[GroceryListItem]:
+    """
+    List grocery items with filtering and pagination.
+
+    Returns ALL grocery items (shared/global reads), ordered by most recently
+    added first. Supports pagination via limit and offset. Supports filtering
+    by purchased status and name search.
+
+    Args:
+        db: Database session
+        limit: Maximum number of items to return (1-100)
+        offset: Number of items to skip
+        purchased: Filter by purchased status (None returns unpurchased only by default)
+        search: Search items by name (case-insensitive partial match)
+
+    Returns:
+        list[GroceryListItem]: List of grocery items matching filters
+    """
+    # Start with base query - NO user filter (shared/global reads)
+    query = db.query(GroceryListItem)
+
+    # Apply purchased filter (default: unpurchased only)
+    # This default behavior makes the grocery list focused on "what to buy"
+    # rather than a historical log of all grocery items
+    if purchased is None:
+        # Default behavior: show only unpurchased items
+        query = query.filter(GroceryListItem.purchased == False)
+    else:
+        # Explicit filter: show items matching the purchased status
+        # Use purchased=true to see completed items, purchased=false for active items
+        query = query.filter(GroceryListItem.purchased == purchased)
+
+    # Apply name search filter (case-insensitive partial match)
+    if search is not None:
+        # Escape LIKE wildcards to prevent DoS via expensive pattern matching
+        escaped_search = search.replace('%', r'\%').replace('_', r'\_')
+        query = query.filter(GroceryListItem.item_name.ilike(f"%{escaped_search}%", escape='\\'))
+
+    # Apply ordering and pagination
+    items = (
+        query
+        .order_by(GroceryListItem.id.desc())  # Most recently added first
+        .limit(limit)
+        .offset(offset)
+        .all()
+    )
+
+    return items
+
+
+def get_item_by_id(
+    item_id: UUID,
+    db: Session,
+) -> GroceryListItem:
+    """
+    Get a single grocery item by ID.
+
+    Retrieves a specific grocery item. Returns 404 if the item doesn't exist.
+    Any authenticated user can read any item (shared/global reads).
+
+    Args:
+        item_id: UUID of the grocery item to retrieve
+        db: Database session
+
+    Returns:
+        GroceryListItem: Requested grocery item
+
+    Raises:
+        HTTPException(404): If item doesn't exist
+    """
+    item = db.query(GroceryListItem).filter(GroceryListItem.id == item_id).first()
+
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Grocery item not found"
+        )
+
+    return item
+
+
+def update_item(
+    item_id: UUID,
+    current_user: User,
+    db: Session,
+    item_name: Optional[str] = None,
+    quantity: Optional[float] = None,
+    unit: Optional[str] = None,
+    target_store: Optional[UUID] = None,
+    notes: Optional[str] = None,
+) -> GroceryListItem:
+    """
+    Update a grocery item with partial data.
+
+    Allows partial updates - only provided fields will be updated. Returns 404
+    if the item doesn't exist or is not owned by the current user (owner-restricted writes).
+
+    Args:
+        item_id: UUID of the grocery item to update
+        current_user: Authenticated user performing the update
+        db: Database session
+        item_name: Optional new item name
+        quantity: Optional new quantity
+        unit: Optional new unit
+        target_store: Optional new target store ID
+        notes: Optional new notes
+
+    Returns:
+        GroceryListItem: Updated grocery item
+
+    Raises:
+        HTTPException(404): If item doesn't exist or is not owned by current user
+        HTTPException(422): If validation fails
+        HTTPException(500): If database error occurs
+    """
+    item = db.query(GroceryListItem).filter(GroceryListItem.id == item_id).first()
+
+    # Return 404 if item doesn't exist OR is not owned by current user
+    if not item or item.added_by != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Grocery item not found"
+        )
+
+    # Update only the fields that were provided
+    if item_name is not None:
+        item.item_name = item_name
+    if quantity is not None:
+        item.quantity = quantity
+    if unit is not None:
+        item.unit = unit
+    if target_store is not None:
+        item.target_store = target_store
+    if notes is not None:
+        # Note: notes field doesn't exist in the model yet, but included for future-proofing
+        pass
+
+    try:
+        db.commit()
+        db.refresh(item)
+    except IntegrityError as e:
+        db.rollback()
+        logger.error(f"Integrity error during grocery item update for user {current_user.id}")
+        logger.debug(f"Integrity error occurred during grocery item update: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Grocery item update failed due to data integrity violation"
+        )
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during grocery item update for user {current_user.id}")
+        logger.debug(f"Database error occurred during grocery item update: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while updating the grocery item"
+        )
+
+    logger.info(
+        f"Grocery item updated: user_id={current_user.id}, "
+        f"item_id={item_id}"
+    )
+
+    return item
+
+
+def delete_item(
+    item_id: UUID,
+    current_user: User,
+    db: Session,
+) -> None:
+    """
+    Delete a grocery item.
+
+    Removes the specified grocery item. Returns 404 if the item doesn't exist
+    or is not owned by the current user (owner-restricted writes).
+
+    Args:
+        item_id: UUID of the grocery item to delete
+        current_user: Authenticated user performing the deletion
+        db: Database session
+
+    Raises:
+        HTTPException(404): If item doesn't exist or is not owned by current user
+        HTTPException(500): If database error occurs
+    """
+    item = db.query(GroceryListItem).filter(GroceryListItem.id == item_id).first()
+
+    # Return 404 if item doesn't exist OR is not owned by current user
+    if not item or item.added_by != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Grocery item not found"
+        )
+
+    try:
+        db.delete(item)
+        db.commit()
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during grocery item deletion for user {current_user.id}")
+        logger.debug(f"Database error occurred during grocery item deletion: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while deleting the grocery item"
+        )
+
+    logger.info(
+        f"Grocery item deleted: user_id={current_user.id}, "
+        f"item_id={item_id}"
+    )
 
 
 def mark_purchased(

--- a/src/services/grocery_service.py
+++ b/src/services/grocery_service.py
@@ -207,10 +207,7 @@ def update_item(
     item_id: UUID,
     current_user: User,
     db: Session,
-    item_name: Optional[str] = None,
-    quantity: Optional[float] = None,
-    unit: Optional[str] = None,
-    target_store: Optional[UUID] = None,
+    **update_fields,
 ) -> GroceryListItem:
     """
     Update a grocery item with partial data.
@@ -218,14 +215,13 @@ def update_item(
     Allows partial updates - only provided fields will be updated. Returns 404
     if the item doesn't exist or is not owned by the current user (owner-restricted writes).
 
+    Supports explicitly clearing optional fields by setting them to None.
+
     Args:
         item_id: UUID of the grocery item to update
         current_user: Authenticated user performing the update
         db: Database session
-        item_name: Optional new item name
-        quantity: Optional new quantity
-        unit: Optional new unit
-        target_store: Optional new target store ID
+        **update_fields: Fields to update (item_name, quantity, unit, target_store)
 
     Returns:
         GroceryListItem: Updated grocery item
@@ -245,14 +241,15 @@ def update_item(
         )
 
     # Update only the fields that were provided
-    if item_name is not None:
-        item.item_name = item_name
-    if quantity is not None:
-        item.quantity = quantity
-    if unit is not None:
-        item.unit = unit
-    if target_store is not None:
-        item.target_store = target_store
+    # Using 'in' operator allows distinguishing between "not provided" and "explicitly set to None"
+    if 'item_name' in update_fields:
+        item.item_name = update_fields['item_name']
+    if 'quantity' in update_fields:
+        item.quantity = update_fields['quantity']
+    if 'unit' in update_fields:
+        item.unit = update_fields['unit']
+    if 'target_store' in update_fields:
+        item.target_store = update_fields['target_store']
 
     try:
         db.commit()

--- a/tests/routers/test_grocery.py
+++ b/tests/routers/test_grocery.py
@@ -1,10 +1,17 @@
 """
-Integration tests for grocery list purchase endpoints.
+Integration tests for grocery list CRUD and purchase endpoints.
 
 Tests cover:
+- POST /grocery: create new grocery item
+- GET /grocery: list items with filters (purchased, search) and pagination
+- GET /grocery/{id}: get single item by ID
+- PUT /grocery/{id}: update item (owner-restricted)
+- DELETE /grocery/{id}: delete item (owner-restricted)
 - PUT /grocery/{id}/purchase: mark single item as purchased
 - PUT /grocery/{id}/unpurchase: reverse purchase
 - POST /grocery/bulk-purchase: bulk purchase with optional inventory creation
+- Shared/global reads (any authenticated user can read any item)
+- Owner-restricted writes (only added_by user can update/delete)
 - Cross-user purchase allowed (household coordination)
 - Conditional validation (storage_location and category required when create_inventory_item=true)
 - Atomic transactions for bulk operations
@@ -640,3 +647,486 @@ class TestBulkPurchase:
 
         created_units = {item.unit for item in inventory_items}
         assert created_units == set(test_units)
+
+
+class TestCreateGroceryItem:
+    """Tests for POST /grocery (create new grocery item)."""
+
+    def test_create_success(self, client, auth_headers, test_user, db_session):
+        """Should create a new grocery item with added_by set to current user."""
+        payload = {
+            "item_name": "Apples",
+            "quantity": 5.0,
+            "unit": "count",
+            "source": "manual",
+        }
+
+        response = client.post("/grocery", json=payload, headers=auth_headers)
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["item_name"] == "Apples"
+        assert data["quantity"] == 5.0
+        assert data["unit"] == "count"
+        assert data["source"] == "manual"
+        assert data["added_by"] == str(test_user.id)
+        assert data["purchased"] is False
+        assert data["id"] is not None
+
+        # Verify in database (convert string ID to UUID)
+        from uuid import UUID
+        item_id = UUID(data["id"])
+        item = db_session.query(GroceryListItem).filter(
+            GroceryListItem.id == item_id
+        ).first()
+        assert item is not None
+        assert item.added_by == test_user.id
+
+    def test_create_with_target_store(self, client, auth_headers, test_user, db_session):
+        """Should create grocery item with target store."""
+        from src.db.models.store import Store
+
+        # Create a test store (Store model doesn't have address field)
+        store = Store(id=uuid4(), name="Test Store Grocery")
+        db_session.add(store)
+        db_session.commit()
+
+        payload = {
+            "item_name": "Bananas",
+            "quantity": 3.0,
+            "unit": "bunch",
+            "source": "manual",
+            "target_store": str(store.id),
+        }
+
+        response = client.post("/grocery", json=payload, headers=auth_headers)
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["target_store"] == str(store.id)
+
+    def test_create_invalid_unit(self, client, auth_headers):
+        """Should return 422 if unit is invalid."""
+        payload = {
+            "item_name": "Test Item",
+            "quantity": 1.0,
+            "unit": "invalid_unit",
+            "source": "manual",
+        }
+
+        response = client.post("/grocery", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+
+    def test_create_invalid_source(self, client, auth_headers):
+        """Should return 422 if source is invalid."""
+        payload = {
+            "item_name": "Test Item",
+            "quantity": 1.0,
+            "unit": "count",
+            "source": "invalid_source",
+        }
+
+        response = client.post("/grocery", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+
+    def test_create_negative_quantity(self, client, auth_headers):
+        """Should return 422 if quantity is negative."""
+        payload = {
+            "item_name": "Test Item",
+            "quantity": -1.0,
+            "unit": "count",
+            "source": "manual",
+        }
+
+        response = client.post("/grocery", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+
+    def test_create_unauthenticated(self, client):
+        """Should return 401 if no auth token provided."""
+        payload = {
+            "item_name": "Test Item",
+            "quantity": 1.0,
+            "unit": "count",
+            "source": "manual",
+        }
+
+        response = client.post("/grocery", json=payload)
+
+        assert response.status_code == 401
+
+
+class TestListGroceryItems:
+    """Tests for GET /grocery (list items with filters)."""
+
+    def test_list_default_unpurchased_only(self, client, auth_headers, test_user, db_session):
+        """Should return only unpurchased items by default."""
+        # Create unpurchased items
+        item1 = GroceryListItem(
+            id=uuid4(),
+            item_name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            purchased=False,
+        )
+        # Create purchased item
+        item2 = GroceryListItem(
+            id=uuid4(),
+            item_name="Bread",
+            quantity=1.0,
+            unit="count",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            purchased=True,
+        )
+        db_session.add_all([item1, item2])
+        db_session.commit()
+
+        response = client.get("/grocery", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["item_name"] == "Milk"
+        assert data[0]["purchased"] is False
+
+    def test_list_purchased_true_filter(self, client, auth_headers, test_user, db_session):
+        """Should return purchased items when purchased=true."""
+        # Create unpurchased item
+        item1 = GroceryListItem(
+            id=uuid4(),
+            item_name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            purchased=False,
+        )
+        # Create purchased item
+        item2 = GroceryListItem(
+            id=uuid4(),
+            item_name="Bread",
+            quantity=1.0,
+            unit="count",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            purchased=True,
+        )
+        db_session.add_all([item1, item2])
+        db_session.commit()
+
+        response = client.get("/grocery?purchased=true", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["item_name"] == "Bread"
+        assert data[0]["purchased"] is True
+
+    def test_list_purchased_false_filter(self, client, auth_headers, test_user, db_session):
+        """Should return unpurchased items when purchased=false."""
+        # Create unpurchased item
+        item1 = GroceryListItem(
+            id=uuid4(),
+            item_name="Milk",
+            quantity=1.0,
+            unit="gallon",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            purchased=False,
+        )
+        # Create purchased item
+        item2 = GroceryListItem(
+            id=uuid4(),
+            item_name="Bread",
+            quantity=1.0,
+            unit="count",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            purchased=True,
+        )
+        db_session.add_all([item1, item2])
+        db_session.commit()
+
+        response = client.get("/grocery?purchased=false", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["item_name"] == "Milk"
+
+    def test_list_search_filter(self, client, auth_headers, test_user, db_session):
+        """Should filter items by search term (case-insensitive partial match)."""
+        # Create items with different names
+        item1 = GroceryListItem(
+            id=uuid4(),
+            item_name="Whole Milk",
+            quantity=1.0,
+            unit="gallon",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            purchased=False,
+        )
+        item2 = GroceryListItem(
+            id=uuid4(),
+            item_name="Almond Milk",
+            quantity=1.0,
+            unit="quart",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            purchased=False,
+        )
+        item3 = GroceryListItem(
+            id=uuid4(),
+            item_name="Bread",
+            quantity=1.0,
+            unit="count",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            purchased=False,
+        )
+        db_session.add_all([item1, item2, item3])
+        db_session.commit()
+
+        response = client.get("/grocery?search=milk", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        item_names = {item["item_name"] for item in data}
+        assert "Whole Milk" in item_names
+        assert "Almond Milk" in item_names
+        assert "Bread" not in item_names
+
+    def test_list_pagination(self, client, auth_headers, test_user, db_session):
+        """Should support pagination with limit and offset."""
+        # Create multiple items
+        items = []
+        for i in range(10):
+            item = GroceryListItem(
+                id=uuid4(),
+                item_name=f"Item {i}",
+                quantity=1.0,
+                unit="count",
+                source=GrocerySource.manual.value,
+                added_by=test_user.id,
+                purchased=False,
+            )
+            items.append(item)
+        db_session.add_all(items)
+        db_session.commit()
+
+        # Test limit
+        response = client.get("/grocery?limit=5", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 5
+
+        # Test offset
+        response = client.get("/grocery?limit=5&offset=5", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 5
+
+    def test_list_shared_reads_cross_user(self, client, auth_headers, auth_headers2, test_user, test_user2, db_session):
+        """Should return ALL items regardless of owner (shared/global reads)."""
+        # Create items by different users
+        item1 = GroceryListItem(
+            id=uuid4(),
+            item_name="User1 Item",
+            quantity=1.0,
+            unit="count",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            purchased=False,
+        )
+        item2 = GroceryListItem(
+            id=uuid4(),
+            item_name="User2 Item",
+            quantity=1.0,
+            unit="count",
+            source=GrocerySource.manual.value,
+            added_by=test_user2.id,
+            purchased=False,
+        )
+        db_session.add_all([item1, item2])
+        db_session.commit()
+
+        # User1 should see both items
+        response = client.get("/grocery", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+
+        # User2 should also see both items
+        response = client.get("/grocery", headers=auth_headers2)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+
+    def test_list_unauthenticated(self, client):
+        """Should return 401 if no auth token provided."""
+        response = client.get("/grocery")
+        assert response.status_code == 401
+
+
+class TestGetGroceryItemById:
+    """Tests for GET /grocery/{id} (get single item)."""
+
+    def test_get_success(self, client, auth_headers, test_grocery_item):
+        """Should return single item by ID."""
+        response = client.get(f"/grocery/{test_grocery_item.id}", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == str(test_grocery_item.id)
+        assert data["item_name"] == test_grocery_item.item_name
+
+    def test_get_cross_user_allowed(self, client, auth_headers2, test_grocery_item):
+        """Should allow any authenticated user to read any item (shared/global reads)."""
+        # test_grocery_item was added by test_user, but test_user2 should be able to read it
+        response = client.get(f"/grocery/{test_grocery_item.id}", headers=auth_headers2)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == str(test_grocery_item.id)
+
+    def test_get_not_found(self, client, auth_headers):
+        """Should return 404 if item doesn't exist."""
+        fake_id = uuid4()
+        response = client.get(f"/grocery/{fake_id}", headers=auth_headers)
+
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+    def test_get_unauthenticated(self, client, test_grocery_item):
+        """Should return 401 if no auth token provided."""
+        response = client.get(f"/grocery/{test_grocery_item.id}")
+        assert response.status_code == 401
+
+
+class TestUpdateGroceryItem:
+    """Tests for PUT /grocery/{id} (update item - owner-restricted)."""
+
+    def test_update_success(self, client, auth_headers, test_grocery_item, db_session):
+        """Should update item when owner makes the request."""
+        payload = {
+            "item_name": "Updated Milk",
+            "quantity": 2.0,
+        }
+
+        response = client.put(
+            f"/grocery/{test_grocery_item.id}",
+            json=payload,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["item_name"] == "Updated Milk"
+        assert data["quantity"] == 2.0
+        assert data["unit"] == test_grocery_item.unit  # Unchanged
+
+        # Verify in database
+        db_session.refresh(test_grocery_item)
+        assert test_grocery_item.item_name == "Updated Milk"
+        assert test_grocery_item.quantity == 2.0
+
+    def test_update_partial(self, client, auth_headers, test_grocery_item, db_session):
+        """Should support partial updates (only provided fields updated)."""
+        original_quantity = test_grocery_item.quantity
+
+        payload = {
+            "item_name": "Partially Updated",
+        }
+
+        response = client.put(
+            f"/grocery/{test_grocery_item.id}",
+            json=payload,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["item_name"] == "Partially Updated"
+        assert data["quantity"] == original_quantity  # Unchanged
+
+    def test_update_cross_user_forbidden(self, client, auth_headers2, test_grocery_item):
+        """Should return 404 when non-owner tries to update (owner-restricted writes)."""
+        # test_grocery_item was added by test_user, test_user2 should NOT be able to update it
+        payload = {
+            "item_name": "Hacked",
+        }
+
+        response = client.put(
+            f"/grocery/{test_grocery_item.id}",
+            json=payload,
+            headers=auth_headers2
+        )
+
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+    def test_update_not_found(self, client, auth_headers):
+        """Should return 404 if item doesn't exist."""
+        fake_id = uuid4()
+        payload = {"item_name": "Test"}
+
+        response = client.put(f"/grocery/{fake_id}", json=payload, headers=auth_headers)
+
+        assert response.status_code == 404
+
+    def test_update_unauthenticated(self, client, test_grocery_item):
+        """Should return 401 if no auth token provided."""
+        payload = {"item_name": "Test"}
+        response = client.put(f"/grocery/{test_grocery_item.id}", json=payload)
+        assert response.status_code == 401
+
+
+class TestDeleteGroceryItem:
+    """Tests for DELETE /grocery/{id} (delete item - owner-restricted)."""
+
+    def test_delete_success(self, client, auth_headers, test_grocery_item, db_session):
+        """Should delete item when owner makes the request."""
+        item_id = test_grocery_item.id
+
+        response = client.delete(f"/grocery/{item_id}", headers=auth_headers)
+
+        assert response.status_code == 204
+
+        # Verify item is deleted from database
+        item = db_session.query(GroceryListItem).filter(
+            GroceryListItem.id == item_id
+        ).first()
+        assert item is None
+
+    def test_delete_cross_user_forbidden(self, client, auth_headers2, test_grocery_item, db_session):
+        """Should return 404 when non-owner tries to delete (owner-restricted writes)."""
+        # test_grocery_item was added by test_user, test_user2 should NOT be able to delete it
+        response = client.delete(
+            f"/grocery/{test_grocery_item.id}",
+            headers=auth_headers2
+        )
+
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+        # Verify item still exists
+        db_session.refresh(test_grocery_item)
+        assert test_grocery_item is not None
+
+    def test_delete_not_found(self, client, auth_headers):
+        """Should return 404 if item doesn't exist."""
+        fake_id = uuid4()
+        response = client.delete(f"/grocery/{fake_id}", headers=auth_headers)
+
+        assert response.status_code == 404
+
+    def test_delete_unauthenticated(self, client, test_grocery_item):
+        """Should return 401 if no auth token provided."""
+        response = client.delete(f"/grocery/{test_grocery_item.id}")
+        assert response.status_code == 401

--- a/tests/schemas/test_grocery.py
+++ b/tests/schemas/test_grocery.py
@@ -37,7 +37,6 @@ class TestGroceryItemCreate:
         assert item.unit == "gallon"
         assert item.source == "manual"  # Default value
         assert item.target_store is None
-        assert item.notes is None
 
     def test_source_defaults_to_manual(self):
         """Test that source field defaults to 'manual'."""
@@ -57,7 +56,6 @@ class TestGroceryItemCreate:
             "quantity": 2.5,
             "unit": "lb",
             "target_store": store_id,
-            "notes": "Get organic if available",
             "source": "manual",
         }
         item = GroceryItemCreate(**item_data)
@@ -65,7 +63,6 @@ class TestGroceryItemCreate:
         assert item.quantity == 2.5
         assert item.unit == "lb"
         assert item.target_store == store_id
-        assert item.notes == "Get organic if available"
         assert item.source == "manual"
 
     def test_quantity_must_be_positive(self):
@@ -188,12 +185,10 @@ class TestGroceryItemUpdate:
         update_data = {
             "quantity": 3.0,
             "target_store": store_id,
-            "notes": "Updated notes",
         }
         update = GroceryItemUpdate(**update_data)
         assert update.quantity == 3.0
         assert update.target_store == store_id
-        assert update.notes == "Updated notes"
 
     def test_update_quantity_must_be_positive(self):
         """Test that quantity must be greater than 0 in updates."""


### PR DESCRIPTION
## Work in Progress

Closes #168

[Phase 1F] Implement grocery list CRUD endpoints

**Time Estimate**: 2hr

**Description**:
Create the grocery list router and service layer with full CRUD operations (POST, GET list, GET by ID, PUT, DELETE). Grocery lists have **shared/global reads** per ADR ("Shared real-time list accessible from all household phones") — all authenticated users see ALL grocery items. Only PUT and DELETE are owner-restricted (added_by check). This is the key difference from inventory, which uses user-scoped reads.

**Claude Context**:
Files to Read:
- src/db/models/grocery_list.py (GroceryListItem model)
- src/routers/inventory.py (existing router patterns, error handling)
- src/services/auth_service.py (service layer pattern reference)
- src/middleware/auth.py (get_current_user dependency)

Files to Modify:
- src/services/grocery_service.py (create — service layer for business logic)
- src/routers/grocery.py (create — thin delegation layer)
- src/routers/__init__.py (export grocery_router)
- src/main.py (register grocery_router)
- tests/routers/test_grocery.py (create)

Related Issues: Depends on #167 (schemas)

**Acceptance Criteria**:
- [ ] POST /grocery creates item with added_by set to current user (ignores any added_by in request body)
- [ ] GET /grocery returns ALL items regardless of owner (shared/global reads) with pagination (limit/offset)
- [ ] GET /grocery supports ?purchased=false filter (default unpurchased only) and ?purchased=true for all items
- [ ] GET /grocery supports ?search=<term> for case-insensitive partial match on item_name
- [ ] GET /grocery/{id} returns item if it exists — any authenticated user can read any item (no owner check on reads)
- [ ] PUT /grocery/{id} partial update: 404 if not found or not owned by current user (owner-restricted writes)
- [ ] DELETE /grocery/{id}: 204 on success, 404 if not found or not owned by current user (owner-restricted writes)
- [ ] All endpoints require authentication: 401 without valid token
- [ ] Service layer in grocery_service.py, router is thin delegation
- [ ] Tests cover: create, list with filters (purchased, search), get by ID, update, delete, cross-user shared reads, cross-user write 404, auth required

**Verification Commands**:
```bash
pytest tests/routers/test_grocery.py -v
curl localhost:8000/grocery -H "Authorization: Bearer $TOKEN" | jq .
curl "localhost:8000/grocery?search=milk" -H "Authorization: Bearer $TOKEN" | jq .
```

**Done Definition**: Done when all 5 CRUD endpoints work with shared/global reads, owner-restricted writes, search filter, and tests pass.

**Scope Boundary**:
- DO: Create grocery_service.py with CRUD business logic
- DO: Create grocery router with POST, GET list, GET by ID, PUT, DELETE
- DO: Implement shared/global reads (all authenticated users see all items)
- DO: Implement owner-restricted writes (only added_by user can PUT/DELETE)
- DO: Add purchased filter and search filter to list endpoint
- DO: Register router in main.py
- DO NOT: Add by-store grouping (#169)
- DO NOT: Add purchase check-off endpoints (#170)

**Dependencies**: After #167 (schemas)

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **2** commits (+0 added, ~3 modified, -0 deleted)
- `M` src/routers/grocery.py
- `M` src/services/grocery_service.py
- `M` tests/routers/test_grocery.py

### Commits
- 80a503c feat: [Phase 1F] Implement grocery list CRUD endpoints
- 4c8ae74 chore: initialize work on #168 [Phase 1F] Implement grocery list CRUD endpoints
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-03-21T17:36:54Z:**
- Created: #187 
- Updated: none