### PR TITLE
Add expiring_soon and search filters to list

### DIFF
--- a/src/routers/prepared_foods.py
+++ b/src/routers/prepared_foods.py
@@ -15,6 +15,7 @@ Logging Policy:
 
 import logging
 from uuid import UUID
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
@@ -134,6 +135,9 @@ def list_prepared_foods(
     type: Optional[str] = Query(default=None, description="Filter by type (complete_meal, batch_portion, component_ingredient)"),
     storage_location: Optional[str] = Query(default=None, description="Filter by storage location (pantry, fridge, freezer)"),
     shareability: Optional[str] = Query(default=None, description="Filter by shareability (shared, reserved, personal)"),
+    expiring_soon: Optional[bool] = Query(default=None, description="Filter items expiring within 7 days"),
+    expiring_within_days: Optional[int] = Query(default=None, ge=1, description="Filter items expiring within N days"),
+    search: Optional[str] = Query(default=None, min_length=2, max_length=255, description="Search items by name (case-insensitive partial match)"),
 ):
     """
     List prepared food items with shareability-aware filtering and pagination.
@@ -143,8 +147,8 @@ def list_prepared_foods(
     foods while maintaining privacy for personal items.
 
     Supports pagination via limit and offset query parameters.
-    Supports filtering by type, storage location, and shareability.
-    Multiple filters combine with AND logic.
+    Supports filtering by type, storage location, shareability, expiration status,
+    and name search. Multiple filters combine with AND logic.
 
     Args:
         current_user: Authenticated user (injected by get_current_user dependency)
@@ -154,6 +158,9 @@ def list_prepared_foods(
         type: Filter by type (must be valid PreparedFoodType enum value)
         storage_location: Filter by storage location (must be valid StorageLocation enum value)
         shareability: Filter by shareability (must be valid Shareability enum value)
+        expiring_soon: Filter items expiring within 7 days (true/false)
+        expiring_within_days: Filter items expiring within N days (overrides expiring_soon if both provided)
+        search: Search items by name (case-insensitive partial match)
 
     Returns:
         list[PreparedFoodListResponse]: List of prepared food items matching filters
@@ -204,6 +211,28 @@ def list_prepared_foods(
         else:
             # For "shared", show all shared items (already covered by base query)
             query = query.filter(PreparedFood.shareability == shareability)
+
+    # Apply expiration filters
+    # expiring_within_days takes precedence over expiring_soon if both provided
+    if expiring_within_days is not None:
+        expiration_cutoff = datetime.now(timezone.utc) + timedelta(days=expiring_within_days)
+        query = query.filter(
+            PreparedFood.estimated_expiration.isnot(None),
+            PreparedFood.estimated_expiration <= expiration_cutoff
+        )
+    elif expiring_soon is not None and expiring_soon:
+        # expiring_soon means within 7 days
+        expiration_cutoff = datetime.now(timezone.utc) + timedelta(days=7)
+        query = query.filter(
+            PreparedFood.estimated_expiration.isnot(None),
+            PreparedFood.estimated_expiration <= expiration_cutoff
+        )
+
+    # Apply name search filter (case-insensitive partial match)
+    if search is not None:
+        # Escape LIKE wildcards to prevent DoS via expensive pattern matching
+        escaped_search = search.replace('%', r'\%').replace('_', r'\_')
+        query = query.filter(PreparedFood.name.ilike(f"%{escaped_search}%", escape='\\'))
 
     # Apply ordering and pagination
     items = (

--- a/tests/routers/test_prepared_foods.py
+++ b/tests/routers/test_prepared_foods.py
@@ -19,6 +19,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from uuid import UUID, uuid4
+from datetime import datetime, timedelta, timezone
 
 from src.db.database import Base, get_db
 from src.db import models
@@ -1603,3 +1604,328 @@ class TestThawPreparedFood:
 
         response = client.post(f"/prepared-foods/{item.id}/thaw")
         assert response.status_code == 401
+
+
+class TestPreparedFoodExpiringAndSearchFilters:
+    """Tests for expiring_soon, expiring_within_days, and search filters on prepared foods list endpoint."""
+
+    def test_filter_by_expiring_soon(self, client, auth_headers, test_user, db_session):
+        """Should filter items expiring within 7 days."""
+        # Create items with different expiration dates
+        expiring_soon_item = PreparedFood(
+            name="Leftover Curry Expiring Soon",
+            type="complete_meal",
+            servings_remaining=2.0,
+            storage_location="fridge",
+            estimated_expiration=datetime.now(timezone.utc) + timedelta(days=3),
+            prepared_by=test_user.id,
+        )
+        expiring_later_item = PreparedFood(
+            name="Frozen Soup Expiring Later",
+            type="batch_portion",
+            servings_remaining=4.0,
+            storage_location="freezer",
+            estimated_expiration=datetime.now(timezone.utc) + timedelta(days=14),
+            prepared_by=test_user.id,
+        )
+        no_expiration_item = PreparedFood(
+            name="Dried Herbs No Expiration",
+            type="component_ingredient",
+            servings_remaining=10.0,
+            storage_location="pantry",
+            estimated_expiration=None,
+            prepared_by=test_user.id,
+        )
+        db_session.add_all([expiring_soon_item, expiring_later_item, no_expiration_item])
+        db_session.commit()
+
+        # Filter by expiring_soon=true
+        response = client.get("/prepared-foods?expiring_soon=true", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Leftover Curry Expiring Soon"
+
+        # Filter by expiring_soon=false (should return all items, including those not expiring soon)
+        response = client.get("/prepared-foods?expiring_soon=false", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        # When expiring_soon=false, no expiration filter is applied, so all items are returned
+        assert len(data) == 3
+
+    def test_filter_by_expiring_within_days(self, client, auth_headers, test_user, db_session):
+        """Should filter items expiring within N days."""
+        # Create items with different expiration dates
+        expiring_in_2_days = PreparedFood(
+            name="Pasta 2 Days",
+            type="complete_meal",
+            servings_remaining=1.0,
+            storage_location="fridge",
+            estimated_expiration=datetime.now(timezone.utc) + timedelta(days=2),
+            prepared_by=test_user.id,
+        )
+        expiring_in_5_days = PreparedFood(
+            name="Rice 5 Days",
+            type="batch_portion",
+            servings_remaining=3.0,
+            storage_location="fridge",
+            estimated_expiration=datetime.now(timezone.utc) + timedelta(days=5),
+            prepared_by=test_user.id,
+        )
+        expiring_in_10_days = PreparedFood(
+            name="Stew 10 Days",
+            type="complete_meal",
+            servings_remaining=2.0,
+            storage_location="freezer",
+            estimated_expiration=datetime.now(timezone.utc) + timedelta(days=10),
+            prepared_by=test_user.id,
+        )
+        db_session.add_all([expiring_in_2_days, expiring_in_5_days, expiring_in_10_days])
+        db_session.commit()
+
+        # Filter by expiring_within_days=3
+        response = client.get("/prepared-foods?expiring_within_days=3", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Pasta 2 Days"
+
+        # Filter by expiring_within_days=6
+        response = client.get("/prepared-foods?expiring_within_days=6", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        item_names = {item["name"] for item in data}
+        assert item_names == {"Pasta 2 Days", "Rice 5 Days"}
+
+        # Filter by expiring_within_days=15
+        response = client.get("/prepared-foods?expiring_within_days=15", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 3
+
+    def test_filter_expiring_within_days_overrides_expiring_soon(self, client, auth_headers, test_user, db_session):
+        """Should use expiring_within_days when both expiring_soon and expiring_within_days are provided."""
+        # Create items
+        expiring_in_2_days = PreparedFood(
+            name="Soup 2 Days",
+            type="complete_meal",
+            servings_remaining=1.0,
+            storage_location="fridge",
+            estimated_expiration=datetime.now(timezone.utc) + timedelta(days=2),
+            prepared_by=test_user.id,
+        )
+        expiring_in_5_days = PreparedFood(
+            name="Curry 5 Days",
+            type="complete_meal",
+            servings_remaining=2.0,
+            storage_location="fridge",
+            estimated_expiration=datetime.now(timezone.utc) + timedelta(days=5),
+            prepared_by=test_user.id,
+        )
+        db_session.add_all([expiring_in_2_days, expiring_in_5_days])
+        db_session.commit()
+
+        # When both are provided, expiring_within_days should take precedence
+        response = client.get(
+            "/prepared-foods?expiring_soon=true&expiring_within_days=3",
+            headers=auth_headers
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Soup 2 Days"
+
+    def test_expiring_filters_exclude_null_expiration(self, client, auth_headers, test_user, db_session):
+        """Should exclude items with null estimated_expiration from expiring filters."""
+        # Create items with and without expiration dates
+        has_expiration = PreparedFood(
+            name="Leftovers With Expiration",
+            type="complete_meal",
+            servings_remaining=1.0,
+            storage_location="fridge",
+            estimated_expiration=datetime.now(timezone.utc) + timedelta(days=3),
+            prepared_by=test_user.id,
+        )
+        no_expiration = PreparedFood(
+            name="Dried Ingredients No Expiration",
+            type="component_ingredient",
+            servings_remaining=5.0,
+            storage_location="pantry",
+            estimated_expiration=None,
+            prepared_by=test_user.id,
+        )
+        db_session.add_all([has_expiration, no_expiration])
+        db_session.commit()
+
+        # Filter by expiring_soon=true
+        response = client.get("/prepared-foods?expiring_soon=true", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Leftovers With Expiration"
+
+        # Filter by expiring_within_days=7
+        response = client.get("/prepared-foods?expiring_within_days=7", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Leftovers With Expiration"
+
+    def test_filter_by_search(self, client, auth_headers, test_user, db_session):
+        """Should search items by name (case-insensitive partial match)."""
+        # Create items with different names
+        item1 = PreparedFood(
+            name="Leftover Curry",
+            type="complete_meal",
+            servings_remaining=2.0,
+            storage_location="fridge",
+            prepared_by=test_user.id,
+        )
+        item2 = PreparedFood(
+            name="Chicken Curry Batch",
+            type="batch_portion",
+            servings_remaining=5.0,
+            storage_location="freezer",
+            prepared_by=test_user.id,
+        )
+        item3 = PreparedFood(
+            name="Tomato Sauce",
+            type="component_ingredient",
+            servings_remaining=3.0,
+            storage_location="fridge",
+            prepared_by=test_user.id,
+        )
+        db_session.add_all([item1, item2, item3])
+        db_session.commit()
+
+        # Search for "curry" (case-insensitive)
+        response = client.get("/prepared-foods?search=curry", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        item_names = {item["name"] for item in data}
+        assert item_names == {"Leftover Curry", "Chicken Curry Batch"}
+
+        # Search for "CURRY" (case-insensitive)
+        response = client.get("/prepared-foods?search=CURRY", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+
+        # Search for "tomato"
+        response = client.get("/prepared-foods?search=tomato", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Tomato Sauce"
+
+        # Search for partial match "chi"
+        response = client.get("/prepared-foods?search=chi", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Chicken Curry Batch"
+
+    def test_search_with_wildcard_characters(self, client, auth_headers, test_user, db_session):
+        """Should escape SQL wildcards in search input to prevent DoS."""
+        # Create items with special characters
+        item1 = PreparedFood(
+            name="Test_Item_With_Underscores",
+            type="complete_meal",
+            servings_remaining=1.0,
+            storage_location="fridge",
+            prepared_by=test_user.id,
+        )
+        item2 = PreparedFood(
+            name="Test%Item%With%Percent",
+            type="batch_portion",
+            servings_remaining=2.0,
+            storage_location="fridge",
+            prepared_by=test_user.id,
+        )
+        item3 = PreparedFood(
+            name="Regular Item",
+            type="component_ingredient",
+            servings_remaining=3.0,
+            storage_location="pantry",
+            prepared_by=test_user.id,
+        )
+        db_session.add_all([item1, item2, item3])
+        db_session.commit()
+
+        # Search with underscore wildcard (should be escaped and match literally)
+        response = client.get("/prepared-foods?search=Test_Item", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Test_Item_With_Underscores"
+
+        # Search with percent wildcard (should be escaped and match literally)
+        response = client.get("/prepared-foods?search=Test%Item", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Test%Item%With%Percent"
+
+    def test_search_min_length_validation(self, client, auth_headers):
+        """Should return 422 when search term is less than 2 characters."""
+        # Single character search should fail
+        response = client.get("/prepared-foods?search=a", headers=auth_headers)
+        assert response.status_code == 422
+
+        # Two character search should succeed
+        response = client.get("/prepared-foods?search=ab", headers=auth_headers)
+        assert response.status_code == 200
+
+    def test_combined_filters_with_expiring_and_search(self, client, auth_headers, test_user, db_session):
+        """Should combine expiring and search filters with existing filters using AND logic."""
+        # Create diverse items
+        target_item = PreparedFood(
+            name="Leftover Curry",
+            type="complete_meal",
+            servings_remaining=2.0,
+            storage_location="fridge",
+            shareability="shared",
+            estimated_expiration=datetime.now(timezone.utc) + timedelta(days=3),
+            prepared_by=test_user.id,
+        )
+        wrong_expiration = PreparedFood(
+            name="Leftover Curry Old",
+            type="complete_meal",
+            servings_remaining=1.0,
+            storage_location="fridge",
+            shareability="shared",
+            estimated_expiration=datetime.now(timezone.utc) + timedelta(days=14),
+            prepared_by=test_user.id,
+        )
+        wrong_name = PreparedFood(
+            name="Tomato Soup",
+            type="complete_meal",
+            servings_remaining=2.0,
+            storage_location="fridge",
+            shareability="shared",
+            estimated_expiration=datetime.now(timezone.utc) + timedelta(days=3),
+            prepared_by=test_user.id,
+        )
+        wrong_type = PreparedFood(
+            name="Leftover Curry Frozen",
+            type="batch_portion",
+            servings_remaining=3.0,
+            storage_location="fridge",
+            shareability="shared",
+            estimated_expiration=datetime.now(timezone.utc) + timedelta(days=3),
+            prepared_by=test_user.id,
+        )
+        db_session.add_all([target_item, wrong_expiration, wrong_name, wrong_type])
+        db_session.commit()
+
+        # Combine type, expiring_within_days, and search filters
+        response = client.get(
+            "/prepared-foods?type=complete_meal&expiring_within_days=5&search=curry",
+            headers=auth_headers
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Leftover Curry"


### PR DESCRIPTION
## Work in Progress

Closes #207

Add expiring_soon and search filters to list

**Time Estimate**: 45min

**Description**:
The PreparedFood list endpoint (`GET /prepared-foods`) supports `type`, `storage_location`, and `shareability` filters but is missing `expiring_soon`, `expiring_within_days`, and `search` — all three of which exist on the inventory list endpoint. The `expiring_soon`/`expiring_within_days` filters are a Phase 3A dependency (suggestion engine priority #1 is expiring leftovers powering the "about to go bad" home screen alert). The `search` filter is needed for consistency with inventory and grocery list endpoints.

**Claude Context**:
Files to Read:
- src/routers/inventory.py (reference implementation: `expiring_soon` bool, `expiring_within_days` int, `search` with escaped ilike — lines 202-285)
- src/routers/prepared_foods.py (current list endpoint, lines 128-217)
- src/db/models/prepared_food.py (has `estimated_expiration` and `name` fields)

Files to Modify:
- src/routers/prepared_foods.py (add three query parameters and filter logic to `list_prepared_foods`)
- tests/routers/test_prepared_foods.py (add filter tests)

Related Issues: Review of #192 and #199 implementation

**Acceptance Criteria**:
- [ ] `GET /prepared-foods?expiring_soon=true` returns items where `estimated_expiration <= now + 7 days` and `estimated_expiration` is not null: verify via test
- [ ] `GET /prepared-foods?expiring_within_days=3` returns items expiring within 3 days: verify via test
- [ ] `expiring_within_days` takes precedence over `expiring_soon` when both provided (matches inventory behavior): verify via test
- [ ] Items with `estimated_expiration = null` are excluded from expiring filters: verify via test
- [ ] `GET /prepared-foods?search=curry` returns items with "curry" in name (case-insensitive partial match): verify via test
- [ ] Search input is escaped for SQL wildcards (`%`, `_`): verify via test with wildcard characters in search term
- [ ] Search minimum length is 2, maximum is 255 (matches inventory): verify 422 on single-char search
- [ ] All existing tests still pass: `pytest tests/routers/test_prepared_foods.py -v`
- [ ] New filters compose with existing filters via AND logic: verify combined filter test

**Verification Commands**:
```bash
pytest tests/routers/test_prepared_foods.py -v -k "expiring or search"
pytest tests/routers/test_prepared_foods.py -v
```

**Done Definition**: Done when `expiring_soon`, `expiring_within_days`, and `search` filters work on the list endpoint with full test coverage, matching the inventory endpoint behavior.

**Scope Boundary**:
- DO: Add `expiring_soon` (bool), `expiring_within_days` (int, ge=1), and `search` (str, min_length=2, max_length=255) query parameters
- DO: Match inventory's filter implementation exactly (escaped ilike for search, utc timedelta for expiration, precedence rules)
- DO: Add tests for each filter individually and in combination
- DO NOT: Change existing filter behavior
- DO NOT: Add filters not present on inventory (keep consistency)

**Dependencies**: None (additive change to existing endpoint)

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+0 added, ~2 modified, -0 deleted)
- `M` src/routers/prepared_foods.py
- `M` tests/routers/test_prepared_foods.py

### Commits
- 34fe368 feat: Add expiring_soon and search filters to list
- dd8f6c2 chore: initialize work on #207 Add expiring_soon and search filters to list
<!-- /sharkrite-changes-summary -->