### PR TITLE
Vite Dev Server Exposed on All Network Interfaces

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,12 +1,37 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { existsSync } from 'fs'
+
+/**
+ * Detects if the application is running inside a Docker container.
+ *
+ * Docker creates a .dockerenv file at the root of the filesystem.
+ * We also support an explicit DOCKER_CONTAINER env var for flexibility.
+ *
+ * @returns {boolean} true if running in Docker, false otherwise
+ */
+function isRunningInDocker(): boolean {
+  return existsSync('/.dockerenv') || process.env.DOCKER_CONTAINER === 'true'
+}
+
+/**
+ * Security: Bind to localhost by default, 0.0.0.0 only in Docker.
+ *
+ * Binding to 0.0.0.0 exposes the dev server on ALL network interfaces,
+ * which is a security risk when running locally (accessible on LAN/WiFi).
+ *
+ * - Docker: Requires 0.0.0.0 for host-to-container networking
+ * - Local dev: Use 127.0.0.1 (localhost only) to minimize attack surface
+ *
+ * Following OWASP principle: Minimize attack surface by default.
+ */
+const devServerHost = isRunningInDocker() ? '0.0.0.0' : '127.0.0.1'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
   server: {
-    // Bind to all interfaces for Docker container accessibility
-    host: '0.0.0.0',
+    host: devServerHost,
     port: 5173,
     // Fail if port is already in use (prevents silent port changes)
     strictPort: true,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,7 +11,19 @@ import { existsSync } from 'fs'
  * @returns {boolean} true if running in Docker, false otherwise
  */
 function isRunningInDocker(): boolean {
-  return existsSync('/.dockerenv') || process.env.DOCKER_CONTAINER === 'true'
+  const hasDockerEnvFile = existsSync('/.dockerenv')
+  const hasDockerEnvVar = process.env.DOCKER_CONTAINER === 'true'
+
+  // Security: Warn if DOCKER_CONTAINER is set but we're not actually in Docker
+  if (hasDockerEnvVar && !hasDockerEnvFile) {
+    console.warn(
+      '\n⚠️  WARNING: DOCKER_CONTAINER=true is set, but /.dockerenv not found.\n' +
+      '   This will expose the dev server on ALL network interfaces (0.0.0.0).\n' +
+      '   If you are not running in Docker, remove this environment variable.\n'
+    )
+  }
+
+  return hasDockerEnvFile || hasDockerEnvVar
 }
 
 /**

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,7 +6,8 @@ import { existsSync } from 'fs'
  * Detects if the application is running inside a Docker container.
  *
  * Docker creates a .dockerenv file at the root of the filesystem.
- * We also support an explicit DOCKER_CONTAINER env var for flexibility.
+ * We prioritize this definitive check over environment variables to prevent
+ * accidental exposure via stale .env files.
  *
  * @returns {boolean} true if running in Docker, false otherwise
  */
@@ -14,16 +15,19 @@ function isRunningInDocker(): boolean {
   const hasDockerEnvFile = existsSync('/.dockerenv')
   const hasDockerEnvVar = process.env.DOCKER_CONTAINER === 'true'
 
-  // Security: Warn if DOCKER_CONTAINER is set but we're not actually in Docker
+  // Security: Only trust DOCKER_CONTAINER env var if it matches reality
   if (hasDockerEnvVar && !hasDockerEnvFile) {
-    console.warn(
-      '\n⚠️  WARNING: DOCKER_CONTAINER=true is set, but /.dockerenv not found.\n' +
-      '   This will expose the dev server on ALL network interfaces (0.0.0.0).\n' +
-      '   If you are not running in Docker, remove this environment variable.\n'
+    console.error(
+      '\n❌ ERROR: DOCKER_CONTAINER=true is set, but /.dockerenv not found.\n' +
+      '   This appears to be a stale environment variable (possibly from .env file).\n' +
+      '   For security, the dev server will bind to localhost (127.0.0.1) only.\n' +
+      '   Remove DOCKER_CONTAINER from your environment to clear this error.\n'
     )
+    // Fail safe: ignore the env var if not actually in Docker
+    return false
   }
 
-  return hasDockerEnvFile || hasDockerEnvVar
+  return hasDockerEnvFile
 }
 
 /**


### PR DESCRIPTION
## Work in Progress

Closes #240

Vite Dev Server Exposed on All Network Interfaces

<!-- sharkrite-source-issue:218 -->## From PR #237 Assessment

**Severity:** MEDIUM
**Category:** Security

## Issue
This is a real security concern - the dev server binds to 0.0.0.0 which exposes it on all network interfaces when run outside Docker. However, the current PR scope is specifically for Docker-based development, and the configuration comment explicitly documents this is for Docker container accessibility.

## Context
The issue scope focuses on establishing a working Docker dev environment. The fix requires environment detection logic which adds complexity beyond the basic initialization scope.

## Defer Reason
Scope exceeds time budget - requires adding environment detection pattern not currently in the codebase

---
_Created by Sharkrite assessment on 2026-03-23T07:52:02Z_
_Parent PR: #237_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**1** files, **2** commits (+0 added, ~1 modified, -0 deleted)
- `M` frontend/vite.config.ts

### Commits
- cd995ad feat: Vite Dev Server Exposed on All Network Interfaces
- 33f55af chore: initialize work on #240 Vite Dev Server Exposed on All Network Interfaces
<!-- /sharkrite-changes-summary -->