### PR TITLE
Validation Logic Duplicated Across Three Locations

### DIFF
--- a/src/routers/recipe_helpers.py
+++ b/src/routers/recipe_helpers.py
@@ -1,10 +1,12 @@
 """
-Helper functions for recipe ownership verification.
+Helper functions for recipe ownership verification and validation.
 
-Centralizes ownership validation logic to reduce code duplication across
-recipe CRUD endpoints and maintain consistent error handling.
+Centralizes ownership validation logic and step_index validation to reduce
+code duplication across recipe CRUD endpoints and maintain consistent error
+handling.
 """
 
+from typing import Optional
 from uuid import UUID
 from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
@@ -103,3 +105,35 @@ def verify_recipe_ownership_with_system_check(
         )
 
     return recipe
+
+
+def validate_step_index(step_index: Optional[int], num_steps: int) -> None:
+    """
+    Validate that step_index is within bounds of recipe steps array.
+
+    step_index references an index in recipe.steps (0-based array).
+    Pydantic validation ensures step_index >= 0 if provided, this function
+    validates the upper bound against the actual number of steps.
+
+    Args:
+        step_index: The step index to validate (None is allowed and skips validation)
+        num_steps: The total number of steps in the recipe
+
+    Raises:
+        HTTPException(400): If step_index is out of bounds, with a descriptive
+                           error message indicating the valid range
+    """
+    if step_index is None:
+        return
+
+    if step_index >= num_steps:
+        if num_steps == 0:
+            detail_msg = f"step_index {step_index} is out of bounds. Recipe has 0 steps"
+        elif num_steps == 1:
+            detail_msg = f"step_index {step_index} is out of bounds. Recipe has 1 step (index 0)"
+        else:
+            detail_msg = f"step_index {step_index} is out of bounds. Recipe has {num_steps} steps (indices 0-{num_steps-1})"
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=detail_msg
+        )

--- a/src/routers/recipes.py
+++ b/src/routers/recipes.py
@@ -42,6 +42,7 @@ from src.middleware.auth import get_current_user
 from src.routers.recipe_helpers import (
     verify_recipe_ownership,
     verify_recipe_ownership_with_system_check,
+    validate_step_index,
 )
 
 logger = logging.getLogger(__name__)
