### PR TITLE
[Phase 1F] Add per-store grocery list grouping

### DIFF
--- a/src/routers/grocery.py
+++ b/src/routers/grocery.py
@@ -32,6 +32,7 @@ from src.schemas.grocery import (
     GroceryItemResponse,
     BulkPurchaseRequest,
     BulkPurchaseResponse,
+    StoreGroupedGroceryResponse,
 )
 from src.middleware.auth import get_current_user
 from src.services import grocery_service
@@ -116,6 +117,39 @@ def list_grocery_items(
         offset=offset,
         purchased=purchased,
         search=search,
+    )
+
+
+@router.get("/by-store", response_model=StoreGroupedGroceryResponse)
+def get_grocery_items_by_store(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+    include_purchased: bool = Query(default=False, description="Include purchased items (default: false - unpurchased only)"),
+):
+    """
+    Get grocery items grouped by target store for per-store shopping lists.
+
+    Returns ALL grocery items (shared/global reads) organized by their target
+    store. Items without a target_store appear in the "unassigned" array.
+    Empty stores (stores with no grocery items) are not included.
+
+    Default behavior: Returns only unpurchased items (include_purchased=false).
+    Use include_purchased=true to see all items including purchased ones.
+
+    Args:
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+        include_purchased: Include purchased items (default: false)
+
+    Returns:
+        StoreGroupedGroceryResponse: Items grouped by store with unassigned items
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+    """
+    return grocery_service.get_items_by_store(
+        db=db,
+        include_purchased=include_purchased,
     )
 
 

