### PR TITLE
[Phase 1G] Implement PreparedFood CRUD endpoints

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -10,7 +10,7 @@ from slowapi.errors import RateLimitExceeded
 
 from src.config import get_settings
 from src.db.database import Base, init_engine, get_engine, get_session_factory
-from src.routers import auth_router, users_router, substitutions_router, inventory_router, recipes_router, grocery_router
+from src.routers import auth_router, users_router, substitutions_router, inventory_router, recipes_router, grocery_router, prepared_foods_router
 from src.middleware.rate_limit import limiter
 
 logger = logging.getLogger(__name__)
@@ -81,6 +81,7 @@ app.include_router(substitutions_router)
 app.include_router(inventory_router)
 app.include_router(recipes_router)
 app.include_router(grocery_router)
+app.include_router(prepared_foods_router)
 
 
 @app.get("/health")

--- a/src/routers/__init__.py
+++ b/src/routers/__init__.py
@@ -12,5 +12,6 @@ from src.routers.substitutions import router as substitutions_router
 from src.routers.inventory import router as inventory_router
 from src.routers.recipes import router as recipes_router
 from src.routers.grocery import router as grocery_router
+from src.routers.prepared_foods import router as prepared_foods_router
 
-__all__ = ["auth_router", "users_router", "substitutions_router", "inventory_router", "recipes_router", "grocery_router"]
+__all__ = ["auth_router", "users_router", "substitutions_router", "inventory_router", "recipes_router", "grocery_router", "prepared_foods_router"]

