### PR TITLE
Ordering by auto-increment ID instead of timestamp

### DIFF
--- a/alembic/versions/a1b2c3d4e5f6_add_created_at_to_grocery_list_items.py
+++ b/alembic/versions/a1b2c3d4e5f6_add_created_at_to_grocery_list_items.py
@@ -1,0 +1,43 @@
+"""add_created_at_to_grocery_list_items
+
+Adds created_at timestamp column to grocery_list_items table to enable
+proper chronological ordering. Previously, items were ordered by UUID
+(id field), which doesn't guarantee chronological order and can produce
+incorrect ordering in bulk imports, migrations, and concurrent operations.
+
+The created_at field uses server_default=CURRENT_TIMESTAMP to ensure
+existing rows are backfilled with the migration timestamp.
+
+An index is added on created_at to optimize ORDER BY queries.
+
+Revision ID: a1b2c3d4e5f6
+Revises: f9d8c7b6a5e4
+Create Date: 2026-03-21 17:40:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a1b2c3d4e5f6'
+down_revision: Union[str, None] = 'f9d8c7b6a5e4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add created_at column to grocery_list_items table
+    # Use server_default to populate existing rows with migration timestamp
+    with op.batch_alter_table('grocery_list_items', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('created_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False))
+        batch_op.create_index('ix_grocery_list_items_created_at', ['created_at'])
+
+
+def downgrade() -> None:
+    # Remove created_at column from grocery_list_items table
+    with op.batch_alter_table('grocery_list_items', schema=None) as batch_op:
+        batch_op.drop_index('ix_grocery_list_items_created_at')
+        batch_op.drop_column('created_at')

--- a/src/db/models/grocery_list.py
+++ b/src/db/models/grocery_list.py
@@ -35,6 +35,7 @@ class GroceryListItem(Base):
     purchased: Mapped[bool] = mapped_column(Boolean, default=False)
     purchased_by: Mapped[Optional[UUID]] = mapped_column(ForeignKey("users.id"), nullable=True)
     purchased_date: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
 
     # Relationships
     added_by_user: Mapped["User"] = relationship(

--- a/src/services/grocery_service.py
+++ b/src/services/grocery_service.py
@@ -163,7 +163,7 @@ def list_items(
     # Apply ordering and pagination
     items = (
         query
-        .order_by(GroceryListItem.id.desc())  # Most recently added first
+        .order_by(GroceryListItem.created_at.desc())  # Most recently added first (chronological)
         .limit(limit)
         .offset(offset)
         .all()
@@ -560,7 +560,7 @@ def get_items_by_store(
     unpurchased items (include_purchased=False).
 
     Uses eager loading (selectinload) to avoid N+1 queries when accessing
-    store relationships. Items are ordered by ID descending (most recent first)
+    store relationships. Items are ordered by created_at descending (most recent first)
     within each store group.
 
     Args:
@@ -583,8 +583,8 @@ def get_items_by_store(
     if not include_purchased:
         query = query.filter(GroceryListItem.purchased.is_(False))
 
-    # Order by most recent first
-    items = query.order_by(GroceryListItem.id.desc()).all()
+    # Order by most recent first (chronological order using created_at timestamp)
+    items = query.order_by(GroceryListItem.created_at.desc()).all()
 
     # Group items by store
     # Use dict to track stores: {store_id: {"store_id": UUID, "store_name": str, "items": [...]}}


### PR DESCRIPTION
## Work in Progress

Closes #187

Ordering by auto-increment ID instead of timestamp

<!-- sharkrite-source-issue:168 -->## From PR #186 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
This is a real functional concern — ordering by ID rather than `created_at` can produce incorrect chronological ordering in edge cases (bulk imports, migrations). However, fixing it requires verifying the model has `created_at` and potentially adding it if not, which exceeds the quick-fix threshold.

## Context
The issue scope covers GET list functionality but doesn't specify ordering requirements. This is a robustness improvement, not a bug in the current implementation.

## Defer Reason
Requires checking model schema and potentially adding `created_at` field — needs separate focused PR

---
_Created by Sharkrite assessment on 2026-03-21T17:36:54Z_
_Parent PR: #186_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **2** commits (+1 added, ~2 modified, -0 deleted)
- `A` alembic/versions/a1b2c3d4e5f6_add_created_at_to_grocery_list_items.py
- `M` src/db/models/grocery_list.py
- `M` src/services/grocery_service.py

### Commits
- 56cf552 feat: Ordering by auto-increment ID instead of timestamp
- bd3b025 chore: initialize work on #187 Ordering by auto-increment ID instead of timestamp
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-03-21T18:47:41Z:**
- Created: #190 
- Updated: none