### PR TITLE
[Phase 1G] Add PreparedFood action endpoints

### DIFF
--- a/src/routers/prepared_foods.py
+++ b/src/routers/prepared_foods.py
@@ -30,11 +30,20 @@ from src.schemas.prepared_food import (
     PreparedFoodUpdate,
     PreparedFoodResponse,
     PreparedFoodListResponse,
+    PreparedFoodConsumptionResponse,
+    TransferRequest,
 )
+from src.schemas.inventory import ConsumptionRequest
 from src.schemas.validators import validate_enum_value
 from src.middleware.auth import get_current_user
 from src.routers.prepared_foods_helpers import verify_prepared_food_ownership
-from src.services.prepared_foods_service import create_prepared_food
+from src.services.prepared_foods_service import (
+    create_prepared_food,
+    consume_prepared_food,
+    transfer_prepared_food,
+    freeze_prepared_food,
+    thaw_prepared_food,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -325,3 +334,141 @@ def delete_prepared_food(
     )
 
     return None
+
+
+@router.post("/{item_id}/consume", response_model=PreparedFoodConsumptionResponse)
+def consume_prepared_food_endpoint(
+    item_id: UUID,
+    consumption_data: ConsumptionRequest = ConsumptionRequest(),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Consume (decrement) prepared food servings with shareability-aware permissions.
+
+    Decrements the item's servings_remaining by the specified amount. If servings reach
+    zero and delete_when_empty is true (default), the item is deleted.
+
+    Implements shareability-aware access control:
+    - Shared items can be consumed by any authenticated user
+    - Personal/reserved items can only be consumed by their owner (404 for non-owner)
+
+    Args:
+        item_id: UUID of the prepared food item to consume
+        consumption_data: Amount to consume and deletion preference
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        PreparedFoodConsumptionResponse: Status message, deletion flag, and updated item (if not deleted)
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If item doesn't exist or is not accessible to current user
+        HTTPException(400): If consumption amount exceeds available servings
+        HTTPException(422): If amount is negative or zero
+    """
+    message, deleted, item = consume_prepared_food(item_id, consumption_data, current_user, db)
+
+    return PreparedFoodConsumptionResponse(
+        message=message,
+        deleted=deleted,
+        item=item
+    )
+
+
+@router.post("/{item_id}/transfer", response_model=PreparedFoodResponse)
+def transfer_prepared_food_endpoint(
+    item_id: UUID,
+    transfer_data: TransferRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Transfer prepared food to a different storage location.
+
+    Updates the item's storage_location field to the specified location.
+    Only the owner (prepared_by user) can transfer items.
+
+    Args:
+        item_id: UUID of the prepared food item to transfer
+        transfer_data: Target storage location
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        PreparedFoodResponse: Updated prepared food item
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If item doesn't exist or belongs to another user
+        HTTPException(422): If storage_location is invalid
+    """
+    # Verify item exists and belongs to current user
+    item = verify_prepared_food_ownership(item_id, current_user, db)
+
+    return transfer_prepared_food(item, transfer_data.storage_location, current_user, db)
+
+
+@router.post("/{item_id}/freeze", response_model=PreparedFoodResponse)
+def freeze_prepared_food_endpoint(
+    item_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Freeze a prepared food item (quick action).
+
+    Updates the item's storage location to "freezer". This endpoint is idempotent -
+    freezing an already-frozen item simply ensures it's in the freezer.
+
+    Only the owner (prepared_by user) can freeze items.
+
+    Args:
+        item_id: UUID of the prepared food item to freeze
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        PreparedFoodResponse: Updated prepared food item with freezer location
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If item doesn't exist or belongs to another user
+    """
+    # Verify item exists and belongs to current user
+    item = verify_prepared_food_ownership(item_id, current_user, db)
+
+    return freeze_prepared_food(item, current_user, db)
+
+
+@router.post("/{item_id}/thaw", response_model=PreparedFoodResponse)
+def thaw_prepared_food_endpoint(
+    item_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Thaw a prepared food item (quick action).
+
+    Updates the item's storage location to "fridge". This endpoint is idempotent -
+    thawing a non-frozen item simply ensures it's in the fridge.
+
+    Only the owner (prepared_by user) can thaw items.
+
+    Args:
+        item_id: UUID of the prepared food item to thaw
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        PreparedFoodResponse: Updated prepared food item with fridge location
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If item doesn't exist or belongs to another user
+    """
+    # Verify item exists and belongs to current user
+    item = verify_prepared_food_ownership(item_id, current_user, db)
+
+    return thaw_prepared_food(item, current_user, db)

--- a/src/schemas/prepared_food.py
+++ b/src/schemas/prepared_food.py
@@ -159,6 +159,20 @@ class PreparedFoodConsumptionResponse(BaseModel):
     item: Optional[PreparedFoodResponse] = Field(default=None, description="Updated item (null if deleted)")
 
 
+class TransferRequest(BaseModel):
+    """Request schema for transferring prepared food to a different storage location."""
+
+    storage_location: str = Field(..., description="Target storage location (pantry, fridge, freezer)")
+
+    @field_validator('storage_location')
+    @classmethod
+    def validate_storage_location_field(cls, v: str) -> str:
+        """Ensure storage_location is a valid StorageLocation enum value."""
+        result = validate_enum_value('Storage location', v, StorageLocation, allow_none=False)
+        # validate_enum_value handles Optional, but this field is required so won't be None
+        return result  # type: ignore
+
+
 __all__ = [
     "PreparedFoodCreate",
     "PreparedFoodUpdate",
@@ -166,4 +180,5 @@ __all__ = [
     "PreparedFoodListResponse",
     "PreparedFoodConsumptionResponse",
     "ConsumptionRequest",
+    "TransferRequest",
 ]

--- a/src/services/prepared_foods_service.py
+++ b/src/services/prepared_foods_service.py
@@ -6,13 +6,19 @@ and maintain separation of concerns.
 """
 
 import logging
+import math
+from uuid import UUID
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError, IntegrityError
+from sqlalchemy import or_
 from fastapi import HTTPException, status
 
+from src.constants import FLOAT_COMPARISON_TOLERANCE
 from src.db.models.prepared_food import PreparedFood
 from src.db.models.user import User
+from src.db.models.inventory_item import StorageLocation, Shareability
 from src.schemas.prepared_food import PreparedFoodCreate
+from src.schemas.inventory import ConsumptionRequest
 
 logger = logging.getLogger(__name__)
 
@@ -75,3 +81,257 @@ def create_prepared_food(
     )
 
     return new_item
+
+
+def consume_prepared_food(
+    item_id: UUID,
+    consumption_data: ConsumptionRequest,
+    current_user: User,
+    db: Session,
+) -> tuple[str, bool, PreparedFood | None]:
+    """
+    Consume (decrement) prepared food servings with shareability-aware permissions.
+
+    Implements shareability-aware access control:
+    - Shared items can be consumed by any authenticated user
+    - Personal/reserved items can only be consumed by their owner
+
+    Decrements servings_remaining by the specified amount. If servings reach
+    zero and delete_when_empty is true (default), the item is deleted.
+
+    Args:
+        item_id: UUID of the prepared food item to consume
+        consumption_data: Amount to consume and deletion preference
+        current_user: Authenticated user consuming the item
+        db: Database session
+
+    Returns:
+        tuple[str, bool, PreparedFood | None]: (message, deleted, item)
+            - message: Status message describing the action
+            - deleted: True if item was deleted, False otherwise
+            - item: Updated PreparedFood item, or None if deleted
+
+    Raises:
+        HTTPException(404): If item doesn't exist or is not accessible to current user
+        HTTPException(400): If consumption amount exceeds available servings
+    """
+    # Shareability-aware fetch: shared items accessible to all, personal/reserved only to owner
+    item = (
+        db.query(PreparedFood)
+        .filter(
+            PreparedFood.id == item_id,
+            or_(
+                PreparedFood.shareability == Shareability.shared.value,
+                PreparedFood.prepared_by == current_user.id
+            )
+        )
+        .first()
+    )
+
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Prepared food item not found"
+        )
+
+    # Validate consumption amount doesn't exceed available servings
+    # Use tolerance to handle floating-point precision issues
+    if consumption_data.amount > item.servings_remaining + FLOAT_COMPARISON_TOLERANCE:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Cannot consume {consumption_data.amount} servings. Only {item.servings_remaining} servings available."
+        )
+
+    # Calculate new servings count
+    new_servings = item.servings_remaining - consumption_data.amount
+
+    # Check if item should be deleted (using math.isclose for proper float comparison)
+    # Handles both "effectively zero" and negative edge cases from floating-point rounding
+    if (math.isclose(new_servings, 0.0, abs_tol=FLOAT_COMPARISON_TOLERANCE) or new_servings < 0) and consumption_data.delete_when_empty:
+        # Delete the item
+        try:
+            db.delete(item)
+            db.commit()
+        except SQLAlchemyError as e:
+            db.rollback()
+            logger.error(f"Database error during prepared food consumption deletion for user {current_user.id}")
+            logger.debug(f"Database error occurred during prepared food consumption deletion: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="An error occurred while deleting the consumed item"
+            )
+
+        logger.info(
+            f"Prepared food consumed and deleted: user_id={current_user.id}, "
+            f"item_id={item_id}, amount={consumption_data.amount}"
+        )
+
+        return (
+            f"Consumed {consumption_data.amount} servings. Item deleted (servings reached 0).",
+            True,
+            None
+        )
+    else:
+        # Update servings - clamp to 0.0 if negative due to floating-point precision
+        item.servings_remaining = max(0.0, new_servings)
+
+        try:
+            db.commit()
+            db.refresh(item)
+        except SQLAlchemyError as e:
+            db.rollback()
+            logger.error(f"Database error during prepared food consumption for user {current_user.id}")
+            logger.debug(f"Database error occurred during prepared food consumption: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="An error occurred while consuming the item"
+            )
+
+        logger.info(
+            f"Prepared food consumed: user_id={current_user.id}, "
+            f"item_id={item_id}, amount={consumption_data.amount}, "
+            f"new_servings={new_servings}"
+        )
+
+        return (
+            f"Consumed {consumption_data.amount} servings. {item.servings_remaining} servings remaining.",
+            False,
+            item
+        )
+
+
+def transfer_prepared_food(
+    item: PreparedFood,
+    storage_location: str,
+    current_user: User,
+    db: Session,
+) -> PreparedFood:
+    """
+    Transfer prepared food to a different storage location.
+
+    Updates the storage_location field for the specified item.
+    Only the owner can transfer items (ownership verified by caller).
+
+    Args:
+        item: PreparedFood item to transfer (ownership already verified)
+        storage_location: Target storage location (pantry, fridge, freezer)
+        current_user: Authenticated user performing the transfer
+        db: Database session
+
+    Returns:
+        PreparedFood: Updated prepared food item
+
+    Raises:
+        HTTPException(500): If database error occurs
+    """
+    # Update storage location
+    item.storage_location = storage_location
+
+    try:
+        db.commit()
+        db.refresh(item)
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during prepared food transfer for user {current_user.id}")
+        logger.debug(f"Database error occurred during prepared food transfer: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while transferring the prepared food item"
+        )
+
+    logger.info(
+        f"Prepared food transferred: user_id={current_user.id}, "
+        f"item_id={item.id}, storage_location={storage_location}"
+    )
+
+    return item
+
+
+def freeze_prepared_food(
+    item: PreparedFood,
+    current_user: User,
+    db: Session,
+) -> PreparedFood:
+    """
+    Freeze a prepared food item (quick action).
+
+    Updates the item's storage location to "freezer".
+    Only the owner can freeze items (ownership verified by caller).
+
+    Args:
+        item: PreparedFood item to freeze (ownership already verified)
+        current_user: Authenticated user performing the freeze
+        db: Database session
+
+    Returns:
+        PreparedFood: Updated prepared food item with freezer location
+
+    Raises:
+        HTTPException(500): If database error occurs
+    """
+    # Update storage location to freezer
+    item.storage_location = StorageLocation.freezer.value
+
+    try:
+        db.commit()
+        db.refresh(item)
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during prepared food freeze for user {current_user.id}")
+        logger.debug(f"Database error occurred during prepared food freeze: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while freezing the prepared food item"
+        )
+
+    logger.info(
+        f"Prepared food frozen: user_id={current_user.id}, "
+        f"item_id={item.id}"
+    )
+
+    return item
+
+
+def thaw_prepared_food(
+    item: PreparedFood,
+    current_user: User,
+    db: Session,
+) -> PreparedFood:
+    """
+    Thaw a prepared food item (quick action).
+
+    Updates the item's storage location to "fridge".
+    Only the owner can thaw items (ownership verified by caller).
+
+    Args:
+        item: PreparedFood item to thaw (ownership already verified)
+        current_user: Authenticated user performing the thaw
+        db: Database session
+
+    Returns:
+        PreparedFood: Updated prepared food item with fridge location
+
+    Raises:
+        HTTPException(500): If database error occurs
+    """
+    # Update storage location to fridge
+    item.storage_location = StorageLocation.fridge.value
+
+    try:
+        db.commit()
+        db.refresh(item)
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during prepared food thaw for user {current_user.id}")
+        logger.debug(f"Database error occurred during prepared food thaw: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while thawing the prepared food item"
+        )
+
+    logger.info(
+        f"Prepared food thawed: user_id={current_user.id}, "
+        f"item_id={item.id}"
+    )
+
+    return item

--- a/tests/routers/test_prepared_foods.py
+++ b/tests/routers/test_prepared_foods.py
@@ -849,6 +849,123 @@ class TestConsumePreparedFood:
         response = client.post(f"/prepared-foods/{item.id}/consume", json=payload)
         assert response.status_code == 401
 
+    def test_consume_floating_point_edge_cases(self, client, auth_headers, test_user, db_session):
+        """Should handle floating-point precision edge cases correctly."""
+        # Test case 1: Consuming amount that would leave tiny remainder due to float precision
+        # e.g., 3.3 - 3.3 might not equal exactly 0.0
+        item1 = PreparedFood(
+            id=uuid4(),
+            name="Float test 1",
+            type="complete_meal",
+            servings_remaining=3.3,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item1)
+        db_session.commit()
+        item1_id = item1.id
+
+        # Consume exact amount (should delete due to tolerance handling)
+        payload = {"amount": 3.3, "delete_when_empty": True}
+        response = client.post(f"/prepared-foods/{item1_id}/consume", json=payload, headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["deleted"] is True
+        deleted_item = db_session.query(PreparedFood).filter_by(id=item1_id).first()
+        assert deleted_item is None
+
+        # Test case 2: Amount within tolerance of remaining servings should succeed
+        item2 = PreparedFood(
+            id=uuid4(),
+            name="Float test 2",
+            type="complete_meal",
+            servings_remaining=2.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item2)
+        db_session.commit()
+        item2_id = item2.id
+
+        # Try to consume slightly more than available (within tolerance)
+        # 2.0 + 1e-10 should be within tolerance (1e-9)
+        payload = {"amount": 2.0 + 1e-10, "delete_when_empty": False}
+        response = client.post(f"/prepared-foods/{item2_id}/consume", json=payload, headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        # Result should be effectively zero (within tolerance)
+        assert data["deleted"] is False
+        assert data["item"]["servings_remaining"] <= 1e-9
+
+        # Test case 3: Amount beyond tolerance should fail
+        item3 = PreparedFood(
+            id=uuid4(),
+            name="Float test 3",
+            type="complete_meal",
+            servings_remaining=1.5,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item3)
+        db_session.commit()
+
+        # Try to consume amount exceeding available by more than tolerance
+        # 1.5 + 1e-8 is greater than tolerance (1e-9)
+        payload = {"amount": 1.5 + 1e-8, "delete_when_empty": False}
+        response = client.post(f"/prepared-foods/{item3.id}/consume", json=payload, headers=auth_headers)
+        assert response.status_code == 400
+        assert "Cannot consume" in response.json()["detail"]
+
+        # Test case 4: Result near zero with delete_when_empty=False should keep item
+        item4 = PreparedFood(
+            id=uuid4(),
+            name="Float test 4",
+            type="complete_meal",
+            servings_remaining=1.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item4)
+        db_session.commit()
+        item4_id = item4.id
+
+        # Consume amount leaving near-zero remainder
+        payload = {"amount": 1.0 - 1e-10, "delete_when_empty": False}
+        response = client.post(f"/prepared-foods/{item4_id}/consume", json=payload, headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["deleted"] is False
+        # Verify item exists with tiny positive remainder
+        existing_item = db_session.query(PreparedFood).filter_by(id=item4_id).first()
+        assert existing_item is not None
+        assert existing_item.servings_remaining >= 0
+
+        # Test case 5: Multiple decimal places consumption
+        item5 = PreparedFood(
+            id=uuid4(),
+            name="Float test 5",
+            type="complete_meal",
+            servings_remaining=0.1 + 0.2,  # Classic float precision issue: may not equal exactly 0.3
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item5)
+        db_session.commit()
+        item5_id = item5.id
+
+        # Consume 0.3 which should match within tolerance
+        payload = {"amount": 0.3, "delete_when_empty": True}
+        response = client.post(f"/prepared-foods/{item5_id}/consume", json=payload, headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        # Should successfully consume and delete due to tolerance handling
+        assert data["deleted"] is True or (data["item"] is not None and abs(data["item"]["servings_remaining"]) < 1e-9)
+
 
 class TestTransferPreparedFood:
     """Tests for POST /prepared-foods/{id}/transfer (transfer to different storage location)."""

--- a/tests/routers/test_prepared_foods.py
+++ b/tests/routers/test_prepared_foods.py
@@ -1009,6 +1009,28 @@ class TestTransferPreparedFood:
         response = client.post(f"/prepared-foods/{item.id}/transfer", json=payload, headers=auth_headers2)
         assert response.status_code == 404
 
+    def test_transfer_to_same_location(self, client, auth_headers, test_user, db_session):
+        """Should be idempotent - transferring to same location succeeds."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Test item",
+            type="complete_meal",
+            servings_remaining=3.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        payload = {"storage_location": "fridge"}
+        response = client.post(f"/prepared-foods/{item.id}/transfer", json=payload, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["storage_location"] == "fridge"
+        assert data["servings_remaining"] == 3.0  # Unchanged
+
     def test_transfer_invalid_location(self, client, auth_headers, test_user, db_session):
         """Should reject invalid storage_location."""
         item = PreparedFood(

--- a/tests/routers/test_prepared_foods.py
+++ b/tests/routers/test_prepared_foods.py
@@ -17,7 +17,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from src.db.database import Base, get_db
 from src.db import models
@@ -170,7 +170,6 @@ class TestCreatePreparedFood:
         assert data["prepared_by"] == str(test_user.id)
 
         # Verify in database
-        from uuid import UUID
         item = db_session.query(PreparedFood).filter_by(id=UUID(data["id"])).first()
         assert item is not None
         assert item.prepared_by == test_user.id

--- a/tests/routers/test_prepared_foods.py
+++ b/tests/routers/test_prepared_foods.py
@@ -611,3 +611,476 @@ class TestDeletePreparedFood:
 
         response = client.delete(f"/prepared-foods/{item.id}")
         assert response.status_code == 401
+
+
+class TestConsumePreparedFood:
+    """Tests for POST /prepared-foods/{id}/consume (consume with shareability-aware permissions)."""
+
+    def test_consume_shared_by_owner(self, client, auth_headers, test_user, db_session):
+        """Should allow owner to consume shared item."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Shared curry",
+            type="complete_meal",
+            servings_remaining=5.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        item_id = item.id
+
+        payload = {"amount": 2.0, "delete_when_empty": False}
+        response = client.post(f"/prepared-foods/{item_id}/consume", json=payload, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["deleted"] is False
+        assert data["item"]["servings_remaining"] == 3.0
+        assert "Consumed 2.0 servings" in data["message"]
+
+    def test_consume_shared_by_other_user(self, client, auth_headers2, test_user, db_session):
+        """Should allow any authenticated user to consume shared items."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Shared meal",
+            type="complete_meal",
+            servings_remaining=4.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        item_id = item.id
+
+        # User2 consumes user1's shared item
+        payload = {"amount": 1.0, "delete_when_empty": False}
+        response = client.post(f"/prepared-foods/{item_id}/consume", json=payload, headers=auth_headers2)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["deleted"] is False
+        assert data["item"]["servings_remaining"] == 3.0
+
+    def test_consume_personal_by_other_user(self, client, auth_headers2, test_user, db_session):
+        """Should reject consumption of personal items by non-owner with 404."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Personal meal",
+            type="complete_meal",
+            servings_remaining=2.0,
+            storage_location="fridge",
+            shareability="personal",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        # User2 tries to consume user1's personal item
+        payload = {"amount": 1.0}
+        response = client.post(f"/prepared-foods/{item.id}/consume", json=payload, headers=auth_headers2)
+
+        assert response.status_code == 404
+
+    def test_consume_reserved_by_other_user(self, client, auth_headers2, test_user, db_session):
+        """Should reject consumption of reserved items by non-owner with 404."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Reserved meal",
+            type="complete_meal",
+            servings_remaining=2.0,
+            storage_location="fridge",
+            shareability="reserved",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        # User2 tries to consume user1's reserved item
+        payload = {"amount": 1.0}
+        response = client.post(f"/prepared-foods/{item.id}/consume", json=payload, headers=auth_headers2)
+
+        assert response.status_code == 404
+
+    def test_consume_exceeds_available(self, client, auth_headers, test_user, db_session):
+        """Should return 400 if amount exceeds servings_remaining."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Test item",
+            type="complete_meal",
+            servings_remaining=2.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        payload = {"amount": 3.0}
+        response = client.post(f"/prepared-foods/{item.id}/consume", json=payload, headers=auth_headers)
+
+        assert response.status_code == 400
+        assert "Cannot consume 3.0 servings" in response.json()["detail"]
+
+    def test_consume_with_delete_when_empty_true(self, client, auth_headers, test_user, db_session):
+        """Should delete item when servings reach 0 and delete_when_empty is true."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Test item",
+            type="complete_meal",
+            servings_remaining=2.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        item_id = item.id
+
+        payload = {"amount": 2.0, "delete_when_empty": True}
+        response = client.post(f"/prepared-foods/{item_id}/consume", json=payload, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["deleted"] is True
+        assert data["item"] is None
+        assert "Item deleted" in data["message"]
+
+        # Verify item is deleted from database
+        deleted_item = db_session.query(PreparedFood).filter_by(id=item_id).first()
+        assert deleted_item is None
+
+    def test_consume_with_delete_when_empty_false(self, client, auth_headers, test_user, db_session):
+        """Should keep item at 0 servings when delete_when_empty is false."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Test item",
+            type="complete_meal",
+            servings_remaining=2.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        item_id = item.id
+
+        payload = {"amount": 2.0, "delete_when_empty": False}
+        response = client.post(f"/prepared-foods/{item_id}/consume", json=payload, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["deleted"] is False
+        assert data["item"]["servings_remaining"] == 0.0
+
+        # Verify item still exists in database
+        existing_item = db_session.query(PreparedFood).filter_by(id=item_id).first()
+        assert existing_item is not None
+        assert existing_item.servings_remaining == 0.0
+
+    def test_consume_default_amount(self, client, auth_headers, test_user, db_session):
+        """Should use default amount of 1.0 when not specified."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Test item",
+            type="complete_meal",
+            servings_remaining=3.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        # No payload - use defaults
+        response = client.post(f"/prepared-foods/{item.id}/consume", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["item"]["servings_remaining"] == 2.0
+
+    def test_consume_default_delete_when_empty(self, client, auth_headers, test_user, db_session):
+        """Should default to delete_when_empty=true."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Test item",
+            type="complete_meal",
+            servings_remaining=1.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+        item_id = item.id
+
+        # Only specify amount, let delete_when_empty use default
+        payload = {"amount": 1.0}
+        response = client.post(f"/prepared-foods/{item_id}/consume", json=payload, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["deleted"] is True  # Should be deleted by default
+
+    def test_consume_nonexistent_item(self, client, auth_headers):
+        """Should return 404 for nonexistent item."""
+        fake_id = uuid4()
+        payload = {"amount": 1.0}
+        response = client.post(f"/prepared-foods/{fake_id}/consume", json=payload, headers=auth_headers)
+        assert response.status_code == 404
+
+    def test_consume_requires_auth(self, client, test_user, db_session):
+        """Should reject request without authentication."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Test item",
+            type="complete_meal",
+            servings_remaining=3.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        payload = {"amount": 1.0}
+        response = client.post(f"/prepared-foods/{item.id}/consume", json=payload)
+        assert response.status_code == 401
+
+
+class TestTransferPreparedFood:
+    """Tests for POST /prepared-foods/{id}/transfer (transfer to different storage location)."""
+
+    def test_transfer_by_owner(self, client, auth_headers, test_user, db_session):
+        """Should allow owner to transfer item to different location."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Test item",
+            type="complete_meal",
+            servings_remaining=3.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        payload = {"storage_location": "freezer"}
+        response = client.post(f"/prepared-foods/{item.id}/transfer", json=payload, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["storage_location"] == "freezer"
+        assert data["servings_remaining"] == 3.0  # Unchanged
+
+    def test_transfer_by_non_owner(self, client, auth_headers2, test_user, db_session):
+        """Should reject transfer by non-owner with 404."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="User1 item",
+            type="complete_meal",
+            servings_remaining=3.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        payload = {"storage_location": "freezer"}
+        response = client.post(f"/prepared-foods/{item.id}/transfer", json=payload, headers=auth_headers2)
+        assert response.status_code == 404
+
+    def test_transfer_invalid_location(self, client, auth_headers, test_user, db_session):
+        """Should reject invalid storage_location."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Test item",
+            type="complete_meal",
+            servings_remaining=3.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        payload = {"storage_location": "garage"}
+        response = client.post(f"/prepared-foods/{item.id}/transfer", json=payload, headers=auth_headers)
+        assert response.status_code == 422
+
+    def test_transfer_requires_auth(self, client, test_user, db_session):
+        """Should reject request without authentication."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Test item",
+            type="complete_meal",
+            servings_remaining=3.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        payload = {"storage_location": "freezer"}
+        response = client.post(f"/prepared-foods/{item.id}/transfer", json=payload)
+        assert response.status_code == 401
+
+
+class TestFreezePreparedFood:
+    """Tests for POST /prepared-foods/{id}/freeze (quick freeze action)."""
+
+    def test_freeze_by_owner(self, client, auth_headers, test_user, db_session):
+        """Should allow owner to freeze item."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Test item",
+            type="complete_meal",
+            servings_remaining=3.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        response = client.post(f"/prepared-foods/{item.id}/freeze", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["storage_location"] == "freezer"
+
+    def test_freeze_already_frozen(self, client, auth_headers, test_user, db_session):
+        """Should be idempotent - freezing already-frozen item succeeds."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Already frozen",
+            type="complete_meal",
+            servings_remaining=3.0,
+            storage_location="freezer",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        response = client.post(f"/prepared-foods/{item.id}/freeze", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["storage_location"] == "freezer"
+
+    def test_freeze_by_non_owner(self, client, auth_headers2, test_user, db_session):
+        """Should reject freeze by non-owner with 404."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="User1 item",
+            type="complete_meal",
+            servings_remaining=3.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        response = client.post(f"/prepared-foods/{item.id}/freeze", headers=auth_headers2)
+        assert response.status_code == 404
+
+    def test_freeze_requires_auth(self, client, test_user, db_session):
+        """Should reject request without authentication."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Test item",
+            type="complete_meal",
+            servings_remaining=3.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        response = client.post(f"/prepared-foods/{item.id}/freeze")
+        assert response.status_code == 401
+
+
+class TestThawPreparedFood:
+    """Tests for POST /prepared-foods/{id}/thaw (quick thaw action)."""
+
+    def test_thaw_by_owner(self, client, auth_headers, test_user, db_session):
+        """Should allow owner to thaw item."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Frozen item",
+            type="complete_meal",
+            servings_remaining=3.0,
+            storage_location="freezer",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        response = client.post(f"/prepared-foods/{item.id}/thaw", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["storage_location"] == "fridge"
+
+    def test_thaw_already_thawed(self, client, auth_headers, test_user, db_session):
+        """Should be idempotent - thawing already-thawed item succeeds."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Already thawed",
+            type="complete_meal",
+            servings_remaining=3.0,
+            storage_location="fridge",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        response = client.post(f"/prepared-foods/{item.id}/thaw", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["storage_location"] == "fridge"
+
+    def test_thaw_by_non_owner(self, client, auth_headers2, test_user, db_session):
+        """Should reject thaw by non-owner with 404."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="User1 item",
+            type="complete_meal",
+            servings_remaining=3.0,
+            storage_location="freezer",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        response = client.post(f"/prepared-foods/{item.id}/thaw", headers=auth_headers2)
+        assert response.status_code == 404
+
+    def test_thaw_requires_auth(self, client, test_user, db_session):
+        """Should reject request without authentication."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Test item",
+            type="complete_meal",
+            servings_remaining=3.0,
+            storage_location="freezer",
+            shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        response = client.post(f"/prepared-foods/{item.id}/thaw")
+        assert response.status_code == 401


### PR DESCRIPTION
## Work in Progress

Closes #193

[Phase 1G] Add PreparedFood action endpoints

**Time Estimate**: 1hr

**Description**:
Add action endpoints for PreparedFood: consume (decrement servings), transfer (change storage location), and freeze/thaw quick actions. The consume endpoint is core 1G functionality — without it, users can log leftovers but can't track eating them.

**Claude Context**:
Files to Read:
- src/routers/inventory.py (consume endpoint pattern, shareability handling)
- src/db/models/prepared_food.py (PreparedFood model, servings_remaining field)
- src/services/grocery_service.py (service layer pattern for domain actions)

Files to Modify:
- src/routers/prepared_foods.py (add action endpoints)
- src/services/prepared_foods_service.py (add consume/transfer/freeze logic)
- tests/routers/test_prepared_foods.py (add action endpoint tests)

Related Issues: After #192 (CRUD endpoints must exist first)

**Acceptance Criteria**:
- [ ] POST /prepared-foods/{id}/consume accepts `amount` (int), decrements `servings_remaining`: `pytest tests/routers/test_prepared_foods.py::test_consume -v`
- [ ] Consume returns 400 if amount > servings_remaining (can't go negative): verify validation
- [ ] Consume with `delete_when_empty=true` (default) auto-deletes item when servings_remaining hits 0: verify deletion
- [ ] Consume with `delete_when_empty=false` keeps item at 0 servings: verify preservation
- [ ] Shared items (shareability=shared) consumable by any authenticated user: `pytest tests/routers/test_prepared_foods.py::test_consume_shared_by_other_user -v`
- [ ] Personal/reserved items consumable only by owner (404 for non-owner): `pytest tests/routers/test_prepared_foods.py::test_consume_personal_by_other_user -v`
- [ ] POST /prepared-foods/{id}/transfer accepts `storage_location` (enum), updates location: verify transfer
- [ ] POST /prepared-foods/{id}/freeze sets storage_location=freezer, POST /prepared-foods/{id}/thaw sets storage_location=fridge: verify quick actions
- [ ] All action endpoints return updated PreparedFoodResponse: verify response schema
- [ ] All tests pass: `pytest tests/routers/test_prepared_foods.py -v -k "consume or transfer or freeze or thaw"`

**Verification Commands**:
```bash
cd /Users/sarahtime/Dev/freshup && .venv/bin/python -m pytest tests/routers/test_prepared_foods.py -v -k "consume or transfer or freeze or thaw"
```

**Done Definition**: Done when consume endpoint works with shareability-aware permissions, delete_when_empty behavior is correct, transfer/freeze/thaw update storage_location, and all tests pass.

**Scope Boundary**:
- DO: Implement consume with shareability-aware permissions (shared=any user, personal/reserved=owner only)
- DO: Implement delete_when_empty on consume (default true)
- DO: Implement transfer, freeze, thaw as convenience endpoints
- DO: Add comprehensive tests including cross-user consume scenarios
- DO NOT: Add notification on low servings (future feature)
- DO NOT: Add consumption history/logging (Phase 3A)

**Dependencies**: After #192

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**4** files, **2** commits (+0 added, ~4 modified, -0 deleted)
- `M` src/routers/prepared_foods.py
- `M` src/schemas/prepared_food.py
- `M` src/services/prepared_foods_service.py
- `M` tests/routers/test_prepared_foods.py

### Commits
- 8107882 feat: [Phase 1G] Add PreparedFood action endpoints
- 8ad262b chore: initialize work on #193 [Phase 1G] Add PreparedFood action endpoints
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-03-22T16:52:41Z:**
- Created: #201 
- Updated: none