### PR TITLE
Add date_prepared and prepared_by to list response

### DIFF
--- a/src/schemas/prepared_food.py
+++ b/src/schemas/prepared_food.py
@@ -147,8 +147,10 @@ class PreparedFoodListResponse(BaseModel):
     type: str
     servings_remaining: float
     storage_location: str
+    date_prepared: datetime
     estimated_expiration: Optional[datetime]
     shareability: str
+    prepared_by: UUID
 
 
 class PreparedFoodConsumptionResponse(BaseModel):

--- a/tests/schemas/test_prepared_food.py
+++ b/tests/schemas/test_prepared_food.py
@@ -299,6 +299,8 @@ class TestPreparedFoodListResponse:
     def test_list_response_includes_summary_fields(self):
         """Test that list response includes summary fields for list views."""
         item_id = uuid4()
+        user_id = uuid4()
+        date_prepared = datetime(2025, 3, 15, 12, 0, 0)
         expiration = datetime(2025, 3, 20, 12, 0, 0)
 
         response_data = {
@@ -307,8 +309,10 @@ class TestPreparedFoodListResponse:
             "type": "batch_portion",
             "servings_remaining": 6.0,
             "storage_location": "fridge",
+            "date_prepared": date_prepared,
             "estimated_expiration": expiration,
             "shareability": "shared",
+            "prepared_by": user_id,
         }
         response = PreparedFoodListResponse(**response_data)
         assert response.id == item_id
@@ -316,8 +320,10 @@ class TestPreparedFoodListResponse:
         assert response.type == "batch_portion"
         assert response.servings_remaining == 6.0
         assert response.storage_location == "fridge"
+        assert response.date_prepared == date_prepared
         assert response.estimated_expiration == expiration
         assert response.shareability == "shared"
+        assert response.prepared_by == user_id
 
 
 class TestPreparedFoodConsumptionResponse:


### PR DESCRIPTION
## Work in Progress

Closes #210

Add date_prepared and prepared_by to list response

**Time Estimate**: 10min

**Description**:
`PreparedFoodListResponse` is missing `date_prepared` and `prepared_by` fields. The list endpoint is the browsing view ("what's in the fridge that's ready to eat?"), but without these fields the client can't show who made it or when — both critical for the browsing UX. Age at a glance matters for food safety decisions. The full `PreparedFoodResponse` has both fields, but the list endpoint returns `PreparedFoodListResponse` which omits them.

**Claude Context**:
Files to Read:
- src/schemas/prepared_food.py (PreparedFoodListResponse lines 140-152 — missing both fields; PreparedFoodResponse lines 122-137 — has both)

Files to Modify:
- src/schemas/prepared_food.py (add `date_prepared: datetime` and `prepared_by: UUID` to `PreparedFoodListResponse`)
- tests/routers/test_prepared_foods.py (verify list response includes both fields)

Related Issues: Review of #195 implementation

**Acceptance Criteria**:
- [ ] `PreparedFoodListResponse` includes `date_prepared: datetime`: verify field present in schema
- [ ] `PreparedFoodListResponse` includes `prepared_by: UUID`: verify field present in schema
- [ ] GET /prepared-foods response items include `date_prepared` and `prepared_by`: verify via test
- [ ] All existing tests still pass: `pytest tests/routers/test_prepared_foods.py -v`

**Verification Commands**:
```bash
pytest tests/routers/test_prepared_foods.py -v
python -c "from src.schemas.prepared_food import PreparedFoodListResponse; f = PreparedFoodListResponse.model_fields; assert 'date_prepared' in f and 'prepared_by' in f; print('OK')"
```

**Done Definition**: Done when list response schema includes both fields and existing tests pass.

**Scope Boundary**:
- DO: Add `date_prepared` and `prepared_by` to `PreparedFoodListResponse`
- DO: Verify existing list tests still pass (ORM conversion should pick up the new fields automatically since the model has them)
- DO NOT: Change `PreparedFoodResponse` (already has both fields)
- DO NOT: Add other missing fields to the list schema

**Dependencies**: None

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+0 added, ~2 modified, -0 deleted)
- `M` src/schemas/prepared_food.py
- `M` tests/schemas/test_prepared_food.py

### Commits
- 6218732 feat: Add date_prepared and prepared_by to list response
- 4977dfb chore: initialize work on #210 Add date_prepared and prepared_by to list response
<!-- /sharkrite-changes-summary -->