### PR TITLE
Align consume authorization with other actions

### DIFF
--- a/src/routers/prepared_foods.py
+++ b/src/routers/prepared_foods.py
@@ -50,6 +50,53 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/prepared-foods", tags=["prepared-foods"])
 
 
+def get_accessible_prepared_food(
+    item_id: UUID,
+    current_user: User,
+    db: Session,
+) -> PreparedFood:
+    """
+    Retrieve a prepared food item with shareability-aware access control.
+
+    Implements the authorization pattern where:
+    - Shared items are accessible to all authenticated users
+    - Personal/reserved items are only accessible to their owner
+
+    This helper consolidates the authorization logic used across multiple
+    action endpoints (consume, transfer, freeze, thaw).
+
+    Args:
+        item_id: UUID of the prepared food item to retrieve
+        current_user: Authenticated user attempting to access the item
+        db: Database session
+
+    Returns:
+        PreparedFood: The requested item if accessible
+
+    Raises:
+        HTTPException(404): If item doesn't exist or is not accessible to current user
+    """
+    item = (
+        db.query(PreparedFood)
+        .filter(
+            PreparedFood.id == item_id,
+            or_(
+                PreparedFood.shareability == Shareability.shared.value,
+                PreparedFood.prepared_by == current_user.id
+            )
+        )
+        .first()
+    )
+
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Prepared food item not found"
+        )
+
+    return item
+
+
 @router.post("", response_model=PreparedFoodResponse, status_code=status.HTTP_201_CREATED)
 def create_prepared_food_endpoint(
     item_data: PreparedFoodCreate,
@@ -407,24 +454,8 @@ def transfer_prepared_food_endpoint(
         HTTPException(404): If item doesn't exist or is not accessible to current user
         HTTPException(422): If storage_location is invalid
     """
-    # Query item with shareability-aware access control
-    item = (
-        db.query(PreparedFood)
-        .filter(
-            PreparedFood.id == item_id,
-            or_(
-                PreparedFood.shareability == Shareability.shared.value,
-                PreparedFood.prepared_by == current_user.id
-            )
-        )
-        .first()
-    )
-
-    if not item:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Prepared food item not found"
-        )
+    # Use helper function for shareability-aware access control
+    item = get_accessible_prepared_food(item_id, current_user, db)
 
     return transfer_prepared_food(item, transfer_data.storage_location, current_user, db)
 
@@ -457,24 +488,8 @@ def freeze_prepared_food_endpoint(
         HTTPException(401): If Authorization header is missing or token is invalid
         HTTPException(404): If item doesn't exist or is not accessible to current user
     """
-    # Query item with shareability-aware access control
-    item = (
-        db.query(PreparedFood)
-        .filter(
-            PreparedFood.id == item_id,
-            or_(
-                PreparedFood.shareability == Shareability.shared.value,
-                PreparedFood.prepared_by == current_user.id
-            )
-        )
-        .first()
-    )
-
-    if not item:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Prepared food item not found"
-        )
+    # Use helper function for shareability-aware access control
+    item = get_accessible_prepared_food(item_id, current_user, db)
 
     return freeze_prepared_food(item, current_user, db)
 
@@ -507,23 +522,7 @@ def thaw_prepared_food_endpoint(
         HTTPException(401): If Authorization header is missing or token is invalid
         HTTPException(404): If item doesn't exist or is not accessible to current user
     """
-    # Query item with shareability-aware access control
-    item = (
-        db.query(PreparedFood)
-        .filter(
-            PreparedFood.id == item_id,
-            or_(
-                PreparedFood.shareability == Shareability.shared.value,
-                PreparedFood.prepared_by == current_user.id
-            )
-        )
-        .first()
-    )
-
-    if not item:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Prepared food item not found"
-        )
+    # Use helper function for shareability-aware access control
+    item = get_accessible_prepared_food(item_id, current_user, db)
 
     return thaw_prepared_food(item, current_user, db)

--- a/src/routers/prepared_foods.py
+++ b/src/routers/prepared_foods.py
@@ -385,10 +385,13 @@ def transfer_prepared_food_endpoint(
     db: Session = Depends(get_db),
 ):
     """
-    Transfer prepared food to a different storage location.
+    Transfer prepared food to a different storage location with shareability-aware permissions.
 
     Updates the item's storage_location field to the specified location.
-    Only the owner (prepared_by user) can transfer items.
+
+    Implements shareability-aware access control:
+    - Shared items can be transferred by any authenticated user
+    - Personal/reserved items can only be transferred by their owner (404 for non-owner)
 
     Args:
         item_id: UUID of the prepared food item to transfer
@@ -401,11 +404,27 @@ def transfer_prepared_food_endpoint(
 
     Raises:
         HTTPException(401): If Authorization header is missing or token is invalid
-        HTTPException(404): If item doesn't exist or belongs to another user
+        HTTPException(404): If item doesn't exist or is not accessible to current user
         HTTPException(422): If storage_location is invalid
     """
-    # Verify item exists and belongs to current user
-    item = verify_prepared_food_ownership(item_id, current_user, db)
+    # Query item with shareability-aware access control
+    item = (
+        db.query(PreparedFood)
+        .filter(
+            PreparedFood.id == item_id,
+            or_(
+                PreparedFood.shareability == Shareability.shared.value,
+                PreparedFood.prepared_by == current_user.id
+            )
+        )
+        .first()
+    )
+
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Prepared food item not found"
+        )
 
     return transfer_prepared_food(item, transfer_data.storage_location, current_user, db)
 
@@ -417,12 +436,14 @@ def freeze_prepared_food_endpoint(
     db: Session = Depends(get_db),
 ):
     """
-    Freeze a prepared food item (quick action).
+    Freeze a prepared food item (quick action) with shareability-aware permissions.
 
     Updates the item's storage location to "freezer". This endpoint is idempotent -
     freezing an already-frozen item simply ensures it's in the freezer.
 
-    Only the owner (prepared_by user) can freeze items.
+    Implements shareability-aware access control:
+    - Shared items can be frozen by any authenticated user
+    - Personal/reserved items can only be frozen by their owner (404 for non-owner)
 
     Args:
         item_id: UUID of the prepared food item to freeze
@@ -434,10 +455,26 @@ def freeze_prepared_food_endpoint(
 
     Raises:
         HTTPException(401): If Authorization header is missing or token is invalid
-        HTTPException(404): If item doesn't exist or belongs to another user
+        HTTPException(404): If item doesn't exist or is not accessible to current user
     """
-    # Verify item exists and belongs to current user
-    item = verify_prepared_food_ownership(item_id, current_user, db)
+    # Query item with shareability-aware access control
+    item = (
+        db.query(PreparedFood)
+        .filter(
+            PreparedFood.id == item_id,
+            or_(
+                PreparedFood.shareability == Shareability.shared.value,
+                PreparedFood.prepared_by == current_user.id
+            )
+        )
+        .first()
+    )
+
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Prepared food item not found"
+        )
 
     return freeze_prepared_food(item, current_user, db)
 
@@ -449,12 +486,14 @@ def thaw_prepared_food_endpoint(
     db: Session = Depends(get_db),
 ):
     """
-    Thaw a prepared food item (quick action).
+    Thaw a prepared food item (quick action) with shareability-aware permissions.
 
     Updates the item's storage location to "fridge". This endpoint is idempotent -
     thawing a non-frozen item simply ensures it's in the fridge.
 
-    Only the owner (prepared_by user) can thaw items.
+    Implements shareability-aware access control:
+    - Shared items can be thawed by any authenticated user
+    - Personal/reserved items can only be thawed by their owner (404 for non-owner)
 
     Args:
         item_id: UUID of the prepared food item to thaw
@@ -466,9 +505,25 @@ def thaw_prepared_food_endpoint(
 
     Raises:
         HTTPException(401): If Authorization header is missing or token is invalid
-        HTTPException(404): If item doesn't exist or belongs to another user
+        HTTPException(404): If item doesn't exist or is not accessible to current user
     """
-    # Verify item exists and belongs to current user
-    item = verify_prepared_food_ownership(item_id, current_user, db)
+    # Query item with shareability-aware access control
+    item = (
+        db.query(PreparedFood)
+        .filter(
+            PreparedFood.id == item_id,
+            or_(
+                PreparedFood.shareability == Shareability.shared.value,
+                PreparedFood.prepared_by == current_user.id
+            )
+        )
+        .first()
+    )
+
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Prepared food item not found"
+        )
 
     return thaw_prepared_food(item, current_user, db)

--- a/src/services/prepared_foods_service.py
+++ b/src/services/prepared_foods_service.py
@@ -210,10 +210,11 @@ def transfer_prepared_food(
     Transfer prepared food to a different storage location.
 
     Updates the storage_location field for the specified item.
-    Only the owner can transfer items (ownership verified by caller).
+    Implements shareability-aware access: shared items can be transferred by any user,
+    personal/reserved items only by owner (access control verified by caller).
 
     Args:
-        item: PreparedFood item to transfer (ownership already verified)
+        item: PreparedFood item to transfer (access control already verified)
         storage_location: Target storage location (pantry, fridge, freezer)
         current_user: Authenticated user performing the transfer
         db: Database session
@@ -256,10 +257,11 @@ def freeze_prepared_food(
     Freeze a prepared food item (quick action).
 
     Updates the item's storage location to "freezer".
-    Only the owner can freeze items (ownership verified by caller).
+    Implements shareability-aware access: shared items can be frozen by any user,
+    personal/reserved items only by owner (access control verified by caller).
 
     Args:
-        item: PreparedFood item to freeze (ownership already verified)
+        item: PreparedFood item to freeze (access control already verified)
         current_user: Authenticated user performing the freeze
         db: Database session
 
@@ -301,10 +303,11 @@ def thaw_prepared_food(
     Thaw a prepared food item (quick action).
 
     Updates the item's storage location to "fridge".
-    Only the owner can thaw items (ownership verified by caller).
+    Implements shareability-aware access: shared items can be thawed by any user,
+    personal/reserved items only by owner (access control verified by caller).
 
     Args:
-        item: PreparedFood item to thaw (ownership already verified)
+        item: PreparedFood item to thaw (access control already verified)
         current_user: Authenticated user performing the thaw
         db: Database session
 

--- a/tests/routers/test_prepared_foods.py
+++ b/tests/routers/test_prepared_foods.py
@@ -1181,6 +1181,50 @@ class TestTransferPreparedFood:
         response = client.post(f"/prepared-foods/{item.id}/transfer", json=payload, headers=auth_headers2)
         assert response.status_code == 404
 
+    def test_transfer_personal_item_by_owner(self, client, auth_headers, test_user, db_session):
+        """Should allow owner to transfer their own personal item."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Personal item",
+            type="complete_meal",
+            servings_remaining=2.0,
+            storage_location="fridge",
+            shareability="personal",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        payload = {"storage_location": "freezer"}
+        response = client.post(f"/prepared-foods/{item.id}/transfer", json=payload, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["storage_location"] == "freezer"
+        assert data["shareability"] == "personal"
+
+    def test_transfer_reserved_item_by_owner(self, client, auth_headers, test_user, db_session):
+        """Should allow owner to transfer their own reserved item."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Reserved item",
+            type="complete_meal",
+            servings_remaining=4.0,
+            storage_location="fridge",
+            shareability="reserved",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        payload = {"storage_location": "freezer"}
+        response = client.post(f"/prepared-foods/{item.id}/transfer", json=payload, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["storage_location"] == "freezer"
+        assert data["shareability"] == "reserved"
+
     def test_transfer_to_same_location(self, client, auth_headers, test_user, db_session):
         """Should be idempotent - transferring to same location succeeds."""
         item = PreparedFood(
@@ -1262,6 +1306,48 @@ class TestFreezePreparedFood:
         assert response.status_code == 200
         data = response.json()
         assert data["storage_location"] == "freezer"
+
+    def test_freeze_personal_item_by_owner(self, client, auth_headers, test_user, db_session):
+        """Should allow owner to freeze their own personal item."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Personal item",
+            type="complete_meal",
+            servings_remaining=2.0,
+            storage_location="fridge",
+            shareability="personal",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        response = client.post(f"/prepared-foods/{item.id}/freeze", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["storage_location"] == "freezer"
+        assert data["shareability"] == "personal"
+
+    def test_freeze_reserved_item_by_owner(self, client, auth_headers, test_user, db_session):
+        """Should allow owner to freeze their own reserved item."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Reserved item",
+            type="complete_meal",
+            servings_remaining=4.0,
+            storage_location="fridge",
+            shareability="reserved",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        response = client.post(f"/prepared-foods/{item.id}/freeze", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["storage_location"] == "freezer"
+        assert data["shareability"] == "reserved"
 
     def test_freeze_already_frozen(self, client, auth_headers, test_user, db_session):
         """Should be idempotent - freezing already-frozen item succeeds."""
@@ -1376,6 +1462,48 @@ class TestThawPreparedFood:
         assert response.status_code == 200
         data = response.json()
         assert data["storage_location"] == "fridge"
+
+    def test_thaw_personal_item_by_owner(self, client, auth_headers, test_user, db_session):
+        """Should allow owner to thaw their own personal item."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Personal frozen item",
+            type="complete_meal",
+            servings_remaining=2.0,
+            storage_location="freezer",
+            shareability="personal",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        response = client.post(f"/prepared-foods/{item.id}/thaw", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["storage_location"] == "fridge"
+        assert data["shareability"] == "personal"
+
+    def test_thaw_reserved_item_by_owner(self, client, auth_headers, test_user, db_session):
+        """Should allow owner to thaw their own reserved item."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="Reserved frozen item",
+            type="complete_meal",
+            servings_remaining=4.0,
+            storage_location="freezer",
+            shareability="reserved",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        response = client.post(f"/prepared-foods/{item.id}/thaw", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["storage_location"] == "fridge"
+        assert data["shareability"] == "reserved"
 
     def test_thaw_already_thawed(self, client, auth_headers, test_user, db_session):
         """Should be idempotent - thawing already-thawed item succeeds."""

--- a/tests/routers/test_prepared_foods.py
+++ b/tests/routers/test_prepared_foods.py
@@ -1125,8 +1125,8 @@ class TestTransferPreparedFood:
         assert data["storage_location"] == "freezer"
         assert data["servings_remaining"] == 3.0  # Unchanged
 
-    def test_transfer_by_non_owner(self, client, auth_headers2, test_user, db_session):
-        """Should reject transfer by non-owner with 404."""
+    def test_transfer_shared_item_by_non_owner(self, client, auth_headers2, test_user, db_session):
+        """Should allow transfer of shared item by non-owner (shareability-aware)."""
         item = PreparedFood(
             id=uuid4(),
             name="User1 item",
@@ -1134,6 +1134,26 @@ class TestTransferPreparedFood:
             servings_remaining=3.0,
             storage_location="fridge",
             shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        payload = {"storage_location": "freezer"}
+        response = client.post(f"/prepared-foods/{item.id}/transfer", json=payload, headers=auth_headers2)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["storage_location"] == "freezer"
+
+    def test_transfer_personal_item_by_non_owner(self, client, auth_headers2, test_user, db_session):
+        """Should reject transfer of personal item by non-owner with 404."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="User1 personal item",
+            type="complete_meal",
+            servings_remaining=3.0,
+            storage_location="fridge",
+            shareability="personal",
             prepared_by=test_user.id,
         )
         db_session.add(item)
@@ -1245,8 +1265,8 @@ class TestFreezePreparedFood:
         data = response.json()
         assert data["storage_location"] == "freezer"
 
-    def test_freeze_by_non_owner(self, client, auth_headers2, test_user, db_session):
-        """Should reject freeze by non-owner with 404."""
+    def test_freeze_shared_item_by_non_owner(self, client, auth_headers2, test_user, db_session):
+        """Should allow freeze of shared item by non-owner (shareability-aware)."""
         item = PreparedFood(
             id=uuid4(),
             name="User1 item",
@@ -1254,6 +1274,25 @@ class TestFreezePreparedFood:
             servings_remaining=3.0,
             storage_location="fridge",
             shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        response = client.post(f"/prepared-foods/{item.id}/freeze", headers=auth_headers2)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["storage_location"] == "freezer"
+
+    def test_freeze_personal_item_by_non_owner(self, client, auth_headers2, test_user, db_session):
+        """Should reject freeze of personal item by non-owner with 404."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="User1 personal item",
+            type="complete_meal",
+            servings_remaining=3.0,
+            storage_location="fridge",
+            shareability="personal",
             prepared_by=test_user.id,
         )
         db_session.add(item)
@@ -1323,8 +1362,8 @@ class TestThawPreparedFood:
         data = response.json()
         assert data["storage_location"] == "fridge"
 
-    def test_thaw_by_non_owner(self, client, auth_headers2, test_user, db_session):
-        """Should reject thaw by non-owner with 404."""
+    def test_thaw_shared_item_by_non_owner(self, client, auth_headers2, test_user, db_session):
+        """Should allow thaw of shared item by non-owner (shareability-aware)."""
         item = PreparedFood(
             id=uuid4(),
             name="User1 item",
@@ -1332,6 +1371,25 @@ class TestThawPreparedFood:
             servings_remaining=3.0,
             storage_location="freezer",
             shareability="shared",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        response = client.post(f"/prepared-foods/{item.id}/thaw", headers=auth_headers2)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["storage_location"] == "fridge"
+
+    def test_thaw_personal_item_by_non_owner(self, client, auth_headers2, test_user, db_session):
+        """Should reject thaw of personal item by non-owner with 404."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="User1 personal item",
+            type="complete_meal",
+            servings_remaining=3.0,
+            storage_location="freezer",
+            shareability="personal",
             prepared_by=test_user.id,
         )
         db_session.add(item)

--- a/tests/routers/test_prepared_foods.py
+++ b/tests/routers/test_prepared_foods.py
@@ -1163,6 +1163,24 @@ class TestTransferPreparedFood:
         response = client.post(f"/prepared-foods/{item.id}/transfer", json=payload, headers=auth_headers2)
         assert response.status_code == 404
 
+    def test_transfer_reserved_item_by_non_owner(self, client, auth_headers2, test_user, db_session):
+        """Should reject transfer of reserved item by non-owner with 404."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="User1 reserved item",
+            type="complete_meal",
+            servings_remaining=3.0,
+            storage_location="fridge",
+            shareability="reserved",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        payload = {"storage_location": "freezer"}
+        response = client.post(f"/prepared-foods/{item.id}/transfer", json=payload, headers=auth_headers2)
+        assert response.status_code == 404
+
     def test_transfer_to_same_location(self, client, auth_headers, test_user, db_session):
         """Should be idempotent - transferring to same location succeeds."""
         item = PreparedFood(
@@ -1301,6 +1319,23 @@ class TestFreezePreparedFood:
         response = client.post(f"/prepared-foods/{item.id}/freeze", headers=auth_headers2)
         assert response.status_code == 404
 
+    def test_freeze_reserved_item_by_non_owner(self, client, auth_headers2, test_user, db_session):
+        """Should reject freeze of reserved item by non-owner with 404."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="User1 reserved item",
+            type="complete_meal",
+            servings_remaining=3.0,
+            storage_location="fridge",
+            shareability="reserved",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        response = client.post(f"/prepared-foods/{item.id}/freeze", headers=auth_headers2)
+        assert response.status_code == 404
+
     def test_freeze_requires_auth(self, client, test_user, db_session):
         """Should reject request without authentication."""
         item = PreparedFood(
@@ -1390,6 +1425,23 @@ class TestThawPreparedFood:
             servings_remaining=3.0,
             storage_location="freezer",
             shareability="personal",
+            prepared_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        response = client.post(f"/prepared-foods/{item.id}/thaw", headers=auth_headers2)
+        assert response.status_code == 404
+
+    def test_thaw_reserved_item_by_non_owner(self, client, auth_headers2, test_user, db_session):
+        """Should reject thaw of reserved item by non-owner with 404."""
+        item = PreparedFood(
+            id=uuid4(),
+            name="User1 reserved item",
+            type="complete_meal",
+            servings_remaining=3.0,
+            storage_location="freezer",
+            shareability="reserved",
             prepared_by=test_user.id,
         )
         db_session.add(item)


### PR DESCRIPTION
## Work in Progress

Closes #201

Align consume authorization with other actions

<!-- sharkrite-source-issue:193 -->## From PR #199 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
The authorization inconsistency is a real architectural concern that could lead to maintenance bugs, but it's not blocking this PR. The consume endpoint intentionally has different semantics (shareability-aware) per the issue requirements, while transfer/freeze/thaw are owner-only operations. This is a valid design that needs documentation, not a bug.

## Context
The issue scope explicitly requires "shareability-aware permissions (shared=any user, personal/reserved=owner only)" for consume, which explains the different pattern. Unifying or documenting this is valuable but exceeds the current scope.

## Defer Reason
Architectural refactor needed - requires either extracting a new helper function or adding documentation across multiple functions

---
_Created by Sharkrite assessment on 2026-03-22T16:52:41Z_
_Parent PR: #199_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **3** commits (+0 added, ~3 modified, -0 deleted)
- `M` src/routers/prepared_foods.py
- `M` src/services/prepared_foods_service.py
- `M` tests/routers/test_prepared_foods.py

### Commits
- c7d3558 feat: Align consume authorization with other actions
- d42b924 Merge remote-tracking branch 'origin/main' into feat/align-consume-authorization-with-other-actions
- ae68b96 chore: initialize work on #201 Align consume authorization with other actions
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-03-22T17:12:45Z:**
- Created: none
- Updated: #201 