--- a/src/routers/prepared_foods.py
+++ b/src/routers/prepared_foods.py
@@ -1,0 +1,327 @@
+"""
+PreparedFood CRUD endpoints for FreshUp.
+
+Provides endpoints for users to manage prepared foods (leftovers, batch prep,
+component ingredients). Implements shareability-aware permissions where shared
+items are visible to all users, but personal/reserved items are only visible
+to their owner.
+
+Logging Policy:
+    User-provided item names are NOT logged as they may contain sensitive
+    health information (e.g., dietary restrictions, medical meal prep).
+    Logs include operational metadata (user_id, item_id, timestamps) for
+    debugging while protecting user privacy per OWASP recommendations.
+"""
+
+import logging
+from uuid import UUID
+from typing import Optional
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError, IntegrityError
+from sqlalchemy import or_
+
+from src.db.database import get_db
+from src.db.models.user import User
+from src.db.models.prepared_food import PreparedFood, PreparedFoodType
+from src.db.models.inventory_item import StorageLocation, Shareability
+from src.schemas.prepared_food import (
+    PreparedFoodCreate,
+    PreparedFoodUpdate,
+    PreparedFoodResponse,
+    PreparedFoodListResponse,
+)
+from src.schemas.validators import validate_enum_value
+from src.middleware.auth import get_current_user
+from src.routers.prepared_foods_helpers import verify_prepared_food_ownership
+from src.services.prepared_foods_service import create_prepared_food
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/prepared-foods", tags=["prepared-foods"])
+
+
+@router.post("", response_model=PreparedFoodResponse, status_code=status.HTTP_201_CREATED)
+def create_prepared_food_endpoint(
+    item_data: PreparedFoodCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Create a new prepared food item for the authenticated user.
+
+    The prepared_by field is automatically set to the current user's ID,
+    ignoring any value provided in the request body.
+
+    Args:
+        item_data: Prepared food data (name, type, servings, storage, etc.)
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        PreparedFoodResponse: Created prepared food item
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(400): If data integrity violation occurs
+        HTTPException(422): If validation fails (invalid type, storage_location, etc.)
+    """
+    return create_prepared_food(item_data, current_user, db)
+
+
+@router.get("", response_model=list[PreparedFoodListResponse])
+def list_prepared_foods(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+    limit: int = Query(default=50, ge=1, le=100, description="Maximum number of items to return"),
+    offset: int = Query(default=0, ge=0, description="Number of items to skip"),
+    type: Optional[str] = Query(default=None, description="Filter by type (complete_meal, batch_portion, component_ingredient)"),
+    storage_location: Optional[str] = Query(default=None, description="Filter by storage location (pantry, fridge, freezer)"),
+    shareability: Optional[str] = Query(default=None, description="Filter by shareability (shared, reserved, personal)"),
+):
+    """
+    List prepared food items with shareability-aware filtering and pagination.
+
+    Returns shared items from ALL users, plus personal/reserved items only from
+    the current user. This implements multi-user visibility for shared prepared
+    foods while maintaining privacy for personal items.
+
+    Supports pagination via limit and offset query parameters.
+    Supports filtering by type, storage location, and shareability.
+    Multiple filters combine with AND logic.
+
+    Args:
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+        limit: Maximum number of items to return (1-100, default 50)
+        offset: Number of items to skip (default 0)
+        type: Filter by type (must be valid PreparedFoodType enum value)
+        storage_location: Filter by storage location (must be valid StorageLocation enum value)
+        shareability: Filter by shareability (must be valid Shareability enum value)
+
+    Returns:
+        list[PreparedFoodListResponse]: List of prepared food items matching filters
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(422): If invalid enum value provided for type, storage_location, or shareability
+    """
+    # Shareability-aware base query:
+    # - Include all items where shareability = 'shared' (from any user)
+    # - Include items where prepared_by = current_user (personal/reserved items)
+    query = db.query(PreparedFood).filter(
+        or_(
+            PreparedFood.shareability == Shareability.shared.value,
+            PreparedFood.prepared_by == current_user.id
+        )
+    )
+
+    # Apply type filter
+    if type is not None:
+        try:
+            validate_enum_value("type", type, PreparedFoodType)
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+        query = query.filter(PreparedFood.type == type)
+
+    # Apply storage_location filter
+    if storage_location is not None:
+        try:
+            validate_enum_value("storage_location", storage_location, StorageLocation)
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+        query = query.filter(PreparedFood.storage_location == storage_location)
+
+    # Apply shareability filter
+    if shareability is not None:
+        try:
+            validate_enum_value("shareability", shareability, Shareability)
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+        # When filtering by shareability, still respect base visibility rules
+        # Example: If filtering for "personal", only show current user's personal items
+        if shareability == Shareability.personal.value or shareability == Shareability.reserved.value:
+            query = query.filter(
+                PreparedFood.shareability == shareability,
+                PreparedFood.prepared_by == current_user.id
+            )
+        else:
+            # For "shared", show all shared items (already covered by base query)
+            query = query.filter(PreparedFood.shareability == shareability)
+
+    # Apply ordering and pagination
+    items = (
+        query
+        .order_by(PreparedFood.date_prepared.desc())
+        .limit(limit)
+        .offset(offset)
+        .all()
+    )
+
+    return items
+
+
+@router.get("/{item_id}", response_model=PreparedFoodResponse)
+def get_prepared_food(
+    item_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Get a single prepared food item by ID.
+
+    Retrieves a specific prepared food item. Returns 404 if the item doesn't exist,
+    or if the item is personal/reserved and belongs to a different user.
+
+    Implements shareability-aware access:
+    - Shared items are accessible to all users
+    - Personal/reserved items are only accessible to their owner
+
+    Args:
+        item_id: UUID of the prepared food item to retrieve
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        PreparedFoodResponse: Requested prepared food item
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If item doesn't exist or is not accessible to current user
+    """
+    # Query item with shareability-aware access control
+    item = (
+        db.query(PreparedFood)
+        .filter(
+            PreparedFood.id == item_id,
+            or_(
+                PreparedFood.shareability == Shareability.shared.value,
+                PreparedFood.prepared_by == current_user.id
+            )
+        )
+        .first()
+    )
+
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Prepared food item not found"
+        )
+
+    return item
+
+
+@router.put("/{item_id}", response_model=PreparedFoodResponse)
+def update_prepared_food(
+    item_id: UUID,
+    update_data: PreparedFoodUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Update a prepared food item with partial data.
+
+    Allows partial updates - only provided fields will be updated. Returns 404
+    if the item doesn't exist or belongs to a different user.
+
+    Only the owner (prepared_by user) can update items, regardless of shareability.
+
+    Args:
+        item_id: UUID of the prepared food item to update
+        update_data: Fields to update (all optional)
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        PreparedFoodResponse: Updated prepared food item
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If item doesn't exist or belongs to another user
+        HTTPException(422): If validation fails (invalid type, storage_location, etc.)
+    """
+    # Verify item exists and belongs to current user
+    item = verify_prepared_food_ownership(item_id, current_user, db)
+
+    # Update only the fields that were provided
+    update_dict = update_data.model_dump(exclude_unset=True)
+
+    # Apply updates
+    for field, value in update_dict.items():
+        setattr(item, field, value)
+
+    try:
+        db.commit()
+        db.refresh(item)
+    except IntegrityError as e:
+        db.rollback()
+        logger.error(f"Integrity error during prepared food update for user {current_user.id}")
+        logger.debug(f"Integrity error occurred during prepared food update: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Prepared food update failed due to data integrity violation"
+        )
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during prepared food update for user {current_user.id}")
+        logger.debug(f"Database error occurred during prepared food update: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while updating the prepared food item"
+        )
+
+    logger.info(
+        f"Prepared food updated: user_id={current_user.id}, "
+        f"item_id={item_id}"
+    )
+
+    return item
+
+
+@router.delete("/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_prepared_food(
+    item_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Delete a prepared food item.
+
+    Removes the specified prepared food item. Returns 404 if the item doesn't exist
+    or belongs to a different user.
+
+    Only the owner (prepared_by user) can delete items, regardless of shareability.
+
+    Args:
+        item_id: UUID of the prepared food item to delete
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        None (204 No Content on success)
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If item doesn't exist or belongs to another user
+    """
+    # Verify item exists and belongs to current user
+    item = verify_prepared_food_ownership(item_id, current_user, db)
+
+    try:
+        db.delete(item)
+        db.commit()
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during prepared food deletion for user {current_user.id}")
+        logger.debug(f"Database error occurred during prepared food deletion: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while deleting the prepared food item"
+        )
+
+    logger.info(
+        f"Prepared food deleted: user_id={current_user.id}, "
+        f"item_id={item_id}"
+    )
+
+    return None

--- a/src/routers/prepared_foods.py
+++ b/src/routers/prepared_foods.py
@@ -152,7 +152,7 @@ def list_prepared_foods(
     # Apply ordering and pagination
     items = (
         query
-        .order_by(PreparedFood.date_prepared.desc())
+        .order_by(PreparedFood.date_prepared.desc(), PreparedFood.id.desc())
         .limit(limit)
         .offset(offset)
         .all()

--- a/src/routers/prepared_foods_helpers.py
+++ b/src/routers/prepared_foods_helpers.py
@@ -1,0 +1,45 @@
+"""
+Helper functions for prepared food ownership verification.
+
+Centralizes ownership validation logic to reduce code duplication across
+prepared food CRUD endpoints and maintain consistent error handling.
+"""
+
+from uuid import UUID
+from sqlalchemy.orm import Session
+
+from src.db.models.user import User
+from src.db.models.prepared_food import PreparedFood
+from src.utils.ownership import verify_ownership
+
+
+def verify_prepared_food_ownership(
+    item_id: UUID,
+    current_user: User,
+    db: Session,
+) -> PreparedFood:
+    """
+    Verify that a prepared food item exists and belongs to the current user.
+
+    Used by update and delete endpoints that enforce ownership at the
+    database query level for efficiency.
+
+    Args:
+        item_id: UUID of the prepared food item to verify
+        current_user: Authenticated user making the request
+        db: Database session
+
+    Returns:
+        PreparedFood: The item if it exists and belongs to current user
+
+    Raises:
+        HTTPException(404): If item doesn't exist or belongs to another user
+    """
+    return verify_ownership(
+        entity_class=PreparedFood,
+        entity_id=item_id,
+        ownership_field='prepared_by',
+        current_user=current_user,
+        db=db,
+        entity_name="Prepared food item"
+    )

--- a/src/services/prepared_foods_service.py
+++ b/src/services/prepared_foods_service.py
@@ -1,0 +1,77 @@
+"""
+Business logic for prepared food operations.
+
+Separates business logic from router layer to improve testability
+and maintain separation of concerns.
+"""
+
+import logging
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError, IntegrityError
+from fastapi import HTTPException, status
+
+from src.db.models.prepared_food import PreparedFood
+from src.db.models.user import User
+from src.schemas.prepared_food import PreparedFoodCreate
+
+logger = logging.getLogger(__name__)
+
+
+def create_prepared_food(
+    item_data: PreparedFoodCreate,
+    current_user: User,
+    db: Session,
+) -> PreparedFood:
+    """
+    Create a new prepared food item for the authenticated user.
+
+    The prepared_by field is automatically set to the current user's ID,
+    ensuring proper ownership tracking.
+
+    Args:
+        item_data: Prepared food data (name, type, servings, etc.)
+        current_user: Authenticated user creating the item
+        db: Database session
+
+    Returns:
+        PreparedFood: Created prepared food item
+
+    Raises:
+        HTTPException(400): If data integrity violation occurs
+        HTTPException(500): If database error occurs
+    """
+    # Create new prepared food item with prepared_by set to current user
+    item_dict = item_data.model_dump()
+    new_item = PreparedFood(
+        **item_dict,
+        prepared_by=current_user.id,
+    )
+
+    db.add(new_item)
+
+    try:
+        db.commit()
+        db.refresh(new_item)
+    except IntegrityError as e:
+        db.rollback()
+        logger.error(f"Integrity error during prepared food creation for user {current_user.id}")
+        logger.debug(f"Integrity error occurred during prepared food creation: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Prepared food creation failed due to data integrity violation"
+        )
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during prepared food creation for user {current_user.id}")
+        logger.debug(f"Database error occurred during prepared food creation: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while creating the prepared food item"
+        )
+
+    logger.info(
+        f"Prepared food created: user_id={current_user.id}, "
+        f"item_id={new_item.id}"
+    )
+
+    return new_item

--- a/tests/routers/test_prepared_foods.py
+++ b/tests/routers/test_prepared_foods.py
@@ -1,0 +1,613 @@
+"""
+Integration tests for prepared food endpoints.
+
+Tests cover:
+- POST /prepared-foods: create items with validation
+- GET /prepared-foods: list items with shareability-aware filtering
+- GET /prepared-foods/{id}: get single item with shareability-aware access
+- PUT /prepared-foods/{id}: update items (owner-only)
+- DELETE /prepared-foods/{id}: delete item (owner-only)
+- Shareability-aware permissions (shared visible to all, personal/reserved to owner only)
+- Filters (type, storage_location, shareability)
+- Pagination (limit, offset)
+- Authentication requirements
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from uuid import uuid4
+
+from src.db.database import Base, get_db
+from src.db import models
+from src.db.models.user import User, UserRole
+from src.db.models.prepared_food import PreparedFood
+from src.services.auth_service import hash_password, create_access_token
+
+from fastapi import FastAPI
+from src.routers import prepared_foods_router
+
+# Create a test app without lifespan
+app = FastAPI(
+    title="FreshUp",
+    description="Privacy-first kitchen management system",
+    version="0.1.0",
+)
+
+# Register the prepared_foods router
+app.include_router(prepared_foods_router)
+
+
+# Create an in-memory SQLite database for testing
+TEST_DATABASE_URL = "sqlite:///:memory:"
+
+
+@pytest.fixture(autouse=True)
+def setup_test_env(monkeypatch):
+    """Set up test environment variables."""
+    from src.config import get_settings
+    get_settings.cache_clear()
+
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars")
+    monkeypatch.setenv("JWT_ALGORITHM", "HS256")
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    monkeypatch.setenv("ACCESS_TOKEN_EXPIRE_MINUTES", "43200")
+
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def db_session():
+    """Create a fresh database session for each test."""
+    from sqlalchemy.pool import StaticPool
+
+    # Import models to ensure all SQLAlchemy model classes are registered
+    # with Base.metadata before create_all() is called
+    _ = models
+
+    engine = create_engine(
+        TEST_DATABASE_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+@pytest.fixture
+def client(db_session):
+    """Create a test client with database dependency override."""
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def test_user(db_session):
+    """Create a test user."""
+    user = User(
+        id=uuid4(),
+        email="test@example.com",
+        hashed_password=hash_password("testpassword123"),
+        name="Test User",
+        role=UserRole.member.value,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def test_user2(db_session):
+    """Create a second test user for cross-user access tests."""
+    user = User(
+        id=uuid4(),
+        email="test2@example.com",
+        hashed_password=hash_password("testpassword123"),
+        name="Test User 2",
+        role=UserRole.member.value,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def auth_headers(test_user):
+    """Generate authorization headers for test user."""
+    access_token = create_access_token({"sub": str(test_user.id)})
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+@pytest.fixture
+def auth_headers2(test_user2):
+    """Generate authorization headers for test user 2."""
+    access_token = create_access_token({"sub": str(test_user2.id)})
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+class TestCreatePreparedFood:
+    """Tests for POST /prepared-foods (create prepared food item)."""
+
+    def test_create_prepared_food(self, client, auth_headers, test_user, db_session):
+        """Should create prepared food item and auto-set prepared_by to current user."""
+        payload = {
+            "name": "Leftover curry",
+            "type": "complete_meal",
+            "servings_remaining": 3.0,
+            "storage_location": "fridge",
+            "shareability": "shared",
+        }
+
+        response = client.post("/prepared-foods", json=payload, headers=auth_headers)
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["name"] == "Leftover curry"
+        assert data["type"] == "complete_meal"
+        assert data["servings_remaining"] == 3.0
+        assert data["storage_location"] == "fridge"
+        assert data["shareability"] == "shared"
+        assert data["prepared_by"] == str(test_user.id)
+
+        # Verify in database
+        from uuid import UUID
+        item = db_session.query(PreparedFood).filter_by(id=UUID(data["id"])).first()
+        assert item is not None
+        assert item.prepared_by == test_user.id
+
+    def test_create_with_defaults(self, client, auth_headers, test_user):
+        """Should create item with default shareability value."""
+        payload = {
+            "name": "Batch chili",
+            "type": "batch_portion",
+            "servings_remaining": 8.0,
+            "storage_location": "freezer",
+        }
+
+        response = client.post("/prepared-foods", json=payload, headers=auth_headers)
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["shareability"] == "shared"  # Default value
+
+    def test_create_requires_auth(self, client):
+        """Should reject request without authentication."""
+        payload = {
+            "name": "Leftover pasta",
+            "type": "complete_meal",
+            "servings_remaining": 2.0,
+            "storage_location": "fridge",
+        }
+
+        response = client.post("/prepared-foods", json=payload)
+
+        assert response.status_code == 401
+
+    def test_create_invalid_type(self, client, auth_headers):
+        """Should reject invalid type enum value."""
+        payload = {
+            "name": "Test item",
+            "type": "invalid_type",
+            "servings_remaining": 1.0,
+            "storage_location": "fridge",
+        }
+
+        response = client.post("/prepared-foods", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+
+    def test_create_invalid_storage_location(self, client, auth_headers):
+        """Should reject invalid storage_location enum value."""
+        payload = {
+            "name": "Test item",
+            "type": "complete_meal",
+            "servings_remaining": 1.0,
+            "storage_location": "garage",
+        }
+
+        response = client.post("/prepared-foods", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+
+    def test_create_negative_servings(self, client, auth_headers):
+        """Should reject negative servings_remaining."""
+        payload = {
+            "name": "Test item",
+            "type": "complete_meal",
+            "servings_remaining": -1.0,
+            "storage_location": "fridge",
+        }
+
+        response = client.post("/prepared-foods", json=payload, headers=auth_headers)
+
+        assert response.status_code == 422
+
+
+class TestListPreparedFoods:
+    """Tests for GET /prepared-foods (list with shareability-aware filtering)."""
+
+    def test_list_includes_shared_items_from_all_users(self, client, auth_headers, auth_headers2, test_user, test_user2, db_session):
+        """Should return shared items from all users."""
+        # Create shared item from user1
+        item1 = PreparedFood(
+            id=uuid4(),
+            name="User1 shared curry",
+            type="complete_meal",
+            servings_remaining=3.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        # Create shared item from user2
+        item2 = PreparedFood(
+            id=uuid4(),
+            name="User2 shared chili",
+            type="batch_portion",
+            servings_remaining=8.0,
+            storage_location="freezer",
+            shareability="shared",
+            prepared_by=test_user2.id,
+        )
+        db_session.add_all([item1, item2])
+        db_session.commit()
+
+        # User1 should see both shared items
+        response = client.get("/prepared-foods", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        names = {item["name"] for item in data}
+        assert "User1 shared curry" in names
+        assert "User2 shared chili" in names
+
+        # User2 should also see both shared items
+        response = client.get("/prepared-foods", headers=auth_headers2)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+
+    def test_list_includes_personal_items_only_for_owner(self, client, auth_headers, auth_headers2, test_user, test_user2, db_session):
+        """Should return personal/reserved items only to their owner."""
+        # Create personal item from user1
+        item1 = PreparedFood(
+            id=uuid4(),
+            name="User1 personal meal",
+            type="complete_meal",
+            servings_remaining=1.0,
+            storage_location="fridge",
+            shareability="personal",
+            prepared_by=test_user.id,
+        )
+        # Create reserved item from user2
+        item2 = PreparedFood(
+            id=uuid4(),
+            name="User2 reserved batch",
+            type="batch_portion",
+            servings_remaining=4.0,
+            storage_location="freezer",
+            shareability="reserved",
+            prepared_by=test_user2.id,
+        )
+        db_session.add_all([item1, item2])
+        db_session.commit()
+
+        # User1 should only see their own personal item
+        response = client.get("/prepared-foods", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "User1 personal meal"
+
+        # User2 should only see their own reserved item
+        response = client.get("/prepared-foods", headers=auth_headers2)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "User2 reserved batch"
+
+    def test_list_filters(self, client, auth_headers, test_user, db_session):
+        """Should filter by type, storage_location, shareability."""
+        # Create diverse items
+        items = [
+            PreparedFood(id=uuid4(), name="Meal1", type="complete_meal", servings_remaining=1.0, storage_location="fridge", shareability="shared", prepared_by=test_user.id),
+            PreparedFood(id=uuid4(), name="Batch1", type="batch_portion", servings_remaining=5.0, storage_location="freezer", shareability="shared", prepared_by=test_user.id),
+            PreparedFood(id=uuid4(), name="Component1", type="component_ingredient", servings_remaining=10.0, storage_location="fridge", shareability="personal", prepared_by=test_user.id),
+        ]
+        db_session.add_all(items)
+        db_session.commit()
+
+        # Filter by type
+        response = client.get("/prepared-foods?type=complete_meal", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["type"] == "complete_meal"
+
+        # Filter by storage_location
+        response = client.get("/prepared-foods?storage_location=freezer", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["storage_location"] == "freezer"
+
+        # Filter by shareability
+        response = client.get("/prepared-foods?shareability=personal", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["shareability"] == "personal"
+
+    def test_list_pagination(self, client, auth_headers, test_user, db_session):
+        """Should support limit and offset pagination."""
+        # Create multiple items
+        items = [
+            PreparedFood(id=uuid4(), name=f"Item{i}", type="complete_meal", servings_remaining=1.0, storage_location="fridge", shareability="shared", prepared_by=test_user.id)
+            for i in range(10)
+        ]
+        db_session.add_all(items)
+        db_session.commit()
+
+        # Get first page
+        response = client.get("/prepared-foods?limit=5&offset=0", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 5
+
+        # Get second page
+        response = client.get("/prepared-foods?limit=5&offset=5", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 5
+
+    def test_list_requires_auth(self, client):
+        """Should reject request without authentication."""
+        response = client.get("/prepared-foods")
+        assert response.status_code == 401
+
+
+class TestGetPreparedFood:
+    """Tests for GET /prepared-foods/{id} (get single item with shareability-aware access)."""
+
+    def test_get_shared_item_by_any_user(self, client, auth_headers, auth_headers2, test_user, test_user2, db_session):
+        """Should allow any user to read shared items."""
+        # Create shared item from user1
+        item = PreparedFood(
+            id=uuid4(),
+            name="Shared curry",
+            type="complete_meal",
+            servings_remaining=3.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        # User1 (owner) should be able to read
+        response = client.get(f"/prepared-foods/{item.id}", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Shared curry"
+
+        # User2 (non-owner) should also be able to read shared item
+        response = client.get(f"/prepared-foods/{item.id}", headers=auth_headers2)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Shared curry"
+
+    def test_get_personal_item_only_by_owner(self, client, auth_headers, auth_headers2, test_user, db_session):
+        """Should only allow owner to read personal items."""
+        # Create personal item from user1
+        item = PreparedFood(
+            id=uuid4(),
+            name="Personal meal",
+            type="complete_meal",
+            servings_remaining=1.0,
+            storage_location="fridge",
+            shareability="personal",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        # User1 (owner) should be able to read
+        response = client.get(f"/prepared-foods/{item.id}", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Personal meal"
+
+        # User2 (non-owner) should get 404
+        response = client.get(f"/prepared-foods/{item.id}", headers=auth_headers2)
+        assert response.status_code == 404
+
+    def test_get_nonexistent_item(self, client, auth_headers):
+        """Should return 404 for nonexistent item."""
+        fake_id = uuid4()
+        response = client.get(f"/prepared-foods/{fake_id}", headers=auth_headers)
+        assert response.status_code == 404
+
+    def test_get_requires_auth(self, client, test_user, db_session):
+        """Should reject request without authentication."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Test item",
+            type="complete_meal",
+            servings_remaining=1.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        response = client.get(f"/prepared-foods/{item.id}")
+        assert response.status_code == 401
+
+
+class TestUpdatePreparedFood:
+    """Tests for PUT /prepared-foods/{id} (update, owner-only)."""
+
+    def test_update_by_owner(self, client, auth_headers, test_user, db_session):
+        """Should allow owner to update their item."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Original name",
+            type="complete_meal",
+            servings_remaining=3.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        payload = {
+            "name": "Updated name",
+            "servings_remaining": 2.0,
+        }
+
+        response = client.put(f"/prepared-foods/{item.id}", json=payload, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Updated name"
+        assert data["servings_remaining"] == 2.0
+        assert data["storage_location"] == "fridge"  # Unchanged
+
+    def test_update_by_non_owner(self, client, auth_headers2, test_user, db_session):
+        """Should reject update by non-owner with 404."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="User1 item",
+            type="complete_meal",
+            servings_remaining=3.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        payload = {"name": "Hacked name"}
+
+        # User2 tries to update user1's item
+        response = client.put(f"/prepared-foods/{item.id}", json=payload, headers=auth_headers2)
+        assert response.status_code == 404
+
+    def test_update_nonexistent_item(self, client, auth_headers):
+        """Should return 404 for nonexistent item."""
+        fake_id = uuid4()
+        payload = {"name": "Test"}
+
+        response = client.put(f"/prepared-foods/{fake_id}", json=payload, headers=auth_headers)
+        assert response.status_code == 404
+
+    def test_update_requires_auth(self, client, test_user, db_session):
+        """Should reject request without authentication."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Test item",
+            type="complete_meal",
+            servings_remaining=1.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        payload = {"name": "New name"}
+        response = client.put(f"/prepared-foods/{item.id}", json=payload)
+        assert response.status_code == 401
+
+
+class TestDeletePreparedFood:
+    """Tests for DELETE /prepared-foods/{id} (delete, owner-only)."""
+
+    def test_delete_by_owner(self, client, auth_headers, test_user, db_session):
+        """Should allow owner to delete their item."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Test item",
+            type="complete_meal",
+            servings_remaining=1.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        item_id = item.id
+
+        response = client.delete(f"/prepared-foods/{item_id}", headers=auth_headers)
+
+        assert response.status_code == 204
+
+        # Verify item is deleted
+        deleted_item = db_session.query(PreparedFood).filter_by(id=item_id).first()
+        assert deleted_item is None
+
+    def test_delete_by_non_owner(self, client, auth_headers2, test_user, db_session):
+        """Should reject delete by non-owner with 404."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="User1 item",
+            type="complete_meal",
+            servings_remaining=1.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        # User2 tries to delete user1's item
+        response = client.delete(f"/prepared-foods/{item.id}", headers=auth_headers2)
+        assert response.status_code == 404
+
+        # Verify item still exists
+        existing_item = db_session.query(PreparedFood).filter_by(id=item.id).first()
+        assert existing_item is not None
+
+    def test_delete_nonexistent_item(self, client, auth_headers):
+        """Should return 404 for nonexistent item."""
+        fake_id = uuid4()
+        response = client.delete(f"/prepared-foods/{fake_id}", headers=auth_headers)
+        assert response.status_code == 404
+
+    def test_delete_requires_auth(self, client, test_user, db_session):
+        """Should reject request without authentication."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Test item",
+            type="complete_meal",
+            servings_remaining=1.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        response = client.delete(f"/prepared-foods/{item.id}")
+        assert response.status_code == 401


### PR DESCRIPTION
## Work in Progress

Closes #192

[Phase 1G] Implement PreparedFood CRUD endpoints

**Time Estimate**: 2hr

**Description**:
Implement full CRUD endpoints for PreparedFood (leftovers, batch prep, component ingredients). Users can log leftovers after cooking, track batch-prepared items, and manage component ingredients like stock blocks that act as inventory for recipe matching.

**Claude Context**:
Files to Read:
- src/routers/inventory.py (existing CRUD pattern, shareability handling, 404 for ownership failures)
- src/db/models/prepared_food.py (PreparedFood model)
- src/middleware/auth.py (get_current_user dependency)

Files to Modify:
- src/routers/prepared_foods.py
- src/services/prepared_foods_service.py (create — router delegates to service) (create)
- src/routers/__init__.py (export prepared_foods_router)
- src/main.py (register router)
- tests/routers/test_prepared_foods.py (create)

Related Issues: Depends on schemas from #191

**Acceptance Criteria**:
- [ ] POST /prepared-foods creates item with prepared_by set to current user: `pytest tests/routers/test_prepared_foods.py::test_create_prepared_food -v`
- [ ] GET /prepared-foods returns shared items from all users + personal/reserved items only for owner: verify list includes shared items from other users
- [ ] GET /prepared-foods supports filters: type, storage_location, shareability: `pytest tests/routers/test_prepared_foods.py::test_list_filters -v`
- [ ] GET /prepared-foods supports pagination (limit, offset): verify via test
- [ ] GET /prepared-foods/{id} returns item if shared OR if owner; 404 otherwise: verify shareability-aware read
- [ ] PUT /prepared-foods/{id} updates only if owner; 404 for non-owner: verify owner-only update
- [ ] DELETE /prepared-foods/{id} deletes only if owner; 404 for non-owner: verify owner-only delete
- [ ] Router registered at /prepared-foods prefix: `curl http://localhost:8000/prepared-foods`
- [ ] All tests pass: `pytest tests/routers/test_prepared_foods.py -v`

**Verification Commands**:
```bash
pytest tests/routers/test_prepared_foods.py -v
curl -X POST http://localhost:8000/prepared-foods \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"name":"Leftover curry","type":"complete_meal","servings_remaining":3.0,"storage_location":"fridge"}'
```

**Done Definition**: Done when all CRUD endpoints work with shareability-aware permissions and all tests pass.

**Scope Boundary**:
- DO: Full CRUD with shareability-aware read permissions (shared visible to all, personal/reserved to owner only)
- DO: Owner-only restrictions on update/delete (404 for non-owner, consistent with inventory pattern)
- DO: Filter by type, storage_location, shareability
- DO: Register router in main.py
- DO NOT: Implement consume endpoint (separate action endpoints issue)
- DO NOT: Implement freeze/thaw endpoints (separate action endpoints issue)
- DO NOT: Add ready-to-eat filtered endpoint (separate action endpoints issue)

**Dependencies**: After #191

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**6** files, **2** commits (+4 added, ~2 modified, -0 deleted)
- `M` src/main.py
- `M` src/routers/__init__.py
- `A` src/routers/prepared_foods.py
- `A` src/routers/prepared_foods_helpers.py
- `A` src/services/prepared_foods_service.py
- `A` tests/routers/test_prepared_foods.py

### Commits
- 4e79934 feat: [Phase 1G] Implement PreparedFood CRUD endpoints
- 7aa4a2d chore: initialize work on #192 [Phase 1G] Implement PreparedFood CRUD endpoints
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues
Created: #198 
**From assessment on 2026-03-22T16:40:21Z:**
- Created: #197 
- Updated: none