@@ -223,21 +224,7 @@ def create_ad_hoc_recipe(
             inventory_item = inventory_map[item_usage.inventory_item_id]
 
             # Validate step_index bounds if provided
-            # step_index references an index in recipe.steps (0-based array)
-            # Pydantic validation ensures step_index >= 0, here we check upper bound
-            if item_usage.step_index is not None:
-                if item_usage.step_index >= len(recipe_data.steps):
-                    num_steps = len(recipe_data.steps)
-                    if num_steps == 0:
-                        detail_msg = f"step_index {item_usage.step_index} is out of bounds. Recipe has 0 steps"
-                    elif num_steps == 1:
-                        detail_msg = f"step_index {item_usage.step_index} is out of bounds. Recipe has 1 step (index 0)"
-                    else:
-                        detail_msg = f"step_index {item_usage.step_index} is out of bounds. Recipe has {num_steps} steps (indices 0-{num_steps-1})"
-                    raise HTTPException(
-                        status_code=status.HTTP_400_BAD_REQUEST,
-                        detail=detail_msg
-                    )
+            validate_step_index(item_usage.step_index, len(recipe_data.steps))
 
             recipe_ingredient = RecipeIngredient(
                 recipe_id=new_recipe.id,
@@ -595,21 +582,7 @@ def add_recipe_ingredient(
     recipe = verify_recipe_ownership_with_system_check(recipe_id, current_user, db)
 
     # Validate step_index bounds if provided
-    # step_index references an index in recipe.steps (0-based array)
-    # Pydantic validation ensures step_index >= 0, here we check upper bound
-    if ingredient_data.step_index is not None:
-        if ingredient_data.step_index >= len(recipe.steps):
-            num_steps = len(recipe.steps)
-            if num_steps == 0:
-                detail_msg = f"step_index {ingredient_data.step_index} is out of bounds. Recipe has 0 steps"
-            elif num_steps == 1:
-                detail_msg = f"step_index {ingredient_data.step_index} is out of bounds. Recipe has 1 step (index 0)"
-            else:
-                detail_msg = f"step_index {ingredient_data.step_index} is out of bounds. Recipe has {num_steps} steps (indices 0-{num_steps-1})"
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=detail_msg
-            )
+    validate_step_index(ingredient_data.step_index, len(recipe.steps))
 
     # Create new ingredient
     ingredient_dict = ingredient_data.model_dump()
@@ -699,21 +672,7 @@ def update_recipe_ingredient(
         )
 
     # Validate step_index bounds if provided
-    # step_index references an index in recipe.steps (0-based array)
-    # Pydantic validation ensures step_index >= 0, here we check upper bound
-    if update_data.step_index is not None:
-        if update_data.step_index >= len(recipe.steps):
-            num_steps = len(recipe.steps)
-            if num_steps == 0:
-                detail_msg = f"step_index {update_data.step_index} is out of bounds. Recipe has 0 steps"
-            elif num_steps == 1:
-                detail_msg = f"step_index {update_data.step_index} is out of bounds. Recipe has 1 step (index 0)"
-            else:
-                detail_msg = f"step_index {update_data.step_index} is out of bounds. Recipe has {num_steps} steps (indices 0-{num_steps-1})"
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=detail_msg
-            )
+    validate_step_index(update_data.step_index, len(recipe.steps))
 
     # Update only the fields that were provided
     update_dict = update_data.model_dump(exclude_unset=True)

--- a/tests/routers/test_recipe_helpers.py
+++ b/tests/routers/test_recipe_helpers.py
@@ -4,7 +4,8 @@ Unit tests for recipe_helpers module.
 Tests cover:
 - verify_recipe_ownership: Basic ownership verification
 - verify_recipe_ownership_with_system_check: Enhanced verification with system recipe protection
-- Error cases: missing recipes, wrong owner, system recipes
+- validate_step_index: Step index validation for recipe ingredients
+- Error cases: missing recipes, wrong owner, system recipes, invalid step indices
 - Security: prevents leaking recipe existence through different error codes
 """
 
@@ -22,6 +23,7 @@ from src.services.auth_service import hash_password
 from src.routers.recipe_helpers import (
     verify_recipe_ownership,
     verify_recipe_ownership_with_system_check,
+    validate_step_index,
 )
 
 
@@ -336,3 +338,78 @@ class TestSecurityConsistency:
             verify_recipe_ownership_with_system_check(system_recipe.id, test_user, db_session)
         assert exc_info_2.value.status_code == 403
         assert exc_info_2.value.detail == "Cannot modify system recipes"
+
+
+class TestValidateStepIndex:
+    """Test validate_step_index function."""
+
+    def test_validate_step_index_none(self):
+        """Test that None step_index is allowed (skips validation)."""
+        # Should not raise exception
+        validate_step_index(None, 5)
+        validate_step_index(None, 0)
+        validate_step_index(None, 100)
+
+    def test_validate_step_index_valid_zero(self):
+        """Test that step_index 0 is valid when recipe has steps."""
+        # Should not raise exception
+        validate_step_index(0, 1)
+        validate_step_index(0, 5)
+        validate_step_index(0, 100)
+
+    def test_validate_step_index_valid_middle(self):
+        """Test that step_index in middle of range is valid."""
+        # Should not raise exception
+        validate_step_index(2, 5)
+        validate_step_index(5, 10)
+        validate_step_index(50, 100)
+
+    def test_validate_step_index_valid_last(self):
+        """Test that step_index at last valid index is valid."""
+        # Should not raise exception
+        validate_step_index(4, 5)  # Last index for 5 steps is 4
+        validate_step_index(9, 10)  # Last index for 10 steps is 9
+        validate_step_index(99, 100)  # Last index for 100 steps is 99
+
+    def test_validate_step_index_out_of_bounds_zero_steps(self):
+        """Test that any step_index fails when recipe has 0 steps."""
+        with pytest.raises(HTTPException) as exc_info:
+            validate_step_index(0, 0)
+
+        assert exc_info.value.status_code == 400
+        assert "step_index 0 is out of bounds. Recipe has 0 steps" in exc_info.value.detail
+
+    def test_validate_step_index_out_of_bounds_one_step(self):
+        """Test error message when recipe has 1 step."""
+        with pytest.raises(HTTPException) as exc_info:
+            validate_step_index(1, 1)
+
+        assert exc_info.value.status_code == 400
+        assert "step_index 1 is out of bounds. Recipe has 1 step (index 0)" in exc_info.value.detail
+
+    def test_validate_step_index_out_of_bounds_multiple_steps(self):
+        """Test error message when recipe has multiple steps."""
+        with pytest.raises(HTTPException) as exc_info:
+            validate_step_index(5, 5)
+
+        assert exc_info.value.status_code == 400
+        assert "step_index 5 is out of bounds. Recipe has 5 steps (indices 0-4)" in exc_info.value.detail
+
+    def test_validate_step_index_out_of_bounds_large_index(self):
+        """Test that very large step_index is rejected."""
+        with pytest.raises(HTTPException) as exc_info:
+            validate_step_index(100, 5)
+
+        assert exc_info.value.status_code == 400
+        assert "step_index 100 is out of bounds" in exc_info.value.detail
+        assert "Recipe has 5 steps (indices 0-4)" in exc_info.value.detail
+
+    def test_validate_step_index_boundary_conditions(self):
+        """Test boundary conditions for step_index validation."""
+        # Valid: exactly at boundary
+        validate_step_index(4, 5)  # Should not raise
+
+        # Invalid: one past boundary
+        with pytest.raises(HTTPException) as exc_info:
+            validate_step_index(5, 5)
+        assert exc_info.value.status_code == 400


### PR DESCRIPTION
## Work in Progress

Closes #238

Validation Logic Duplicated Across Three Locations

<!-- sharkrite-source-issue:235 -->## From PR #236 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
The duplication is real and creates maintenance burden, but the PR is functional and correct. Extracting a helper function is a refactoring task that exceeds the immediate scope of adding the step_index field.

## Context
The original issue scope specifies adding step_index validation in the router endpoints. The validation works correctly; the duplication is a follow-up improvement. Recent commit history shows a DRY violation PR was merged separately (#217), suggesting this team tracks DRY issues as separate work items.

## Defer Reason
Needs separate focused PR — refactoring to extract helper function is independent of the feature work

---
_Created by Sharkrite assessment on 2026-03-23T07:48:22Z_
_Parent PR: #236_

---

## Additional Assessment (PR #236)

**Severity:** MEDIUM
**Reasoning:** This is the same finding from the prior assessment. The only file changed since classification is `src/routers/recipes.py`, but the change was to address other review findings — the duplicated validation logic still exists in the same form across three locations. The prior decision to defer stands: the duplication is real but extracting a helper function is a refactoring task that exceeds the immediate scope.
**Context:** The original issue scope is to add the step_index field with proper validation. The validation works correctly; consolidating it is a maintainability improvement, not a functional requirement.
**Defer Reason:** Scope exceeds time budget — refactoring working code into a helper function is maintenance work, not part of the feature implementation.

_Added by Sharkrite on 2026-03-23T07:54:10Z_

---

## Additional Assessment (PR #236)

**Severity:** MEDIUM
**Reasoning:** This is the same finding from prior assessments, already classified as ACTIONABLE_LATER. The validation logic remains duplicated in three locations. The changes to `src/routers/recipes.py` since the prior classification did not address this duplication.
**Context:** Extracting a helper function is a refactoring task that exceeds the immediate scope of adding the step_index field. The code is correct and functional; this is maintainability debt.
**Defer Reason:** Scope exceeds time budget

_Added by Sharkrite on 2026-03-23T07:58:49Z_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**9** files, **2** commits (+0 added, ~7 modified, -2 deleted)
- `M` frontend/package-lock.json
- `M` frontend/package.json
- `D` frontend/postcss.config.js
- `M` frontend/src/App.tsx
- `M` frontend/src/index.css
- `D` frontend/tailwind.config.js
- `M` src/routers/recipe_helpers.py
- `M` src/routers/recipes.py
- `M` tests/routers/test_recipe_helpers.py

### Commits
- b772497 feat: Validation Logic Duplicated Across Three Locations
- f0de05c chore: initialize work on #238 Validation Logic Duplicated Across Three Locations
<!-- /sharkrite-changes-summary -->