### PR TITLE
Add optional date_prepared to PreparedFoodCreate

### DIFF
--- a/src/schemas/prepared_food.py
+++ b/src/schemas/prepared_food.py
@@ -31,6 +31,7 @@ class PreparedFoodCreate(BaseModel):
     estimated_expiration: Optional[datetime] = Field(default=None, description="Estimated expiration date")
     shareability: str = Field(default=Shareability.shared.value, description="Shareability status (shared, reserved, personal)")
     notes: Optional[str] = Field(default=None, max_length=10000, description="Additional notes")
+    date_prepared: Optional[datetime] = Field(default=None, description="Date the food was prepared (defaults to server time if omitted)")
 
     @field_validator('name')
     @classmethod

--- a/src/services/prepared_foods_service.py
+++ b/src/services/prepared_foods_service.py
@@ -47,7 +47,8 @@ def create_prepared_food(
         HTTPException(500): If database error occurs
     """
     # Create new prepared food item with prepared_by set to current user
-    item_dict = item_data.model_dump()
+    # Exclude date_prepared if None so the DB default (func.now()) kicks in
+    item_dict = item_data.model_dump(exclude_none=True)
     new_item = PreparedFood(
         **item_dict,
         prepared_by=current_user.id,

--- a/tests/routers/test_prepared_foods.py
+++ b/tests/routers/test_prepared_foods.py
@@ -243,6 +243,43 @@ class TestCreatePreparedFood:
 
         assert response.status_code == 422
 
+    def test_create_with_explicit_date_prepared(self, client, auth_headers, test_user):
+        """Should use provided date_prepared instead of server default."""
+        explicit_date = datetime(2026, 3, 20, 12, 0, 0)
+        payload = {
+            "name": "Backdated stock blocks",
+            "type": "component_ingredient",
+            "servings_remaining": 6.0,
+            "storage_location": "freezer",
+            "date_prepared": explicit_date.isoformat(),
+        }
+
+        response = client.post("/prepared-foods", json=payload, headers=auth_headers)
+
+        assert response.status_code == 201
+        data = response.json()
+        response_date = datetime.fromisoformat(data["date_prepared"])
+        assert response_date == explicit_date
+
+    def test_create_without_date_prepared_uses_server_default(self, client, auth_headers, test_user):
+        """Should default date_prepared to server time when omitted."""
+        payload = {
+            "name": "Fresh curry",
+            "type": "complete_meal",
+            "servings_remaining": 4.0,
+            "storage_location": "fridge",
+        }
+
+        response = client.post("/prepared-foods", json=payload, headers=auth_headers)
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["date_prepared"] is not None
+        response_date = datetime.fromisoformat(data["date_prepared"])
+        # func.now() may return UTC; use utcnow for comparison
+        now = datetime.utcnow()
+        assert abs((now - response_date).total_seconds()) < 60
+
 
 class TestListPreparedFoods:
     """Tests for GET /prepared-foods (list with shareability-aware filtering)."""


### PR DESCRIPTION
## Work in Progress

Closes #208

Add optional date_prepared to PreparedFoodCreate

**Time Estimate**: 20min

**Description**:
The `PreparedFoodCreate` schema does not include a `date_prepared` field. The model defaults to `func.now()`, which means there is no API-level way to backdate entries. If a user batch-preps stock blocks on Saturday and logs them on Monday, they show as Monday. This is a data accuracy issue that becomes load-bearing in Phase 3D when daily reconciliation uses `date_prepared` for freshness calculations and expiration estimates.

Should be fixed before Phase 2 starts building on top of the current schema, to avoid retrofitting later.

**Claude Context**:
Files to Read:
- src/schemas/prepared_food.py (PreparedFoodCreate — line 23, no date_prepared field)
- src/db/models/prepared_food.py (model has `date_prepared` with `default=func.now()`)
- src/services/prepared_foods_service.py (create function — line 26, model_dump + prepared_by)

Files to Modify:
- src/schemas/prepared_food.py (add optional `date_prepared` to `PreparedFoodCreate`)
- src/services/prepared_foods_service.py (conditionally set `date_prepared` from request if provided)
- tests/routers/test_prepared_foods.py (add test for backdated create and default behavior)

Related Issues: Review of #192 implementation

**Acceptance Criteria**:
- [ ] `PreparedFoodCreate` has optional `date_prepared: Optional[datetime] = Field(default=None)`: verify field exists on schema
- [ ] POST /prepared-foods without `date_prepared` still defaults to server time (existing behavior preserved): verify via test
- [ ] POST /prepared-foods with `date_prepared` set uses the provided value: verify via test that response `date_prepared` matches request value
- [ ] `date_prepared` in service layer: if provided in request, pass to model; if None, omit so DB default kicks in: verify via test
- [ ] All existing tests still pass: `pytest tests/routers/test_prepared_foods.py -v`

**Verification Commands**:
```bash
pytest tests/routers/test_prepared_foods.py -v -k "date_prepared"
pytest tests/routers/test_prepared_foods.py -v
```

**Done Definition**: Done when `date_prepared` can be optionally set on create, defaults to server time when omitted, and both paths are tested.

**Scope Boundary**:
- DO: Add optional `date_prepared` to `PreparedFoodCreate`
- DO: Update service layer to conditionally pass `date_prepared` to model constructor
- DO: Test both paths (provided and omitted)
- DO NOT: Add `date_prepared` to `PreparedFoodUpdate` (updating prep date after creation is a different semantic — revisit if needed)
- DO NOT: Add validation constraining `date_prepared` to the past (users may prep today and log it with today's date before midnight)

**Dependencies**: None

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **3** commits (+0 added, ~3 modified, -0 deleted)
- `M` src/schemas/prepared_food.py
- `M` src/services/prepared_foods_service.py
- `M` tests/routers/test_prepared_foods.py

### Commits
- 10c265d Add optional date_prepared to PreparedFoodCreate schema
- f77137b Merge remote-tracking branch 'origin/main' into feat/add-optional-dateprepared-to-preparedfoodcreate
- 550ab97 chore: initialize work on #208 Add optional date_prepared to PreparedFoodCreate
<!-- /sharkrite-changes-summary -->