### PR TITLE
Add step_index to RecipeIngredient model

### DIFF
--- a/alembic/versions/a1b2c3d4e5f7_add_step_index_to_recipe_ingredients.py
+++ b/alembic/versions/a1b2c3d4e5f7_add_step_index_to_recipe_ingredients.py
@@ -1,0 +1,30 @@
+"""add_step_index_to_recipe_ingredients
+
+Revision ID: a1b2c3d4e5f7
+Revises: f9d8c7b6a5e4
+Create Date: 2026-03-23 01:40:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a1b2c3d4e5f7'
+down_revision: Union[str, None] = 'f9d8c7b6a5e4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add step_index column to recipe_ingredients table
+    with op.batch_alter_table('recipe_ingredients', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('step_index', sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    # Remove step_index column from recipe_ingredients table
+    with op.batch_alter_table('recipe_ingredients', schema=None) as batch_op:
+        batch_op.drop_column('step_index')

--- a/src/db/models/recipe_ingredient.py
+++ b/src/db/models/recipe_ingredient.py
@@ -4,7 +4,7 @@ from uuid import UUID, uuid4
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import String, Float, Boolean, ForeignKey, DateTime, func
+from sqlalchemy import String, Float, Boolean, Integer, ForeignKey, DateTime, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.db.database import Base
@@ -21,6 +21,7 @@ class RecipeIngredient(Base):
     variation_group: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
     variation_diet: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
     is_optional: Mapped[bool] = mapped_column(Boolean, default=False)
+    step_index: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
 
     # Relationships

--- a/src/routers/recipes.py
+++ b/src/routers/recipes.py
@@ -227,10 +227,13 @@ def create_ad_hoc_recipe(
             # Pydantic validation ensures step_index >= 0, here we check upper bound
             if item_usage.step_index is not None:
                 if item_usage.step_index >= len(recipe_data.steps):
-                    if len(recipe_data.steps) == 0:
+                    num_steps = len(recipe_data.steps)
+                    if num_steps == 0:
                         detail_msg = f"step_index {item_usage.step_index} is out of bounds. Recipe has 0 steps"
+                    elif num_steps == 1:
+                        detail_msg = f"step_index {item_usage.step_index} is out of bounds. Recipe has 1 step (index 0)"
                     else:
-                        detail_msg = f"step_index {item_usage.step_index} is out of bounds. Recipe has {len(recipe_data.steps)} steps (indices 0-{len(recipe_data.steps)-1})"
+                        detail_msg = f"step_index {item_usage.step_index} is out of bounds. Recipe has {num_steps} steps (indices 0-{num_steps-1})"
                     raise HTTPException(
                         status_code=status.HTTP_400_BAD_REQUEST,
                         detail=detail_msg
@@ -596,10 +599,13 @@ def add_recipe_ingredient(
     # Pydantic validation ensures step_index >= 0, here we check upper bound
     if ingredient_data.step_index is not None:
         if ingredient_data.step_index >= len(recipe.steps):
-            if len(recipe.steps) == 0:
+            num_steps = len(recipe.steps)
+            if num_steps == 0:
                 detail_msg = f"step_index {ingredient_data.step_index} is out of bounds. Recipe has 0 steps"
+            elif num_steps == 1:
+                detail_msg = f"step_index {ingredient_data.step_index} is out of bounds. Recipe has 1 step (index 0)"
             else:
-                detail_msg = f"step_index {ingredient_data.step_index} is out of bounds. Recipe has {len(recipe.steps)} steps (indices 0-{len(recipe.steps)-1})"
+                detail_msg = f"step_index {ingredient_data.step_index} is out of bounds. Recipe has {num_steps} steps (indices 0-{num_steps-1})"
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=detail_msg
@@ -697,10 +703,13 @@ def update_recipe_ingredient(
     # Pydantic validation ensures step_index >= 0, here we check upper bound
     if update_data.step_index is not None:
         if update_data.step_index >= len(recipe.steps):
-            if len(recipe.steps) == 0:
+            num_steps = len(recipe.steps)
+            if num_steps == 0:
                 detail_msg = f"step_index {update_data.step_index} is out of bounds. Recipe has 0 steps"
+            elif num_steps == 1:
+                detail_msg = f"step_index {update_data.step_index} is out of bounds. Recipe has 1 step (index 0)"
             else:
-                detail_msg = f"step_index {update_data.step_index} is out of bounds. Recipe has {len(recipe.steps)} steps (indices 0-{len(recipe.steps)-1})"
+                detail_msg = f"step_index {update_data.step_index} is out of bounds. Recipe has {num_steps} steps (indices 0-{num_steps-1})"
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=detail_msg

--- a/src/routers/recipes.py
+++ b/src/routers/recipes.py
@@ -222,11 +222,22 @@ def create_ad_hoc_recipe(
         for item_usage in recipe_data.inventory_items:
             inventory_item = inventory_map[item_usage.inventory_item_id]
 
+            # Validate step_index bounds if provided
+            # step_index references an index in recipe.steps (0-based array)
+            # Pydantic validation ensures step_index >= 0, here we check upper bound
+            if item_usage.step_index is not None:
+                if item_usage.step_index >= len(recipe_data.steps):
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail=f"step_index {item_usage.step_index} is out of bounds. Recipe has {len(recipe_data.steps)} steps (indices 0-{len(recipe_data.steps)-1})"
+                    )
+
             recipe_ingredient = RecipeIngredient(
                 recipe_id=new_recipe.id,
                 ingredient_name=inventory_item.name,  # Use canonical name from inventory
                 quantity=item_usage.quantity_used,
                 unit=item_usage.unit,
+                step_index=item_usage.step_index,  # Pass through step_index from inventory usage
             )
             db.add(recipe_ingredient)
 
@@ -576,6 +587,16 @@ def add_recipe_ingredient(
     # Verify recipe exists, is not a system recipe, and belongs to current user
     recipe = verify_recipe_ownership_with_system_check(recipe_id, current_user, db)
 
+    # Validate step_index bounds if provided
+    # step_index references an index in recipe.steps (0-based array)
+    # Pydantic validation ensures step_index >= 0, here we check upper bound
+    if ingredient_data.step_index is not None:
+        if ingredient_data.step_index >= len(recipe.steps):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"step_index {ingredient_data.step_index} is out of bounds. Recipe has {len(recipe.steps)} steps (indices 0-{len(recipe.steps)-1})"
+            )
+
     # Create new ingredient
     ingredient_dict = ingredient_data.model_dump()
     new_ingredient = RecipeIngredient(
@@ -662,6 +683,16 @@ def update_recipe_ingredient(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Ingredient not found"
         )
+
+    # Validate step_index bounds if provided
+    # step_index references an index in recipe.steps (0-based array)
+    # Pydantic validation ensures step_index >= 0, here we check upper bound
+    if update_data.step_index is not None:
+        if update_data.step_index >= len(recipe.steps):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"step_index {update_data.step_index} is out of bounds. Recipe has {len(recipe.steps)} steps (indices 0-{len(recipe.steps)-1})"
+            )
 
     # Update only the fields that were provided
     update_dict = update_data.model_dump(exclude_unset=True)

--- a/src/routers/recipes.py
+++ b/src/routers/recipes.py
@@ -227,9 +227,13 @@ def create_ad_hoc_recipe(
             # Pydantic validation ensures step_index >= 0, here we check upper bound
             if item_usage.step_index is not None:
                 if item_usage.step_index >= len(recipe_data.steps):
+                    if len(recipe_data.steps) == 0:
+                        detail_msg = f"step_index {item_usage.step_index} is out of bounds. Recipe has 0 steps"
+                    else:
+                        detail_msg = f"step_index {item_usage.step_index} is out of bounds. Recipe has {len(recipe_data.steps)} steps (indices 0-{len(recipe_data.steps)-1})"
                     raise HTTPException(
                         status_code=status.HTTP_400_BAD_REQUEST,
-                        detail=f"step_index {item_usage.step_index} is out of bounds. Recipe has {len(recipe_data.steps)} steps (indices 0-{len(recipe_data.steps)-1})"
+                        detail=detail_msg
                     )
 
             recipe_ingredient = RecipeIngredient(
@@ -592,9 +596,13 @@ def add_recipe_ingredient(
     # Pydantic validation ensures step_index >= 0, here we check upper bound
     if ingredient_data.step_index is not None:
         if ingredient_data.step_index >= len(recipe.steps):
+            if len(recipe.steps) == 0:
+                detail_msg = f"step_index {ingredient_data.step_index} is out of bounds. Recipe has 0 steps"
+            else:
+                detail_msg = f"step_index {ingredient_data.step_index} is out of bounds. Recipe has {len(recipe.steps)} steps (indices 0-{len(recipe.steps)-1})"
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"step_index {ingredient_data.step_index} is out of bounds. Recipe has {len(recipe.steps)} steps (indices 0-{len(recipe.steps)-1})"
+                detail=detail_msg
             )
 
     # Create new ingredient
@@ -689,9 +697,13 @@ def update_recipe_ingredient(
     # Pydantic validation ensures step_index >= 0, here we check upper bound
     if update_data.step_index is not None:
         if update_data.step_index >= len(recipe.steps):
+            if len(recipe.steps) == 0:
+                detail_msg = f"step_index {update_data.step_index} is out of bounds. Recipe has 0 steps"
+            else:
+                detail_msg = f"step_index {update_data.step_index} is out of bounds. Recipe has {len(recipe.steps)} steps (indices 0-{len(recipe.steps)-1})"
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"step_index {update_data.step_index} is out of bounds. Recipe has {len(recipe.steps)} steps (indices 0-{len(recipe.steps)-1})"
+                detail=detail_msg
             )
 
     # Update only the fields that were provided

--- a/src/schemas/recipe.py
+++ b/src/schemas/recipe.py
@@ -195,6 +195,7 @@ class RecipeIngredientCreate(BaseModel):
     variation_group: Optional[str] = Field(default=None, max_length=100, description="Variation group identifier")
     variation_diet: Optional[str] = Field(default=None, max_length=50, description="Dietary variation identifier")
     is_optional: bool = Field(default=False, description="Whether ingredient is optional")
+    step_index: Optional[int] = Field(default=None, ge=0, description="Step index this ingredient is associated with")
 
     @field_validator('ingredient_name', 'unit')
     @classmethod
@@ -224,6 +225,7 @@ class RecipeIngredientUpdate(BaseModel):
     variation_group: Optional[str] = Field(default=None, max_length=100, description="Variation group identifier")
     variation_diet: Optional[str] = Field(default=None, max_length=50, description="Dietary variation identifier")
     is_optional: Optional[bool] = Field(default=None, description="Whether ingredient is optional")
+    step_index: Optional[int] = Field(default=None, ge=0, description="Step index this ingredient is associated with")
 
     @field_validator('ingredient_name', 'unit')
     @classmethod
@@ -259,6 +261,7 @@ class RecipeIngredientResponse(BaseModel):
     variation_group: Optional[str]
     variation_diet: Optional[str]
     is_optional: bool
+    step_index: Optional[int]
 
 
 class UserRecipeRatingCreate(BaseModel):
@@ -305,6 +308,7 @@ class InventoryItemUsage(BaseModel):
     inventory_item_id: UUID = Field(..., description="ID of the inventory item to use")
     quantity_used: float = Field(..., gt=0, description="Quantity to use from inventory (must be positive)")
     unit: str = Field(..., min_length=1, max_length=50, description="Unit of measurement")
+    step_index: Optional[int] = Field(default=None, ge=0, description="Step index this ingredient is associated with")
 
     @field_validator('unit')
     @classmethod

--- a/tests/routers/test_recipes.py
+++ b/tests/routers/test_recipes.py
@@ -2395,3 +2395,324 @@ class TestAdHocRecipeCreation:
         detail = response.json()["detail"]
         # Verify it's a validation error on the unit field
         assert any("unit" in str(error).lower() for error in detail)
+
+
+class TestRecipeIngredientStepIndex:
+    """Test step_index field for recipe ingredients."""
+
+    @pytest.fixture
+    def test_recipe_with_steps(self, db_session, test_user):
+        """Create a test recipe with 3 steps."""
+        recipe = Recipe(
+            id=uuid4(),
+            name="Recipe with Steps",
+            source_type="manual",
+            created_by=test_user.id,
+            tags=[],
+            steps=["Step 1: Prep ingredients", "Step 2: Cook", "Step 3: Serve"],
+        )
+        db_session.add(recipe)
+        db_session.commit()
+        db_session.refresh(recipe)
+        return recipe
+
+    @pytest.fixture
+    def test_recipe_no_steps(self, db_session, test_user):
+        """Create a test recipe with no steps."""
+        recipe = Recipe(
+            id=uuid4(),
+            name="Recipe without Steps",
+            source_type="manual",
+            created_by=test_user.id,
+            tags=[],
+            steps=[],
+        )
+        db_session.add(recipe)
+        db_session.commit()
+        db_session.refresh(recipe)
+        return recipe
+
+    def test_add_ingredient_with_step_index_zero(self, client, auth_headers, test_recipe_with_steps):
+        """Test adding ingredient with step_index=0 succeeds."""
+        ingredient_data = {
+            "ingredient_name": "Tomatoes",
+            "quantity": 2.0,
+            "unit": "lbs",
+            "step_index": 0,
+        }
+
+        response = client.post(
+            f"/recipes/{test_recipe_with_steps.id}/ingredients",
+            json=ingredient_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["ingredient_name"] == "Tomatoes"
+        assert data["step_index"] == 0
+
+    def test_add_ingredient_with_step_index_none(self, client, auth_headers, test_recipe_with_steps):
+        """Test adding ingredient with step_index=None succeeds (backwards compatible)."""
+        ingredient_data = {
+            "ingredient_name": "Salt",
+            "quantity": 1.0,
+            "unit": "tsp",
+            "step_index": None,
+        }
+
+        response = client.post(
+            f"/recipes/{test_recipe_with_steps.id}/ingredients",
+            json=ingredient_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["ingredient_name"] == "Salt"
+        assert data["step_index"] is None
+
+    def test_add_ingredient_without_step_index_field(self, client, auth_headers, test_recipe_with_steps):
+        """Test adding ingredient without step_index field succeeds (backwards compatible)."""
+        ingredient_data = {
+            "ingredient_name": "Pepper",
+            "quantity": 1.0,
+            "unit": "tsp",
+        }
+
+        response = client.post(
+            f"/recipes/{test_recipe_with_steps.id}/ingredients",
+            json=ingredient_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["ingredient_name"] == "Pepper"
+        assert data["step_index"] is None
+
+    def test_add_ingredient_with_negative_step_index(self, client, auth_headers, test_recipe_with_steps):
+        """Test adding ingredient with step_index=-1 returns 422 (Pydantic validation)."""
+        ingredient_data = {
+            "ingredient_name": "Invalid Ingredient",
+            "quantity": 1.0,
+            "unit": "cup",
+            "step_index": -1,
+        }
+
+        response = client.post(
+            f"/recipes/{test_recipe_with_steps.id}/ingredients",
+            json=ingredient_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        # Verify it's a validation error mentioning step_index
+        assert any("step_index" in str(error).lower() for error in detail)
+
+    def test_add_ingredient_with_step_index_out_of_bounds(self, client, auth_headers, test_recipe_with_steps):
+        """Test adding ingredient with step_index >= len(steps) returns 400."""
+        ingredient_data = {
+            "ingredient_name": "Out of Bounds Ingredient",
+            "quantity": 1.0,
+            "unit": "cup",
+            "step_index": 5,  # Recipe has only 3 steps (indices 0-2)
+        }
+
+        response = client.post(
+            f"/recipes/{test_recipe_with_steps.id}/ingredients",
+            json=ingredient_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 400
+        detail = response.json()["detail"]
+        assert "step_index 5 is out of bounds" in detail
+        assert "Recipe has 3 steps" in detail
+
+    def test_add_ingredient_with_step_index_to_empty_steps_recipe(self, client, auth_headers, test_recipe_no_steps):
+        """Test adding ingredient with step_index to recipe with no steps returns 400."""
+        ingredient_data = {
+            "ingredient_name": "No Steps Ingredient",
+            "quantity": 1.0,
+            "unit": "cup",
+            "step_index": 0,
+        }
+
+        response = client.post(
+            f"/recipes/{test_recipe_no_steps.id}/ingredients",
+            json=ingredient_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 400
+        detail = response.json()["detail"]
+        assert "step_index 0 is out of bounds" in detail
+        assert "Recipe has 0 steps" in detail
+
+    def test_update_ingredient_step_index(self, client, auth_headers, test_recipe_with_steps, db_session):
+        """Test updating an ingredient's step_index."""
+        from src.db.models.recipe_ingredient import RecipeIngredient
+
+        # Create an ingredient without step_index
+        ingredient = RecipeIngredient(
+            id=uuid4(),
+            recipe_id=test_recipe_with_steps.id,
+            ingredient_name="Updateable Ingredient",
+            quantity=1.0,
+            unit="cup",
+            step_index=None,
+        )
+        db_session.add(ingredient)
+        db_session.commit()
+        db_session.refresh(ingredient)
+
+        # Update to add step_index
+        update_data = {
+            "step_index": 1,
+        }
+
+        response = client.put(
+            f"/recipes/{test_recipe_with_steps.id}/ingredients/{ingredient.id}",
+            json=update_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["step_index"] == 1
+
+    def test_update_ingredient_step_index_out_of_bounds(self, client, auth_headers, test_recipe_with_steps, db_session):
+        """Test updating ingredient with out of bounds step_index returns 400."""
+        from src.db.models.recipe_ingredient import RecipeIngredient
+
+        ingredient = RecipeIngredient(
+            id=uuid4(),
+            recipe_id=test_recipe_with_steps.id,
+            ingredient_name="Test Ingredient",
+            quantity=1.0,
+            unit="cup",
+            step_index=0,
+        )
+        db_session.add(ingredient)
+        db_session.commit()
+        db_session.refresh(ingredient)
+
+        # Try to update to out of bounds step_index
+        update_data = {
+            "step_index": 10,
+        }
+
+        response = client.put(
+            f"/recipes/{test_recipe_with_steps.id}/ingredients/{ingredient.id}",
+            json=update_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 400
+        detail = response.json()["detail"]
+        assert "step_index 10 is out of bounds" in detail
+
+    def test_ad_hoc_recipe_with_step_index(self, client, auth_headers, test_user, db_session):
+        """Test creating ad-hoc recipe with step_index in inventory items."""
+        from src.db.models.inventory_item import InventoryItem
+
+        # Create inventory items
+        item1 = InventoryItem(
+            id=uuid4(),
+            name="Pasta",
+            quantity=500,
+            unit="g",
+            category="grain",
+            storage_location="pantry",
+            added_by=test_user.id,
+        )
+        item2 = InventoryItem(
+            id=uuid4(),
+            name="Tomato Sauce",
+            quantity=200,
+            unit="ml",
+            category="condiment",
+            storage_location="pantry",
+            added_by=test_user.id,
+        )
+        db_session.add_all([item1, item2])
+        db_session.commit()
+
+        recipe_data = {
+            "name": "Quick Pasta",
+            "steps": ["Boil pasta", "Heat sauce", "Mix together"],
+            "inventory_items": [
+                {
+                    "inventory_item_id": str(item1.id),
+                    "quantity_used": 200,
+                    "unit": "g",
+                    "step_index": 0,  # For "Boil pasta" step
+                },
+                {
+                    "inventory_item_id": str(item2.id),
+                    "quantity_used": 100,
+                    "unit": "ml",
+                    "step_index": 1,  # For "Heat sauce" step
+                },
+            ],
+            "decrement_inventory": False,
+        }
+
+        response = client.post("/recipes/ad-hoc", json=recipe_data, headers=auth_headers)
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["name"] == "Quick Pasta"
+        assert data["source_type"] == "ad_hoc"
+
+        # Verify ingredients were created with step_index
+        recipe_id = UUID(data["id"])
+        from src.db.models.recipe_ingredient import RecipeIngredient
+        ingredients = db_session.query(RecipeIngredient).filter(
+            RecipeIngredient.recipe_id == recipe_id
+        ).all()
+
+        assert len(ingredients) == 2
+        # Check that step_index values were preserved
+        step_indices = {ing.ingredient_name: ing.step_index for ing in ingredients}
+        assert step_indices["Pasta"] == 0
+        assert step_indices["Tomato Sauce"] == 1
+
+    def test_ad_hoc_recipe_with_step_index_out_of_bounds(self, client, auth_headers, test_user, db_session):
+        """Test creating ad-hoc recipe with out of bounds step_index returns 400."""
+        from src.db.models.inventory_item import InventoryItem
+
+        item = InventoryItem(
+            id=uuid4(),
+            name="Test Item",
+            quantity=100,
+            unit="g",
+            category="other",
+            storage_location="pantry",
+            added_by=test_user.id,
+        )
+        db_session.add(item)
+        db_session.commit()
+
+        recipe_data = {
+            "name": "Invalid Recipe",
+            "steps": ["Step 1"],
+            "inventory_items": [
+                {
+                    "inventory_item_id": str(item.id),
+                    "quantity_used": 50,
+                    "unit": "g",
+                    "step_index": 5,  # Out of bounds - recipe has only 1 step
+                },
+            ],
+            "decrement_inventory": False,
+        }
+
+        response = client.post("/recipes/ad-hoc", json=recipe_data, headers=auth_headers)
+
+        assert response.status_code == 400
+        detail = response.json()["detail"]
+        assert "step_index 5 is out of bounds" in detail
+        assert "Recipe has 1 steps" in detail

--- a/tests/routers/test_recipes.py
+++ b/tests/routers/test_recipes.py
@@ -2715,4 +2715,4 @@ class TestRecipeIngredientStepIndex:
         assert response.status_code == 400
         detail = response.json()["detail"]
         assert "step_index 5 is out of bounds" in detail
-        assert "Recipe has 1 steps" in detail
+        assert "Recipe has 1 step" in detail


### PR DESCRIPTION
## Work in Progress

Closes #235

Add step_index to RecipeIngredient model

**Time Estimate**: 1hr

**Description**:
Add an optional `step_index` field to `RecipeIngredient` that maps an ingredient to a step in the parent recipe's `steps` JSON array. This supports the frontend displaying ingredients inline with their associated cooking step rather than as a flat list. The field is a 0-based integer referencing an index in `Recipe.steps` (a JSON array of strings). Nullable for backwards compatibility — existing recipes and imports won't have step mappings.

**Claude Context**:
Files to Read:
- src/db/models/recipe_ingredient.py (RecipeIngredient model — add step_index field)
- src/schemas/recipe.py (RecipeIngredientCreate line 189, RecipeIngredientUpdate line 218, RecipeIngredientResponse line 249, InventoryItemUsage line 302, AdHocRecipeCreate line 319)
- src/routers/recipes.py (add_recipe_ingredient and update_recipe_ingredient endpoints — add cross-field validation)
- src/db/models/recipe.py (Recipe model — steps field is JSON array of strings)

Files to Modify:
- src/db/models/recipe_ingredient.py (add step_index column)
- src/schemas/recipe.py (add step_index to RecipeIngredientCreate, RecipeIngredientUpdate, RecipeIngredientResponse, InventoryItemUsage)
- src/routers/recipes.py (add step_index bounds validation in add/update ingredient endpoints, pass through step_index in ad-hoc recipe creation)
- alembic/ (generate migration for new column)
- tests/routers/test_recipes.py (add step_index test cases)

**Acceptance Criteria**:
- [ ] `RecipeIngredient` model has `step_index: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)`: verify column exists
- [ ] Alembic migration adds `step_index` column to `recipe_ingredients` table using `batch_alter_table` for SQLite compatibility: `alembic upgrade head` succeeds
- [ ] `RecipeIngredientCreate` has `step_index: Optional[int] = Field(default=None, ge=0, description="Step index this ingredient is associated with")`: verify via test
- [ ] `RecipeIngredientUpdate` has same optional step_index field: verify via test
- [ ] `RecipeIngredientResponse` includes `step_index: Optional[int]`: verify in response JSON
- [ ] `InventoryItemUsage` has `step_index: Optional[int] = Field(default=None, ge=0)`: verify ad-hoc recipe creation passes it through
- [ ] Router validates `step_index < len(recipe.steps)` when step_index is provided on add/update ingredient: returns 400 with clear error message if out of bounds
- [ ] Creating ingredient with `step_index=0` succeeds: verify via test
- [ ] Creating ingredient with `step_index=None` succeeds (backwards compatible): verify via test
- [ ] Creating ingredient with `step_index=-1` returns 422: verify via test
- [ ] Creating ingredient with `step_index >= len(recipe.steps)` returns 400: verify via test
- [ ] Updating ingredient step_index works: verify via test
- [ ] Ad-hoc recipe creation passes through step_index to RecipeIngredient: verify via test
- [ ] Existing ingredient tests still pass without step_index: `pytest tests/routers/test_recipes.py -v`

**Verification Commands**:
```bash
alembic upgrade head
pytest tests/routers/test_recipes.py -v
python -c "from src.db.models.recipe_ingredient import RecipeIngredient; print('step_index' in RecipeIngredient.__table__.columns)"
```

**Done Definition**: Done when step_index column exists, migration applies cleanly, schema validation works, cross-field bounds checking is in the router, and all tests pass.

**Scope Boundary**:
- DO: Add nullable step_index to model, schemas, migration, and router validation
- DO: Use `batch_alter_table` with `render_as_batch=True` in migration for SQLite compatibility
- DO: Validate step_index >= 0 at schema level (ge=0) and step_index < len(recipe.steps) at router level
- DO: Pass step_index through in ad-hoc recipe creation from InventoryItemUsage
- DO NOT: Modify Recipe.steps JSON structure (stays as flat string array)
- DO NOT: Create a separate Steps table
- DO NOT: Make step_index required — must remain optional
- DO NOT: Add frontend code

**Dependencies**: None

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**5** files, **2** commits (+1 added, ~4 modified, -0 deleted)
- `A` alembic/versions/a1b2c3d4e5f7_add_step_index_to_recipe_ingredients.py
- `M` src/db/models/recipe_ingredient.py
- `M` src/routers/recipes.py
- `M` src/schemas/recipe.py
- `M` tests/routers/test_recipes.py

### Commits
- 9de631e feat: Add step_index to RecipeIngredient model
- 5333981 chore: initialize work on #235 Add step_index to RecipeIngredient model
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues
 Updated: #238  Updated: #238 
**From assessment on 2026-03-23T07:48:22Z:**
- Created: #238 
- Updated: none