### PR TITLE
Add max_length to PreparedFood notes field

### DIFF
--- a/src/schemas/prepared_food.py
+++ b/src/schemas/prepared_food.py
@@ -30,7 +30,7 @@ class PreparedFoodCreate(BaseModel):
     storage_location: str = Field(..., description="Storage location (pantry, fridge, freezer)")
     estimated_expiration: Optional[datetime] = Field(default=None, description="Estimated expiration date")
     shareability: str = Field(default=Shareability.shared.value, description="Shareability status (shared, reserved, personal)")
-    notes: Optional[str] = Field(default=None, description="Additional notes")
+    notes: Optional[str] = Field(default=None, max_length=10000, description="Additional notes")
 
     @field_validator('name')
     @classmethod
@@ -86,7 +86,7 @@ class PreparedFoodUpdate(BaseModel):
     storage_location: Optional[str] = Field(default=None, description="Storage location (pantry, fridge, freezer)")
     estimated_expiration: Optional[datetime] = Field(default=None, description="Estimated expiration date")
     shareability: Optional[str] = Field(default=None, description="Shareability status (shared, reserved, personal)")
-    notes: Optional[str] = Field(default=None, description="Additional notes")
+    notes: Optional[str] = Field(default=None, max_length=10000, description="Additional notes")
 
     @field_validator('name')
     @classmethod

--- a/tests/schemas/test_prepared_food.py
+++ b/tests/schemas/test_prepared_food.py
@@ -159,6 +159,37 @@ class TestPreparedFoodCreate:
         # Verify the created item doesn't have prepared_by attribute
         assert not hasattr(item, "prepared_by") or "prepared_by" not in item.model_fields
 
+    def test_notes_at_max_length_is_accepted(self):
+        """Test that notes at exactly 10000 characters are accepted."""
+        notes_10000 = "a" * 10000
+        item_data = {
+            "name": "Test Item",
+            "type": "complete_meal",
+            "servings_remaining": 2.0,
+            "storage_location": "fridge",
+            "notes": notes_10000,
+        }
+        item = PreparedFoodCreate(**item_data)
+        assert item.notes == notes_10000
+        assert len(item.notes) == 10000
+
+    def test_notes_exceeding_max_length_is_rejected(self):
+        """Test that notes exceeding 10000 characters are rejected."""
+        notes_10001 = "a" * 10001
+        item_data = {
+            "name": "Test Item",
+            "type": "complete_meal",
+            "servings_remaining": 2.0,
+            "storage_location": "fridge",
+            "notes": notes_10001,
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            PreparedFoodCreate(**item_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("notes",) for error in errors)
+        assert any("10000" in str(error["msg"]) for error in errors)
+
 
 class TestPreparedFoodUpdate:
     """Tests for PreparedFoodUpdate schema."""
@@ -203,6 +234,25 @@ class TestPreparedFoodUpdate:
         errors = exc_info.value.errors()
         assert any(error["loc"] == ("servings_remaining",) for error in errors)
         assert any("negative" in error["msg"].lower() for error in errors)
+
+    def test_update_notes_at_max_length_is_accepted(self):
+        """Test that update with notes at exactly 10000 characters are accepted."""
+        notes_10000 = "b" * 10000
+        update_data = {"notes": notes_10000}
+        update = PreparedFoodUpdate(**update_data)
+        assert update.notes == notes_10000
+        assert len(update.notes) == 10000
+
+    def test_update_notes_exceeding_max_length_is_rejected(self):
+        """Test that update with notes exceeding 10000 characters are rejected."""
+        notes_10001 = "b" * 10001
+        update_data = {"notes": notes_10001}
+        with pytest.raises(ValidationError) as exc_info:
+            PreparedFoodUpdate(**update_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("notes",) for error in errors)
+        assert any("10000" in str(error["msg"]) for error in errors)
 
 
 class TestPreparedFoodResponse:


### PR DESCRIPTION
## Work in Progress

Closes #209

Add max_length to PreparedFood notes field

**Time Estimate**: 10min

**Description**:
The `notes` field on `PreparedFoodCreate` and `PreparedFoodUpdate` has no `max_length` constraint. The model uses `Text` (unbounded). Recipe schemas cap notes at 10,000 characters; inventory caps `reserved_note` at 500. PreparedFood notes are semantically equivalent to recipe notes (freeform description), so they should get the same 10,000 character limit for consistency. Not a security issue with SQLite but becomes one on migration to Postgres with length-constrained columns.

**Claude Context**:
Files to Read:
- src/schemas/prepared_food.py (lines 33 and 89 — notes fields without max_length)
- src/schemas/recipe.py (line 31 — `notes: Optional[str] = Field(default=None, max_length=10000)`)
- src/schemas/inventory.py (line 46 — `reserved_note` at max_length=500, different semantic)

Files to Modify:
- src/schemas/prepared_food.py (add `max_length=10000` to notes on both Create and Update)
- tests/schemas/test_prepared_food.py (add test that notes exceeding 10000 chars returns 422)

Related Issues: Review of #195 implementation

**Acceptance Criteria**:
- [ ] `PreparedFoodCreate.notes` has `max_length=10000`: verify via schema inspection
- [ ] `PreparedFoodUpdate.notes` has `max_length=10000`: verify via schema inspection
- [ ] Notes at exactly 10000 chars are accepted: verify via test
- [ ] Notes at 10001 chars return 422: verify via test
- [ ] All existing tests still pass: `pytest tests/schemas/test_prepared_food.py -v`

**Verification Commands**:
```bash
pytest tests/schemas/test_prepared_food.py -v -k "notes"
pytest tests/schemas/test_prepared_food.py -v
```

**Done Definition**: Done when both schemas enforce 10,000 char limit on notes and boundary tests pass.

**Scope Boundary**:
- DO: Add `max_length=10000` to notes on PreparedFoodCreate and PreparedFoodUpdate
- DO: Add boundary tests (10000 ok, 10001 rejected)
- DO NOT: Change the DB column type (Text is fine, this is application-level validation)
- DO NOT: Change other field constraints

**Dependencies**: None

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+0 added, ~2 modified, -0 deleted)
- `M` src/schemas/prepared_food.py
- `M` tests/schemas/test_prepared_food.py

### Commits
- ecaebac feat: Add max_length to PreparedFood notes field
- 1aceaf1 chore: initialize work on #209 Add max_length to PreparedFood notes field
<!-- /sharkrite-changes-summary -->