### PR TITLE
[Phase 1-FE] Build Recipe browse screen

### DIFF
--- a/frontend/src/components/recipe/FilterChips.tsx
+++ b/frontend/src/components/recipe/FilterChips.tsx
@@ -1,0 +1,144 @@
+import { X } from 'lucide-react'
+
+export interface RecipeFilters {
+  source_type?: string
+  tag?: string
+  max_cook_time?: number
+}
+
+interface FilterChipsProps {
+  filters: RecipeFilters
+  onFilterChange: (filters: RecipeFilters) => void
+}
+
+/**
+ * FilterChips component for recipe grid view filtering
+ *
+ * Features:
+ * - Displays active filters as removable chips
+ * - Filter dropdowns for source_type, tag, and cook_time
+ * - Each chip has X button to remove filter
+ * - Filters combine with AND logic
+ */
+export default function FilterChips({ filters, onFilterChange }: FilterChipsProps) {
+  const removeFilter = (key: keyof RecipeFilters) => {
+    const newFilters = { ...filters }
+    delete newFilters[key]
+    onFilterChange(newFilters)
+  }
+
+  const setFilter = (key: keyof RecipeFilters, value: string | number | undefined) => {
+    if (value === undefined || value === '') {
+      removeFilter(key)
+    } else {
+      onFilterChange({ ...filters, [key]: value })
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Filter dropdowns */}
+      <div className="flex flex-wrap gap-2">
+        {/* Source type filter */}
+        <select
+          value={filters.source_type || ''}
+          onChange={(e) => setFilter('source_type', e.target.value)}
+          className="px-3 py-1.5 rounded-full border border-warm-border bg-white text-xs text-text-primary focus:outline-none focus:ring-2 focus:ring-olive focus:border-transparent"
+        >
+          <option value="">All sources</option>
+          <option value="manual">My recipes</option>
+          <option value="hellofresh_card">HelloFresh</option>
+          <option value="ad_hoc">Ad-hoc</option>
+        </select>
+
+        {/* Cook time filter */}
+        <select
+          value={filters.max_cook_time || ''}
+          onChange={(e) => setFilter('max_cook_time', e.target.value ? Number(e.target.value) : undefined)}
+          className="px-3 py-1.5 rounded-full border border-warm-border bg-white text-xs text-text-primary focus:outline-none focus:ring-2 focus:ring-olive focus:border-transparent"
+        >
+          <option value="">Any time</option>
+          <option value="15">15 min or less</option>
+          <option value="30">30 min or less</option>
+          <option value="45">45 min or less</option>
+          <option value="60">1 hour or less</option>
+        </select>
+
+        {/* Tag filter */}
+        <select
+          value={filters.tag || ''}
+          onChange={(e) => setFilter('tag', e.target.value)}
+          className="px-3 py-1.5 rounded-full border border-warm-border bg-white text-xs text-text-primary focus:outline-none focus:ring-2 focus:ring-olive focus:border-transparent"
+        >
+          <option value="">All cuisines</option>
+          <option value="italian">Italian</option>
+          <option value="mexican">Mexican</option>
+          <option value="asian">Asian</option>
+          <option value="american">American</option>
+          <option value="mediterranean">Mediterranean</option>
+          <option value="indian">Indian</option>
+          <option value="thai">Thai</option>
+          <option value="vegan">Vegan</option>
+          <option value="vegetarian">Vegetarian</option>
+        </select>
+      </div>
+
+      {/* Active filter chips */}
+      {(filters.source_type || filters.tag || filters.max_cook_time) && (
+        <div className="flex flex-wrap gap-2">
+          {filters.source_type && (
+            <FilterChip
+              label={`Source: ${getSourceTypeLabel(filters.source_type)}`}
+              onRemove={() => removeFilter('source_type')}
+            />
+          )}
+          {filters.tag && (
+            <FilterChip
+              label={`Cuisine: ${filters.tag}`}
+              onRemove={() => removeFilter('tag')}
+            />
+          )}
+          {filters.max_cook_time && (
+            <FilterChip
+              label={`Max ${filters.max_cook_time} min`}
+              onRemove={() => removeFilter('max_cook_time')}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface FilterChipProps {
+  label: string
+  onRemove: () => void
+}
+
+function FilterChip({ label, onRemove }: FilterChipProps) {
+  return (
+    <div className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-olive/10 text-xs text-olive border border-olive/20">
+      <span>{label}</span>
+      <button
+        onClick={onRemove}
+        className="hover:bg-olive/20 rounded-full p-0.5 transition-colors"
+        aria-label={`Remove ${label} filter`}
+      >
+        <X size={12} />
+      </button>
+    </div>
+  )
+}
+
+function getSourceTypeLabel(sourceType: string): string {
+  switch (sourceType) {
+    case 'manual':
+      return 'My recipes'
+    case 'hellofresh_card':
+      return 'HelloFresh'
+    case 'ad_hoc':
+      return 'Ad-hoc'
+    default:
+      return sourceType
+  }
+}

--- a/frontend/src/components/recipe/RecipeCarousel.tsx
+++ b/frontend/src/components/recipe/RecipeCarousel.tsx
@@ -1,0 +1,80 @@
+import { useRecipeList, type RecipeListFilters } from '../../api'
+import RecipeCard from './RecipeCard'
+import SectionHeader from '../ui/SectionHeader'
+import { ChevronRight } from 'lucide-react'
+
+interface RecipeCarouselProps {
+  title: string
+  filters: RecipeListFilters
+  onSeeAll: () => void
+  sectionId?: string
+}
+
+/**
+ * RecipeCarousel displays a horizontal scrollable row of recipe cards
+ *
+ * Features:
+ * - Section header with olive period
+ * - "See all →" link on right
+ * - Horizontal scroll of RecipeCard components in carousel variant
+ * - Last visible card has opacity 0.7 to hint scrollability
+ * - Loading and error states
+ * - Empty state when no recipes match filters
+ */
+export default function RecipeCarousel({ title, filters, onSeeAll, sectionId }: RecipeCarouselProps) {
+  const { data: recipes, isLoading, isError, error } = useRecipeList(filters)
+
+  return (
+    <section id={sectionId} className="scroll-mt-24">
+      {/* Header with title and "See all" link */}
+      <div className="flex items-center justify-between mb-3">
+        <SectionHeader>{title}</SectionHeader>
+        <button
+          onClick={onSeeAll}
+          className="flex items-center gap-1 text-sm text-olive hover:text-olive/80 transition-colors font-medium"
+          aria-label={`See all ${title.toLowerCase()}`}
+        >
+          See all
+          <ChevronRight size={16} />
+        </button>
+      </div>
+
+      {/* Content */}
+      <div>
+        {isLoading && (
+          <p className="text-sm text-text-secondary">Loading recipes...</p>
+        )}
+
+        {isError && (
+          <div className="px-4 py-3 bg-red-50 border border-red-200 rounded-md text-sm text-red-800">
+            Failed to load recipes.{' '}
+            {error instanceof Error ? error.message : 'Please try again.'}
+          </div>
+        )}
+
+        {!isLoading && !isError && recipes && recipes.length === 0 && (
+          <p className="text-sm text-text-secondary">
+            No recipes found for this category.
+          </p>
+        )}
+
+        {!isLoading && !isError && recipes && recipes.length > 0 && (
+          <div
+            className="flex gap-3 overflow-x-auto pb-2 -mx-4 px-4 scrollbar-hide"
+            role="list"
+            aria-label={`${title} carousel`}
+          >
+            {recipes.map((recipe, index) => (
+              <RecipeCard
+                key={recipe.id}
+                recipe={recipe}
+                variant="carousel"
+                isLastVisible={index === recipes.length - 1}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/recipe/RecipeGrid.tsx
+++ b/frontend/src/components/recipe/RecipeGrid.tsx
@@ -1,0 +1,94 @@
+import { useRecipeList, type RecipeListFilters } from '../../api'
+import RecipeCard from './RecipeCard'
+import FilterChips, { type RecipeFilters } from './FilterChips'
+import { ArrowLeft } from 'lucide-react'
+
+interface RecipeGridProps {
+  searchQuery: string
+  filters: RecipeFilters
+  onFilterChange: (filters: RecipeFilters) => void
+  onBack: () => void
+}
+
+/**
+ * RecipeGrid displays recipes in a 2-column grid layout
+ *
+ * Features:
+ * - Back button to return to carousel view
+ * - FilterChips for source_type, tag, and cook_time
+ * - 2-column responsive grid
+ * - RecipeCard components in grid variant
+ * - Loading, error, and empty states
+ * - Combines search query with filters
+ */
+export default function RecipeGrid({ searchQuery, filters, onFilterChange, onBack }: RecipeGridProps) {
+  // Combine search query and filters for API request
+  const apiFilters: RecipeListFilters = {
+    limit: 50,
+    search: searchQuery || undefined,
+    source_type: filters.source_type,
+    tag: filters.tag,
+    max_cook_time: filters.max_cook_time,
+  }
+
+  const { data: recipes, isLoading, isError, error } = useRecipeList(apiFilters)
+
+  return (
+    <div className="space-y-4">
+      {/* Back button */}
+      <button
+        onClick={onBack}
+        className="flex items-center gap-2 text-sm text-text-secondary hover:text-text-primary transition-colors"
+        aria-label="Back to browse view"
+      >
+        <ArrowLeft size={16} />
+        Back to browse
+      </button>
+
+      {/* Filter chips */}
+      <FilterChips filters={filters} onFilterChange={onFilterChange} />
+
+      {/* Results count */}
+      {!isLoading && !isError && recipes && (
+        <p className="text-sm text-text-secondary">
+          {recipes.length} {recipes.length === 1 ? 'recipe' : 'recipes'} found
+        </p>
+      )}
+
+      {/* Grid content */}
+      <div>
+        {isLoading && (
+          <p className="text-sm text-text-secondary">Loading recipes...</p>
+        )}
+
+        {isError && (
+          <div className="px-4 py-3 bg-red-50 border border-red-200 rounded-md text-sm text-red-800">
+            Failed to load recipes.{' '}
+            {error instanceof Error ? error.message : 'Please try again.'}
+          </div>
+        )}
+
+        {!isLoading && !isError && recipes && recipes.length === 0 && (
+          <div className="text-center py-12">
+            <p className="text-text-secondary mb-2">No recipes found</p>
+            <p className="text-sm text-text-tertiary">
+              Try adjusting your search or filters
+            </p>
+          </div>
+        )}
+
+        {!isLoading && !isError && recipes && recipes.length > 0 && (
+          <div className="grid grid-cols-2 gap-3">
+            {recipes.map((recipe) => (
+              <RecipeCard
+                key={recipe.id}
+                recipe={recipe}
+                variant="grid"
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/recipe/RecipeGrid.tsx
+++ b/frontend/src/components/recipe/RecipeGrid.tsx
@@ -50,7 +50,7 @@ export default function RecipeGrid({ searchQuery, filters, onFilterChange, onBac
 
       {/* Results count */}
       {!isLoading && !isError && recipes && (
-        <p className="text-sm text-text-secondary">
+        <p className="text-sm text-text-secondary" aria-live="polite">
           {recipes.length} {recipes.length === 1 ? 'recipe' : 'recipes'} found
         </p>
       )}

--- a/frontend/src/components/recipe/SearchBar.tsx
+++ b/frontend/src/components/recipe/SearchBar.tsx
@@ -1,0 +1,48 @@
+import { Search, X } from 'lucide-react'
+
+interface SearchBarProps {
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+}
+
+/**
+ * SearchBar component for recipe search
+ *
+ * Features:
+ * - Search icon on left
+ * - Clear button (X) on right when text is present
+ * - Auto-triggers grid view when user types
+ * - Returns to carousel view when cleared
+ */
+export default function SearchBar({ value, onChange, placeholder = 'Search recipes...' }: SearchBarProps) {
+  return (
+    <div className="relative">
+      {/* Search icon */}
+      <Search
+        size={18}
+        className="absolute left-3 top-1/2 -translate-y-1/2 text-text-tertiary"
+      />
+
+      {/* Input field */}
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="w-full pl-10 pr-10 py-2.5 rounded-lg border border-warm-border bg-white text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-olive focus:border-transparent"
+      />
+
+      {/* Clear button */}
+      {value && (
+        <button
+          onClick={() => onChange('')}
+          className="absolute right-3 top-1/2 -translate-y-1/2 p-1 hover:bg-warm-gray rounded-full transition-colors"
+          aria-label="Clear search"
+        >
+          <X size={16} className="text-text-tertiary" />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/recipe/SearchBar.tsx
+++ b/frontend/src/components/recipe/SearchBar.tsx
@@ -1,9 +1,11 @@
 import { Search, X } from 'lucide-react'
+import { useState, useEffect } from 'react'
 
 interface SearchBarProps {
   value: string
   onChange: (value: string) => void
   placeholder?: string
+  debounceMs?: number
 }
 
 /**
@@ -14,8 +16,32 @@ interface SearchBarProps {
  * - Clear button (X) on right when text is present
  * - Auto-triggers grid view when user types
  * - Returns to carousel view when cleared
+ * - Debounced input to prevent excessive updates
  */
-export default function SearchBar({ value, onChange, placeholder = 'Search recipes...' }: SearchBarProps) {
+export default function SearchBar({ value, onChange, placeholder = 'Search recipes...', debounceMs = 300 }: SearchBarProps) {
+  const [localValue, setLocalValue] = useState(value)
+
+  // Sync local value with prop value when it changes externally (e.g., clear button from parent)
+  useEffect(() => {
+    setLocalValue(value)
+  }, [value])
+
+  // Debounce the onChange callback
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (localValue !== value) {
+        onChange(localValue)
+      }
+    }, debounceMs)
+
+    return () => clearTimeout(timer)
+  }, [localValue, debounceMs, onChange, value])
+
+  const handleClear = () => {
+    setLocalValue('')
+    onChange('')
+  }
+
   return (
     <div className="relative">
       {/* Search icon */}
@@ -27,16 +53,16 @@ export default function SearchBar({ value, onChange, placeholder = 'Search recip
       {/* Input field */}
       <input
         type="text"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
+        value={localValue}
+        onChange={(e) => setLocalValue(e.target.value)}
         placeholder={placeholder}
         className="w-full pl-10 pr-10 py-2.5 rounded-lg border border-warm-border bg-white text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-olive focus:border-transparent"
       />
 
       {/* Clear button */}
-      {value && (
+      {localValue && (
         <button
-          onClick={() => onChange('')}
+          onClick={handleClear}
           className="absolute right-3 top-1/2 -translate-y-1/2 p-1 hover:bg-warm-gray rounded-full transition-colors"
           aria-label="Clear search"
         >

--- a/frontend/src/components/recipe/SectionNav.tsx
+++ b/frontend/src/components/recipe/SectionNav.tsx
@@ -1,0 +1,45 @@
+interface SectionNavProps {
+  sections: Array<{ id: string; label: string }>
+}
+
+/**
+ * SectionNav displays a sticky horizontal navigation bar
+ *
+ * Features:
+ * - Sticky positioning below search bar
+ * - Horizontal scroll for navigation links
+ * - Smooth scroll to section when clicked
+ * - Active section highlighting (future enhancement)
+ */
+export default function SectionNav({ sections }: SectionNavProps) {
+  const scrollToSection = (sectionId: string) => {
+    const element = document.getElementById(sectionId)
+    if (element) {
+      // Scroll with offset to account for sticky nav
+      const offset = 120 // Account for nav height + padding
+      const elementPosition = element.getBoundingClientRect().top
+      const offsetPosition = elementPosition + window.scrollY - offset
+
+      window.scrollTo({
+        top: offsetPosition,
+        behavior: 'smooth',
+      })
+    }
+  }
+
+  return (
+    <nav className="sticky top-0 z-10 bg-cream-light border-b border-warm-border py-2 -mx-4 px-4">
+      <div className="flex gap-3 overflow-x-auto scrollbar-hide">
+        {sections.map((section) => (
+          <button
+            key={section.id}
+            onClick={() => scrollToSection(section.id)}
+            className="flex-shrink-0 px-3 py-1.5 text-sm text-text-secondary hover:text-text-primary hover:bg-warm-gray rounded-md transition-colors whitespace-nowrap"
+          >
+            {section.label}
+          </button>
+        ))}
+      </div>
+    </nav>
+  )
+}

--- a/frontend/src/pages/Recipes.tsx
+++ b/frontend/src/pages/Recipes.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
 import PageContainer from '../components/layout/PageContainer'
 import PageTitle from '../components/ui/PageTitle'
 import SearchBar from '../components/recipe/SearchBar'
@@ -38,7 +38,7 @@ export default function Recipes() {
   ]
 
   // Handle search input - transition to grid view when typing
-  const handleSearchChange = (value: string) => {
+  const handleSearchChange = useCallback((value: string) => {
     setSearchQuery(value)
     if (value) {
       setViewMode('grid')
@@ -46,11 +46,16 @@ export default function Recipes() {
       // Return to carousel if search is cleared and no filters active
       setViewMode('carousel')
     }
-  }
+  }, [filters])
 
   // Handle "See all" button - transition to grid with filter
-  const handleSeeAll = (sectionFilters: RecipeFilters) => {
-    setFilters(sectionFilters)
+  const handleSeeAll = (sectionFilters: { limit?: number; max_cook_time?: number; tag?: string }) => {
+    // Extract only RecipeFilters properties (exclude limit which is for carousel only)
+    const { max_cook_time, tag } = sectionFilters
+    const gridFilters: RecipeFilters = {}
+    if (max_cook_time !== undefined) gridFilters.max_cook_time = max_cook_time
+    if (tag !== undefined) gridFilters.tag = tag
+    setFilters(gridFilters)
     setViewMode('grid')
   }
 
@@ -85,7 +90,7 @@ export default function Recipes() {
                   key={section.id}
                   title={section.label}
                   filters={section.filters}
-                  onSeeAll={() => handleSeeAll(section.filters as RecipeFilters)}
+                  onSeeAll={() => handleSeeAll(section.filters)}
                   sectionId={section.id}
                 />
               ))}

--- a/frontend/src/pages/Recipes.tsx
+++ b/frontend/src/pages/Recipes.tsx
@@ -49,7 +49,7 @@ export default function Recipes() {
   }, [filters])
 
   // Handle "See all" button - transition to grid with filter
-  const handleSeeAll = (sectionFilters: { limit?: number; max_cook_time?: number; tag?: string }) => {
+  const handleSeeAll = useCallback((sectionFilters: { limit?: number; max_cook_time?: number; tag?: string }) => {
     // Extract only RecipeFilters properties (exclude limit which is for carousel only)
     const { max_cook_time, tag } = sectionFilters
     const gridFilters: RecipeFilters = {}
@@ -57,7 +57,7 @@ export default function Recipes() {
     if (tag !== undefined) gridFilters.tag = tag
     setFilters(gridFilters)
     setViewMode('grid')
-  }
+  }, [])
 
   // Handle back button - return to carousel view
   const handleBack = () => {

--- a/frontend/src/pages/Recipes.tsx
+++ b/frontend/src/pages/Recipes.tsx
@@ -1,19 +1,107 @@
+import { useState } from 'react'
 import PageContainer from '../components/layout/PageContainer'
+import PageTitle from '../components/ui/PageTitle'
+import SearchBar from '../components/recipe/SearchBar'
+import SectionNav from '../components/recipe/SectionNav'
+import RecipeCarousel from '../components/recipe/RecipeCarousel'
+import RecipeGrid from '../components/recipe/RecipeGrid'
+import type { RecipeFilters } from '../components/recipe/FilterChips'
 
+/**
+ * Recipes page - Primary recipe discovery interface
+ *
+ * View Modes:
+ * - Carousel view (default): Multiple horizontal carousels by category
+ * - Grid view: 2-column grid with search and filters
+ *
+ * Features:
+ * - Search bar transitions to grid view on input
+ * - Sticky section navigation in carousel view
+ * - "See all" links transition to filtered grid view
+ * - Back button returns to carousel view
+ * - Recipe cards navigate to /recipes/:id
+ */
 export default function Recipes() {
+  const [viewMode, setViewMode] = useState<'carousel' | 'grid'>('carousel')
+  const [searchQuery, setSearchQuery] = useState('')
+  const [filters, setFilters] = useState<RecipeFilters>({})
+
+  // Define carousel sections
+  const sections = [
+    { id: 'favorites', label: 'Your favorites', filters: { limit: 10 } },
+    { id: 'quick-meals', label: 'Quick meals', filters: { limit: 10, max_cook_time: 30 } },
+    { id: 'recently-added', label: 'Recently added', filters: { limit: 10 } },
+    { id: 'italian', label: 'Italian', filters: { limit: 10, tag: 'italian' } },
+    { id: 'mexican', label: 'Mexican', filters: { limit: 10, tag: 'mexican' } },
+    { id: 'asian', label: 'Asian', filters: { limit: 10, tag: 'asian' } },
+    { id: 'vegan', label: 'Vegan', filters: { limit: 10, tag: 'vegan' } },
+  ]
+
+  // Handle search input - transition to grid view when typing
+  const handleSearchChange = (value: string) => {
+    setSearchQuery(value)
+    if (value) {
+      setViewMode('grid')
+    } else if (!Object.keys(filters).length) {
+      // Return to carousel if search is cleared and no filters active
+      setViewMode('carousel')
+    }
+  }
+
+  // Handle "See all" button - transition to grid with filter
+  const handleSeeAll = (sectionFilters: RecipeFilters) => {
+    setFilters(sectionFilters)
+    setViewMode('grid')
+  }
+
+  // Handle back button - return to carousel view
+  const handleBack = () => {
+    setViewMode('carousel')
+    setSearchQuery('')
+    setFilters({})
+  }
+
   return (
     <PageContainer>
-      <div className="py-8">
-        <h1 className="text-4xl font-bold text-text-primary mb-4">Recipes</h1>
-        <p className="text-text-secondary mb-6">
-          Browse and manage your recipe collection
-        </p>
+      <div className="py-6 space-y-4">
+        {/* Page title */}
+        <PageTitle>Recipes</PageTitle>
 
-        <div className="bg-cream-dark rounded-card border border-warm-border p-6">
-          <p className="text-text-secondary">
-            Recipe browsing, filtering, and management features coming soon.
-          </p>
-        </div>
+        {/* Search bar */}
+        <SearchBar value={searchQuery} onChange={handleSearchChange} />
+
+        {/* Carousel view */}
+        {viewMode === 'carousel' && (
+          <>
+            {/* Section navigation */}
+            <SectionNav
+              sections={sections.map((s) => ({ id: s.id, label: s.label }))}
+            />
+
+            {/* Carousels */}
+            <div className="space-y-6">
+              {sections.map((section) => (
+                <RecipeCarousel
+                  key={section.id}
+                  title={section.label}
+                  filters={section.filters}
+                  onSeeAll={() => handleSeeAll(section.filters as RecipeFilters)}
+                  sectionId={section.id}
+                />
+              ))}
+            </div>
+          </>
+        )}
+
+        {/* Grid view */}
+        {viewMode === 'grid' && (
+          <RecipeGrid
+            searchQuery={searchQuery}
+            filters={filters}
+            onFilterChange={setFilters}
+            onBack={handleBack}
+          />
+        )}
       </div>
     </PageContainer>
   )


### PR DESCRIPTION
## Work in Progress

Closes #229

[Phase 1-FE] Build Recipe browse screen

**Time Estimate**: 2hr

**Description**:
Build the Recipe browse screen with Spotify-style carousels, sticky section nav, search bar, and transition to filtered grid view. This is the primary recipe discovery interface.

**Claude Context**:
Files to Read:
- docs/FreshUp-Design-System.md (Section 5.7 - Carousel Section, Section 6 - Recipe Browse → Grid Transition)
- src/routers/recipes.py (list endpoint filters: source_type, tag, cook_time, has_variation)

Files to Modify:
- frontend/src/pages/Recipes.tsx (update from placeholder)
- frontend/src/components/recipe/RecipeCarousel.tsx (create)
- frontend/src/components/recipe/SectionNav.tsx (create - sticky horizontal scroll)
- frontend/src/components/recipe/RecipeGrid.tsx (create)
- frontend/src/components/recipe/SearchBar.tsx (create)
- frontend/src/components/recipe/FilterChips.tsx (create)

**Acceptance Criteria**:
- [ ] Default view: multiple carousels ("Your favorites", "Quick meals", "Recently added", cuisine categories)
- [ ] Each carousel has section header with olive period and "See all →" link
- [ ] Last card in carousel has opacity 0.7 to hint scrollability
- [ ] SectionNav: sticky bar below search, horizontal scroll, taps smooth-scroll to section
- [ ] SearchBar: search input transitions view to grid mode
- [ ] "See all" transitions to filtered grid view with back navigation
- [ ] Grid view: 2-column layout with FilterChips for source_type, cook_time, tag
- [ ] Back button returns to carousel view
- [ ] Recipe cards navigate to /recipes/:id on click

**Verification Commands**:
```bash
cd frontend && npm run dev &
# Manual: browse carousels, search, tap "See all", verify grid
```

**Done Definition**: Done when recipe browse shows carousels with real data, search transitions to grid, and "See all" applies the correct filter.

**Scope Boundary**:
- DO: Carousel view with multiple sections
- DO: Grid view with filters
- DO: Search with grid transition
- DO: SectionNav sticky scroll
- DO NOT: "Show what I can make now" toggle (Phase 3A - requires ingredient availability)
- DO NOT: Sort dropdown (Phase 2 nice-to-have)

**Dependencies**: After "[Phase 1-FE] Build RecipeCard component", After "[Phase 1-FE] Implement authentication flow"

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**6** files, **2** commits (+5 added, ~1 modified, -0 deleted)
- `A` frontend/src/components/recipe/FilterChips.tsx
- `A` frontend/src/components/recipe/RecipeCarousel.tsx
- `A` frontend/src/components/recipe/RecipeGrid.tsx
- `A` frontend/src/components/recipe/SearchBar.tsx
- `A` frontend/src/components/recipe/SectionNav.tsx
- `M` frontend/src/pages/Recipes.tsx

### Commits
- 0456d89 feat: [Phase 1-FE] Build Recipe browse screen
- fc7f7a9 chore: initialize work on #229 [Phase 1-FE] Build Recipe browse screen
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues
 Updated: #260  Updated: #260 
**From assessment on 2026-03-23T17:55:43Z:**
- Created: #262 #263 
- Updated: none