--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -11,8 +11,10 @@ from src.schemas.grocery import (
     GroceryItemCreate,
     GroceryItemUpdate,
     GroceryItemResponse,
+    StoreGroupedItems,
     StoreGroupedGroceryResponse,
     BulkPurchaseRequest,
+    BulkPurchaseResponse,
 )
 
 __all__ = [
@@ -23,6 +25,8 @@ __all__ = [
     "GroceryItemCreate",
     "GroceryItemUpdate",
     "GroceryItemResponse",
+    "StoreGroupedItems",
     "StoreGroupedGroceryResponse",
     "BulkPurchaseRequest",
+    "BulkPurchaseResponse",
 ]

--- a/src/services/grocery_service.py
+++ b/src/services/grocery_service.py
@@ -10,7 +10,7 @@ import logging
 from uuid import UUID
 from datetime import datetime, timezone
 from typing import Optional
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 from sqlalchemy.exc import SQLAlchemyError, IntegrityError
 from fastapi import HTTPException, status
 
@@ -546,3 +546,73 @@ def bulk_purchase(
     )
 
     return updated_items, inventory_count
+
+
+def get_items_by_store(
+    db: Session,
+    include_purchased: bool = False,
+) -> dict:
+    """
+    Get grocery items grouped by target store.
+
+    Returns items organized by their target store, with items lacking a
+    target_store in a separate "unassigned" list. By default, only returns
+    unpurchased items (include_purchased=False).
+
+    Uses eager loading (selectinload) to avoid N+1 queries when accessing
+    store relationships. Items are ordered by ID descending (most recent first)
+    within each store group.
+
+    Args:
+        db: Database session
+        include_purchased: If True, return all items; if False, only unpurchased (default: False)
+
+    Returns:
+        dict: {
+            "stores": [
+                {"store_id": UUID, "store_name": str, "items": [GroceryListItem, ...]},
+                ...
+            ],
+            "unassigned": [GroceryListItem, ...]
+        }
+    """
+    # Build query with eager loading to prevent N+1 queries
+    query = db.query(GroceryListItem).options(selectinload(GroceryListItem.target_store_rel))
+
+    # Apply purchased filter
+    if not include_purchased:
+        query = query.filter(GroceryListItem.purchased == False)
+
+    # Order by most recent first
+    items = query.order_by(GroceryListItem.id.desc()).all()
+
+    # Group items by store
+    # Use dict to track stores: {store_id: {"store_id": UUID, "store_name": str, "items": [...]}}
+    stores_dict = {}
+    unassigned = []
+
+    for item in items:
+        if item.target_store is None:
+            # Item has no target store
+            unassigned.append(item)
+        else:
+            # Item has a target store
+            store_id = item.target_store
+            if store_id not in stores_dict:
+                # First time seeing this store - initialize group
+                # Access the relationship to get store details (already eager-loaded)
+                store = item.target_store_rel
+                stores_dict[store_id] = {
+                    "store_id": store_id,
+                    "store_name": store.name,
+                    "items": []
+                }
+            stores_dict[store_id]["items"].append(item)
+
+    # Convert stores dict to list
+    stores = list(stores_dict.values())
+
+    return {
+        "stores": stores,
+        "unassigned": unassigned
+    }

--- a/src/services/grocery_service.py
+++ b/src/services/grocery_service.py
@@ -598,6 +598,12 @@ def get_items_by_store(
         else:
             # Item has a target store
             store_id = item.target_store
+            # Check if store relationship exists (handles dangling foreign key if store was deleted)
+            if item.target_store_rel is None:
+                # Store was deleted - treat as unassigned
+                unassigned.append(item)
+                continue
+
             if store_id not in stores_dict:
                 # First time seeing this store - initialize group
                 # Access the relationship to get store details (already eager-loaded)

--- a/src/services/grocery_service.py
+++ b/src/services/grocery_service.py
@@ -148,7 +148,7 @@ def list_items(
     # rather than a historical log of all grocery items
     if purchased is None:
         # Default behavior: show only unpurchased items
-        query = query.filter(GroceryListItem.purchased == False)
+        query = query.filter(GroceryListItem.purchased.is_(False))
     else:
         # Explicit filter: show items matching the purchased status
         # Use purchased=true to see completed items, purchased=false for active items
@@ -581,7 +581,7 @@ def get_items_by_store(
 
     # Apply purchased filter
     if not include_purchased:
-        query = query.filter(GroceryListItem.purchased == False)
+        query = query.filter(GroceryListItem.purchased.is_(False))
 
     # Order by most recent first
     items = query.order_by(GroceryListItem.id.desc()).all()

--- a/tests/routers/test_grocery.py
+++ b/tests/routers/test_grocery.py
@@ -1130,3 +1130,309 @@ class TestDeleteGroceryItem:
         """Should return 401 if no auth token provided."""
         response = client.delete(f"/grocery/{test_grocery_item.id}")
         assert response.status_code == 401
+
+
+class TestGetGroceryItemsByStore:
+    """Tests for GET /grocery/by-store (items grouped by target store)."""
+
+    def test_by_store_basic_grouping(self, client, auth_headers, test_user, db_session):
+        """Should group items by target store with store names."""
+        from src.db.models.store import Store
+
+        # Create stores
+        store1 = Store(id=uuid4(), name="Whole Foods")
+        store2 = Store(id=uuid4(), name="Trader Joe's")
+        db_session.add_all([store1, store2])
+        db_session.commit()
+
+        # Create items for different stores
+        item1 = GroceryListItem(
+            id=uuid4(),
+            item_name="Organic Apples",
+            quantity=5.0,
+            unit="count",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            target_store=store1.id,
+            purchased=False,
+        )
+        item2 = GroceryListItem(
+            id=uuid4(),
+            item_name="Bananas",
+            quantity=3.0,
+            unit="lb",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            target_store=store2.id,
+            purchased=False,
+        )
+        item3 = GroceryListItem(
+            id=uuid4(),
+            item_name="Bread",
+            quantity=1.0,
+            unit="count",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            target_store=store1.id,
+            purchased=False,
+        )
+        db_session.add_all([item1, item2, item3])
+        db_session.commit()
+
+        response = client.get("/grocery/by-store", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "stores" in data
+        assert "unassigned" in data
+        assert len(data["stores"]) == 2
+        assert len(data["unassigned"]) == 0
+
+        # Check store grouping
+        stores_by_name = {s["store_name"]: s for s in data["stores"]}
+        assert "Whole Foods" in stores_by_name
+        assert "Trader Joe's" in stores_by_name
+
+        # Whole Foods should have 2 items
+        wf_store = stores_by_name["Whole Foods"]
+        assert len(wf_store["items"]) == 2
+        wf_item_names = {item["item_name"] for item in wf_store["items"]}
+        assert "Organic Apples" in wf_item_names
+        assert "Bread" in wf_item_names
+
+        # Trader Joe's should have 1 item
+        tj_store = stores_by_name["Trader Joe's"]
+        assert len(tj_store["items"]) == 1
+        assert tj_store["items"][0]["item_name"] == "Bananas"
+
+    def test_by_store_unassigned_items(self, client, auth_headers, test_user, db_session):
+        """Should include items without target_store in unassigned array."""
+        from src.db.models.store import Store
+
+        store = Store(id=uuid4(), name="Target")
+        db_session.add(store)
+        db_session.commit()
+
+        # Create items with and without target store
+        item1 = GroceryListItem(
+            id=uuid4(),
+            item_name="Store Item",
+            quantity=1.0,
+            unit="count",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            target_store=store.id,
+            purchased=False,
+        )
+        item2 = GroceryListItem(
+            id=uuid4(),
+            item_name="Unassigned Item 1",
+            quantity=2.0,
+            unit="count",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            target_store=None,
+            purchased=False,
+        )
+        item3 = GroceryListItem(
+            id=uuid4(),
+            item_name="Unassigned Item 2",
+            quantity=3.0,
+            unit="count",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            target_store=None,
+            purchased=False,
+        )
+        db_session.add_all([item1, item2, item3])
+        db_session.commit()
+
+        response = client.get("/grocery/by-store", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["stores"]) == 1
+        assert len(data["unassigned"]) == 2
+
+        # Check unassigned items
+        unassigned_names = {item["item_name"] for item in data["unassigned"]}
+        assert "Unassigned Item 1" in unassigned_names
+        assert "Unassigned Item 2" in unassigned_names
+
+    def test_by_store_default_unpurchased_only(self, client, auth_headers, test_user, db_session):
+        """Should return only unpurchased items by default."""
+        from src.db.models.store import Store
+
+        store = Store(id=uuid4(), name="Safeway")
+        db_session.add(store)
+        db_session.commit()
+
+        # Create unpurchased and purchased items
+        item1 = GroceryListItem(
+            id=uuid4(),
+            item_name="Unpurchased Item",
+            quantity=1.0,
+            unit="count",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            target_store=store.id,
+            purchased=False,
+        )
+        item2 = GroceryListItem(
+            id=uuid4(),
+            item_name="Purchased Item",
+            quantity=2.0,
+            unit="count",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            target_store=store.id,
+            purchased=True,
+            purchased_by=test_user.id,
+            purchased_date=datetime.now(timezone.utc),
+        )
+        db_session.add_all([item1, item2])
+        db_session.commit()
+
+        response = client.get("/grocery/by-store", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["stores"]) == 1
+        assert len(data["stores"][0]["items"]) == 1
+        assert data["stores"][0]["items"][0]["item_name"] == "Unpurchased Item"
+
+    def test_by_store_include_purchased_true(self, client, auth_headers, test_user, db_session):
+        """Should return all items when include_purchased=true."""
+        from src.db.models.store import Store
+
+        store = Store(id=uuid4(), name="Kroger")
+        db_session.add(store)
+        db_session.commit()
+
+        # Create unpurchased and purchased items
+        item1 = GroceryListItem(
+            id=uuid4(),
+            item_name="Unpurchased Item",
+            quantity=1.0,
+            unit="count",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            target_store=store.id,
+            purchased=False,
+        )
+        item2 = GroceryListItem(
+            id=uuid4(),
+            item_name="Purchased Item",
+            quantity=2.0,
+            unit="count",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            target_store=store.id,
+            purchased=True,
+            purchased_by=test_user.id,
+            purchased_date=datetime.now(timezone.utc),
+        )
+        db_session.add_all([item1, item2])
+        db_session.commit()
+
+        response = client.get("/grocery/by-store?include_purchased=true", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["stores"]) == 1
+        assert len(data["stores"][0]["items"]) == 2
+
+        item_names = {item["item_name"] for item in data["stores"][0]["items"]}
+        assert "Unpurchased Item" in item_names
+        assert "Purchased Item" in item_names
+
+    def test_by_store_shared_reads_cross_user(self, client, auth_headers, auth_headers2, test_user, test_user2, db_session):
+        """Should return items from all users (shared/global reads)."""
+        from src.db.models.store import Store
+
+        store = Store(id=uuid4(), name="Costco")
+        db_session.add(store)
+        db_session.commit()
+
+        # Create items by different users
+        item1 = GroceryListItem(
+            id=uuid4(),
+            item_name="User1 Item",
+            quantity=1.0,
+            unit="count",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            target_store=store.id,
+            purchased=False,
+        )
+        item2 = GroceryListItem(
+            id=uuid4(),
+            item_name="User2 Item",
+            quantity=2.0,
+            unit="count",
+            source=GrocerySource.manual.value,
+            added_by=test_user2.id,
+            target_store=store.id,
+            purchased=False,
+        )
+        db_session.add_all([item1, item2])
+        db_session.commit()
+
+        # User1 should see both items
+        response = client.get("/grocery/by-store", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["stores"]) == 1
+        assert len(data["stores"][0]["items"]) == 2
+
+        # User2 should also see both items
+        response = client.get("/grocery/by-store", headers=auth_headers2)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["stores"]) == 1
+        assert len(data["stores"][0]["items"]) == 2
+
+    def test_by_store_empty_stores_not_included(self, client, auth_headers, test_user, db_session):
+        """Should not include stores with no grocery items."""
+        from src.db.models.store import Store
+
+        # Create a store but no grocery items for it
+        store1 = Store(id=uuid4(), name="Empty Store")
+        store2 = Store(id=uuid4(), name="Store With Items")
+        db_session.add_all([store1, store2])
+        db_session.commit()
+
+        # Create item only for store2
+        item = GroceryListItem(
+            id=uuid4(),
+            item_name="Test Item",
+            quantity=1.0,
+            unit="count",
+            source=GrocerySource.manual.value,
+            added_by=test_user.id,
+            target_store=store2.id,
+            purchased=False,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        response = client.get("/grocery/by-store", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["stores"]) == 1
+        assert data["stores"][0]["store_name"] == "Store With Items"
+
+    def test_by_store_unauthenticated(self, client):
+        """Should return 401 if no auth token provided."""
+        response = client.get("/grocery/by-store")
+        assert response.status_code == 401
+
+    def test_by_store_empty_response(self, client, auth_headers, db_session):
+        """Should return empty stores and unassigned arrays when no items exist."""
+        response = client.get("/grocery/by-store", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["stores"] == []
+        assert data["unassigned"] == []


### PR DESCRIPTION
## Work in Progress

Closes #169

[Phase 1F] Add per-store grocery list grouping

**Time Estimate**: 45min

**Description**:
Add GET /grocery/by-store endpoint that returns grocery items grouped by target store, enabling per-store shopping lists. Items without a target_store appear in an "unassigned" group. Default returns unpurchased items only; ?include_purchased=true returns all. Per the shared/global read model, this endpoint returns ALL items from all users — not user-scoped.

**Claude Context**:
Files to Read:
- src/db/models/grocery_list.py (target_store FK)
- src/db/models/store.py (Store model)
- src/routers/inventory.py (query patterns with relationships)

Files to Modify:
- src/services/grocery_service.py (add grouping logic)
- src/routers/grocery.py (add by-store endpoint)
- tests/routers/test_grocery.py (add grouping tests)

Related Issues: Depends on #168 (CRUD must exist)

**Acceptance Criteria**:
- [ ] GET /grocery/by-store returns StoreGroupedGroceryResponse: `{stores: [{store_id, store_name, items: [...]}, ...], unassigned: [...]}`
- [ ] Items grouped by target_store; items with null target_store appear in unassigned array
- [ ] Default behavior returns unpurchased items only (purchased=false)
- [ ] ?include_purchased=true returns all items regardless of purchased status
- [ ] Returns ALL items from all users (shared/global reads, not user-scoped)
- [ ] Empty stores with no items are not included in response
- [ ] Tests cover: grouping, unassigned items, purchased filter, shared reads (items from multiple users visible)

**Verification Commands**:
```bash
pytest tests/routers/test_grocery.py::test_by_store -v
curl "localhost:8000/grocery/by-store" -H "Authorization: Bearer $TOKEN" | jq .
curl "localhost:8000/grocery/by-store?include_purchased=true" -H "Authorization: Bearer $TOKEN" | jq .
```

**Done Definition**: Done when GET /grocery/by-store returns correctly grouped items from all users with purchased filter working.

**Scope Boundary**:
- DO: Add GET /grocery/by-store endpoint
- DO: Implement grouping in grocery_service.py
- DO: Add include_purchased query parameter
- DO: Return items from all users (shared/global reads)
- DO NOT: Add purchase mutation endpoints (#170)

**Dependencies**: After #168 (CRUD endpoints)

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **2** commits (+0 added, ~3 modified, -0 deleted)
- `M` src/routers/grocery.py
- `M` src/services/grocery_service.py
- `M` tests/routers/test_grocery.py

### Commits
- 5eed744 feat: [Phase 1F] Add per-store grocery list grouping
- 8007932 chore: initialize work on #169 [Phase 1F] Add per-store grocery list grouping
<!-- /sharkrite-changes-summary -->