### PR TITLE
Strengthen validation error test assertions

### DIFF
--- a/src/routers/prepared_foods.py
+++ b/src/routers/prepared_foods.py
@@ -177,7 +177,16 @@ def list_prepared_foods(
         try:
             validate_enum_value("type", type, PreparedFoodType)
         except ValueError as e:
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=[
+                    {
+                        "loc": ["query", "type"],
+                        "msg": str(e),
+                        "type": "value_error"
+                    }
+                ]
+            )
         query = query.filter(PreparedFood.type == type)
 
     # Apply storage_location filter
@@ -185,7 +194,16 @@ def list_prepared_foods(
         try:
             validate_enum_value("storage_location", storage_location, StorageLocation)
         except ValueError as e:
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=[
+                    {
+                        "loc": ["query", "storage_location"],
+                        "msg": str(e),
+                        "type": "value_error"
+                    }
+                ]
+            )
         query = query.filter(PreparedFood.storage_location == storage_location)
 
     # Apply shareability filter
@@ -193,7 +211,16 @@ def list_prepared_foods(
         try:
             validate_enum_value("shareability", shareability, Shareability)
         except ValueError as e:
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=[
+                    {
+                        "loc": ["query", "shareability"],
+                        "msg": str(e),
+                        "type": "value_error"
+                    }
+                ]
+            )
         # When filtering by shareability, still respect base visibility rules
         # Example: If filtering for "personal", only show current user's personal items
         if shareability == Shareability.personal.value or shareability == Shareability.reserved.value:

--- a/tests/routers/test_prepared_foods.py
+++ b/tests/routers/test_prepared_foods.py
@@ -446,30 +446,36 @@ class TestListPreparedFoodsFilterCombinations:
         response = client.get("/prepared-foods?type=invalid_type", headers=auth_headers)
         assert response.status_code == 422
         data = response.json()
-        # Assert validation error detail exists (resilient to error message format changes)
+        # Assert validation error detail exists and has proper structure
         assert "detail" in data
-        assert isinstance(data["detail"], str)
+        assert isinstance(data["detail"], list)
         assert len(data["detail"]) > 0
+        # Verify the error is specifically about the 'type' field (semantic validation)
+        assert any("type" in error.get("loc", []) for error in data["detail"])
 
     def test_invalid_storage_location_filter(self, client, auth_headers):
         """Should reject invalid storage_location enum value with 422."""
         response = client.get("/prepared-foods?storage_location=garage", headers=auth_headers)
         assert response.status_code == 422
         data = response.json()
-        # Assert validation error detail exists (resilient to error message format changes)
+        # Assert validation error detail exists and has proper structure
         assert "detail" in data
-        assert isinstance(data["detail"], str)
+        assert isinstance(data["detail"], list)
         assert len(data["detail"]) > 0
+        # Verify the error is specifically about the 'storage_location' field (semantic validation)
+        assert any("storage_location" in error.get("loc", []) for error in data["detail"])
 
     def test_invalid_shareability_filter(self, client, auth_headers):
         """Should reject invalid shareability enum value with 422."""
         response = client.get("/prepared-foods?shareability=public", headers=auth_headers)
         assert response.status_code == 422
         data = response.json()
-        # Assert validation error detail exists (resilient to error message format changes)
+        # Assert validation error detail exists and has proper structure
         assert "detail" in data
-        assert isinstance(data["detail"], str)
+        assert isinstance(data["detail"], list)
         assert len(data["detail"]) > 0
+        # Verify the error is specifically about the 'shareability' field (semantic validation)
+        assert any("shareability" in error.get("loc", []) for error in data["detail"])
 
     def test_combined_filters_with_pagination(self, client, auth_headers, test_user, db_session):
         """Should apply filters and pagination together correctly."""


### PR DESCRIPTION
## Work in Progress

Closes #206

Strengthen validation error test assertions

<!-- sharkrite-source-issue:202 -->## From PR #205 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
The concern is valid—tests that pass on any 422 response without semantic validation could mask regressions where the actual enum validation breaks. However, the original issue scope was specifically to make error message assertions less brittle, not to add new semantic validation.

## Context
The original issue (#202) was created to address brittle error message assertions. The current fix removes hardcoded message matching, which solves the stated problem. Adding semantic validation is a quality improvement that exceeds the defined scope and would require additional design consideration for what terms/patterns to check across different FastAPI versions.

## Defer Reason
Scope exceeds time budget

---
_Created by Sharkrite assessment on 2026-03-22T17:28:12Z_
_Parent PR: #205_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+0 added, ~2 modified, -0 deleted)
- `M` src/routers/prepared_foods.py
- `M` tests/routers/test_prepared_foods.py

### Commits
- 58a2e27 fix: Strengthen validation error test assertions
- 9fb2d52 chore: initialize work on #206 Strengthen validation error test assertions
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-03-22T20:43:42Z:**
- Created: #213 
- Updated: none