### PR TITLE
Docker Container Security - Running as Root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python dependencies
+# Create non-root user for security
+# Using UID/GID 1000 for compatibility with common development environments
+RUN groupadd -r appuser -g 1000 && \
+    useradd -r -u 1000 -g appuser -m -s /bin/bash appuser
+
+# Install Python dependencies as root (required for system-wide packages)
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
@@ -16,6 +21,12 @@ COPY src/ ./src/
 COPY tests/ ./tests/
 COPY alembic/ ./alembic/
 COPY alembic.ini .
+
+# Set ownership of application files to non-root user
+RUN chown -R appuser:appuser /app
+
+# Switch to non-root user for running the application
+USER appuser
 
 EXPOSE 8000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
     image: node:20-alpine
     container_name: freshup-frontend
     working_dir: /app
+    # Run as node user (UID 1000) instead of root for security
+    user: "node"
     ports:
       - "5173:5173"
     volumes:


### PR DESCRIPTION
## Work in Progress

Closes #239

Docker Container Security - Running as Root

<!-- sharkrite-source-issue:218 -->## From PR #237 Assessment

**Severity:** MEDIUM
**Category:** Security

## Issue
Running containers as root is a valid security concern, but this is a development environment configuration. The issue scope focuses on establishing a working dev environment, not production hardening.

## Context
The original issue scope states "Docker compose dev service with volume mounts" - this is for local development, not production deployment. Production security hardening is a separate concern.

## Defer Reason
Scope exceeds time budget - production security hardening should be addressed when preparing for deployment, not during initial project scaffolding

---
_Created by Sharkrite assessment on 2026-03-23T07:49:17Z_
_Parent PR: #237_

---

## Additional Assessment (PR #237)

**Severity:** MEDIUM
**Reasoning:** Valid reliability improvement for container orchestration. However, the acceptance criteria only require "Docker compose includes frontend dev service with hot reload" - health checks are production hardening beyond the Phase 1 initialization scope.
**Context:** Phase 1 is about establishing a working dev environment. Health checks become important when services have dependencies or in production orchestration, which is out of scope for this initialization issue.
**Defer Reason:** Scope exceeds time budget - production hardening feature not required for basic dev environment initialization

_Added by Sharkrite on 2026-03-23T07:52:02Z_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+0 added, ~2 modified, -0 deleted)
- `M` Dockerfile
- `M` docker-compose.yml

### Commits
- 15ec676 feat: Docker Container Security - Running as Root
- a271487 chore: initialize work on #239 Docker Container Security - Running as Root
<!-- /sharkrite-changes-summary -->