### PR TITLE
[Phase 1-FE] Build Recipe detail view

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -286,6 +286,7 @@ export interface RecipeResponse {
   id: string;
   name: string;
   source_type: string;
+  source_image: string | null;
   steps: string[];
   created_by: string | null;
   created_at: string;
@@ -295,6 +296,7 @@ export interface RecipeResponse {
   prep_time_minutes: number | null;
   hellofresh_card_id: string | null;
   variation_groups: Record<string, unknown> | null;
+  nutritional_info: Record<string, unknown> | null;
   ingredients: RecipeIngredientResponse[];
 }
 

--- a/frontend/src/components/recipe/ActionBar.tsx
+++ b/frontend/src/components/recipe/ActionBar.tsx
@@ -1,0 +1,53 @@
+import { Heart } from 'lucide-react'
+
+interface ActionBarProps {
+  isFavorited: boolean
+  onFavoriteToggle: () => void
+  onAddToMealPlan: () => void
+  isLoading?: boolean
+}
+
+/**
+ * ActionBar component for recipe detail actions
+ *
+ * Features:
+ * - Fixed bottom bar (mobile-friendly)
+ * - "Add to meal plan" primary button
+ * - Favorite heart toggle (filled when favorited)
+ * - Sticky positioning with shadow for visibility
+ */
+export default function ActionBar({
+  isFavorited,
+  onFavoriteToggle,
+  onAddToMealPlan,
+  isLoading = false,
+}: ActionBarProps) {
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-cream border-t border-warm-border shadow-lg z-10">
+      <div className="max-w-2xl mx-auto px-4 py-3 flex items-center gap-3">
+        {/* Add to meal plan button */}
+        <button
+          onClick={onAddToMealPlan}
+          disabled={isLoading}
+          className="flex-1 bg-olive text-cream font-medium py-3 px-4 rounded-button hover:bg-olive-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Add to meal plan
+        </button>
+
+        {/* Favorite toggle button */}
+        <button
+          onClick={onFavoriteToggle}
+          disabled={isLoading}
+          className="flex-shrink-0 p-3 rounded-button border-2 border-warm-border bg-cream hover:bg-cream-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          aria-label={isFavorited ? 'Remove from favorites' : 'Add to favorites'}
+        >
+          <Heart
+            size={24}
+            className={isFavorited ? 'fill-mocha stroke-mocha' : 'stroke-mocha'}
+            strokeWidth={2}
+          />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/recipe/CookTab.tsx
+++ b/frontend/src/components/recipe/CookTab.tsx
@@ -1,0 +1,48 @@
+import RecipeStep from './RecipeStep'
+import type { RecipeIngredientResponse } from '../../api/types'
+
+interface CookTabProps {
+  steps: string[]
+  ingredients: RecipeIngredientResponse[]
+  servingsMultiplier: number
+}
+
+/**
+ * CookTab component displays recipe cooking steps
+ *
+ * Features:
+ * - Numbered steps with olive circle indicators
+ * - Step-by-step instructions
+ * - Inline ingredient pills below each step (for ingredients with matching step_index)
+ * - Scaled ingredient quantities
+ */
+export default function CookTab({ steps, ingredients, servingsMultiplier }: CookTabProps) {
+  if (steps.length === 0) {
+    return (
+      <div className="text-center py-8 text-text-secondary">
+        No cooking steps provided for this recipe.
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      {steps.map((step, index) => {
+        const stepIndex = index
+        const stepIngredients = ingredients.filter(
+          (ing) => ing.step_index === stepIndex
+        )
+
+        return (
+          <RecipeStep
+            key={stepIndex}
+            stepNumber={stepIndex + 1}
+            instruction={step}
+            ingredients={stepIngredients}
+            servingsMultiplier={servingsMultiplier}
+          />
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/components/recipe/IngredientsTab.tsx
+++ b/frontend/src/components/recipe/IngredientsTab.tsx
@@ -1,0 +1,47 @@
+import type { RecipeIngredientResponse } from '../../api/types'
+
+interface IngredientsTabProps {
+  ingredients: RecipeIngredientResponse[]
+  servingsMultiplier: number
+}
+
+/**
+ * IngredientsTab component displays all recipe ingredients
+ *
+ * Features:
+ * - Lists all ingredients with scaled quantities
+ * - Shows quantity, unit, and ingredient name
+ * - Grouped presentation (can be enhanced with categories later)
+ * - Quantities scaled by servingsMultiplier
+ */
+export default function IngredientsTab({ ingredients, servingsMultiplier }: IngredientsTabProps) {
+  if (ingredients.length === 0) {
+    return (
+      <div className="text-center py-8 text-text-secondary">
+        No ingredients listed for this recipe.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {ingredients.map((ingredient) => {
+        const scaledQuantity = ingredient.quantity * servingsMultiplier
+
+        return (
+          <div
+            key={ingredient.id}
+            className="flex items-start gap-3 py-3 border-b border-warm-border last:border-b-0"
+          >
+            <div className="flex-shrink-0 w-20 text-sm font-medium text-text-primary">
+              {scaledQuantity} {ingredient.unit}
+            </div>
+            <div className="flex-1 text-sm text-text-primary">
+              {ingredient.ingredient_name}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/components/recipe/IngredientsTab.tsx
+++ b/frontend/src/components/recipe/IngredientsTab.tsx
@@ -6,6 +6,47 @@ interface IngredientsTabProps {
 }
 
 /**
+ * Formats a quantity for display, handling fractions and decimals appropriately
+ * - Rounds to 2 decimal places for readability
+ * - Converts common fractions to readable format (0.25 -> 1/4, 0.33 -> 1/3, etc.)
+ */
+function formatQuantity(quantity: number): string {
+  // Handle whole numbers
+  if (Number.isInteger(quantity)) {
+    return quantity.toString()
+  }
+
+  // Common fractions for cooking
+  const fractions: Record<string, string> = {
+    '0.25': '1/4',
+    '0.33': '1/3',
+    '0.5': '1/2',
+    '0.67': '2/3',
+    '0.75': '3/4',
+  }
+
+  const rounded = quantity.toFixed(2)
+
+  // Check if it matches a common fraction
+  if (fractions[rounded]) {
+    const whole = Math.floor(quantity)
+    const fraction = fractions[rounded]
+    return whole > 0 ? `${whole} ${fraction}` : fraction
+  }
+
+  // For other decimals, check if the fractional part matches a common fraction
+  const wholePart = Math.floor(quantity)
+  const fractionalPart = (quantity - wholePart).toFixed(2)
+
+  if (fractions[fractionalPart]) {
+    return `${wholePart} ${fractions[fractionalPart]}`
+  }
+
+  // Round to 2 decimal places for readability
+  return quantity.toFixed(2)
+}
+
+/**
  * IngredientsTab component displays all recipe ingredients
  *
  * Features:
@@ -27,6 +68,7 @@ export default function IngredientsTab({ ingredients, servingsMultiplier }: Ingr
     <div className="space-y-3">
       {ingredients.map((ingredient) => {
         const scaledQuantity = ingredient.quantity * servingsMultiplier
+        const formattedQuantity = formatQuantity(scaledQuantity)
 
         return (
           <div
@@ -34,7 +76,7 @@ export default function IngredientsTab({ ingredients, servingsMultiplier }: Ingr
             className="flex items-start gap-3 py-3 border-b border-warm-border last:border-b-0"
           >
             <div className="flex-shrink-0 w-20 text-sm font-medium text-text-primary">
-              {scaledQuantity} {ingredient.unit}
+              {formattedQuantity} {ingredient.unit}
             </div>
             <div className="flex-1 text-sm text-text-primary">
               {ingredient.ingredient_name}

--- a/frontend/src/components/recipe/IngredientsTab.tsx
+++ b/frontend/src/components/recipe/IngredientsTab.tsx
@@ -25,21 +25,15 @@ function formatQuantity(quantity: number): string {
     '0.75': '3/4',
   }
 
-  const rounded = quantity.toFixed(2)
-
-  // Check if it matches a common fraction
-  if (fractions[rounded]) {
-    const whole = Math.floor(quantity)
-    const fraction = fractions[rounded]
-    return whole > 0 ? `${whole} ${fraction}` : fraction
-  }
-
   // For other decimals, check if the fractional part matches a common fraction
   const wholePart = Math.floor(quantity)
-  const fractionalPart = (quantity - wholePart).toFixed(2)
+  const fractionalPart = quantity - wholePart
 
-  if (fractions[fractionalPart]) {
-    return `${wholePart} ${fractions[fractionalPart]}`
+  // Convert fractional part to string with 2 decimals, then remove trailing zeros
+  const fractionalStr = fractionalPart.toFixed(2).replace(/\.?0+$/, '')
+
+  if (fractions[fractionalStr]) {
+    return wholePart > 0 ? `${wholePart} ${fractions[fractionalStr]}` : fractions[fractionalStr]
   }
 
   // Round to 2 decimal places for readability

--- a/frontend/src/components/recipe/NutritionTab.tsx
+++ b/frontend/src/components/recipe/NutritionTab.tsx
@@ -1,0 +1,39 @@
+interface NutritionTabProps {
+  nutritionalInfo: Record<string, unknown> | null
+}
+
+/**
+ * NutritionTab component displays nutritional information
+ *
+ * Features:
+ * - Displays nutritional_info JSON if available
+ * - Shows "Not available" message if no data
+ * - Future enhancement: format nutrition data in structured layout
+ */
+export default function NutritionTab({ nutritionalInfo }: NutritionTabProps) {
+  if (!nutritionalInfo || Object.keys(nutritionalInfo).length === 0) {
+    return (
+      <div className="text-center py-8">
+        <p className="text-text-secondary">Nutritional information not available for this recipe.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {Object.entries(nutritionalInfo).map(([key, value]) => (
+        <div
+          key={key}
+          className="flex justify-between items-center py-3 border-b border-warm-border last:border-b-0"
+        >
+          <span className="text-sm font-medium text-text-primary capitalize">
+            {key.replace(/_/g, ' ')}
+          </span>
+          <span className="text-sm text-text-secondary">
+            {String(value)}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/recipe/RecipeHeader.tsx
+++ b/frontend/src/components/recipe/RecipeHeader.tsx
@@ -1,0 +1,61 @@
+import { useNavigate } from 'react-router-dom'
+import { ArrowLeft } from 'lucide-react'
+
+interface RecipeHeaderProps {
+  title: string
+  subtitle?: string
+  imageUrl?: string
+}
+
+/**
+ * RecipeHeader component for recipe detail view
+ *
+ * Features:
+ * - Back navigation button (top-left)
+ * - Recipe title (26px/500) with olive period
+ * - Subtitle below title
+ * - Hero image with 16:9 aspect ratio
+ */
+export default function RecipeHeader({ title, subtitle, imageUrl }: RecipeHeaderProps) {
+  const navigate = useNavigate()
+
+  return (
+    <div className="mb-4">
+      {/* Back button */}
+      <button
+        onClick={() => navigate(-1)}
+        className="flex items-center gap-2 mb-4 text-text-secondary hover:text-text-primary transition-colors"
+        aria-label="Go back"
+      >
+        <ArrowLeft size={20} />
+        <span className="text-sm font-medium">Back</span>
+      </button>
+
+      {/* Hero image (16:9 aspect ratio) */}
+      {imageUrl && (
+        <div className="relative w-full mb-4 rounded-card overflow-hidden bg-warm-gray" style={{ paddingBottom: '56.25%' }}>
+          <img
+            src={imageUrl}
+            alt={title}
+            className="absolute inset-0 w-full h-full object-cover"
+            onError={(e) => {
+              // Hide image on error
+              e.currentTarget.style.display = 'none'
+            }}
+          />
+        </div>
+      )}
+
+      {/* Title with olive period */}
+      <h1 className="text-[26px] font-medium text-text-primary mb-1">
+        {title}
+        <span className="text-olive">.</span>
+      </h1>
+
+      {/* Subtitle */}
+      {subtitle && (
+        <p className="text-sm text-text-secondary">{subtitle}</p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/recipe/RecipeStep.tsx
+++ b/frontend/src/components/recipe/RecipeStep.tsx
@@ -1,0 +1,56 @@
+import Pill from '../ui/Pill'
+import type { RecipeIngredientResponse } from '../../api/types'
+
+interface RecipeStepProps {
+  stepNumber: number
+  instruction: string
+  ingredients: RecipeIngredientResponse[]
+  servingsMultiplier: number
+}
+
+/**
+ * RecipeStep component for displaying cooking steps
+ *
+ * Features:
+ * - Step number in olive circle
+ * - Step instruction text
+ * - Inline ingredient pills for ingredients used in this step
+ * - Scaled ingredient quantities
+ */
+export default function RecipeStep({
+  stepNumber,
+  instruction,
+  ingredients,
+  servingsMultiplier,
+}: RecipeStepProps) {
+  return (
+    <div className="flex gap-4 mb-6">
+      {/* Step number circle */}
+      <div className="flex-shrink-0">
+        <div className="w-8 h-8 rounded-full bg-olive flex items-center justify-center">
+          <span className="text-sm font-medium text-cream">{stepNumber}</span>
+        </div>
+      </div>
+
+      {/* Step content */}
+      <div className="flex-1">
+        {/* Instruction text */}
+        <p className="text-sm text-text-primary mb-2 leading-relaxed">{instruction}</p>
+
+        {/* Inline ingredient pills */}
+        {ingredients.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {ingredients.map((ingredient) => {
+              const scaledQuantity = ingredient.quantity * servingsMultiplier
+              return (
+                <Pill key={ingredient.id} variant="default">
+                  {scaledQuantity} {ingredient.unit} {ingredient.ingredient_name}
+                </Pill>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/recipe/ServingsControl.tsx
+++ b/frontend/src/components/recipe/ServingsControl.tsx
@@ -1,0 +1,45 @@
+interface ServingsControlProps {
+  selectedServings: 2 | 4 | 6
+  onServingsChange: (servings: 2 | 4 | 6) => void
+}
+
+/**
+ * ServingsControl - Segmented control for selecting serving sizes
+ *
+ * Features:
+ * - Three options: 2, 4, 6 servings
+ * - Segmented button group styling
+ * - Active state with olive background
+ * - Scales ingredient quantities in parent component
+ */
+export default function ServingsControl({ selectedServings, onServingsChange }: ServingsControlProps) {
+  const servingsOptions: Array<2 | 4 | 6> = [2, 4, 6]
+
+  return (
+    <div className="mb-4">
+      <label className="block text-sm font-medium text-text-primary mb-2">
+        Servings
+      </label>
+      <div className="inline-flex rounded-button border border-warm-border bg-cream overflow-hidden">
+        {servingsOptions.map((servings) => (
+          <button
+            key={servings}
+            onClick={() => onServingsChange(servings)}
+            className={`
+              px-6 py-2 text-sm font-medium transition-colors
+              ${selectedServings === servings
+                ? 'bg-olive text-cream'
+                : 'bg-cream text-text-primary hover:bg-cream-dark'
+              }
+              ${servings !== servingsOptions[servingsOptions.length - 1] ? 'border-r border-warm-border' : ''}
+            `}
+            aria-label={`${servings} servings`}
+            aria-pressed={selectedServings === servings}
+          >
+            {servings}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/recipe/TabBar.tsx
+++ b/frontend/src/components/recipe/TabBar.tsx
@@ -1,0 +1,48 @@
+type TabType = 'ingredients' | 'cook' | 'nutrition'
+
+interface TabBarProps {
+  activeTab: TabType
+  onTabChange: (tab: TabType) => void
+}
+
+/**
+ * TabBar component for recipe detail navigation
+ *
+ * Features:
+ * - Three tabs: Ingredients | Cook & enjoy! | Nutrition
+ * - Active tab indicated with olive underline
+ * - Horizontal scroll on mobile if needed
+ */
+export default function TabBar({ activeTab, onTabChange }: TabBarProps) {
+  const tabs: Array<{ id: TabType; label: string }> = [
+    { id: 'ingredients', label: 'Ingredients' },
+    { id: 'cook', label: 'Cook & enjoy!' },
+    { id: 'nutrition', label: 'Nutrition' },
+  ]
+
+  return (
+    <div className="border-b border-warm-border mb-6">
+      <div className="flex gap-6 overflow-x-auto">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => onTabChange(tab.id)}
+            className={`
+              pb-3 px-1 text-sm font-medium whitespace-nowrap transition-colors
+              ${activeTab === tab.id
+                ? 'text-olive border-b-2 border-olive'
+                : 'text-text-secondary hover:text-text-primary'
+              }
+            `}
+            aria-label={tab.label}
+            aria-current={activeTab === tab.id ? 'page' : undefined}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export type { TabType }

--- a/frontend/src/pages/RecipeDetail.tsx
+++ b/frontend/src/pages/RecipeDetail.tsx
@@ -24,7 +24,7 @@ export default function RecipeDetail() {
     enabled: !!id,
   })
 
-  const { data: myRating } = useMyRecipeRating(id!, {
+  const { data: myRating, isLoading: isLoadingRating } = useMyRecipeRating(id!, {
     enabled: !!id,
     retry: false,
   })
@@ -49,6 +49,10 @@ export default function RecipeDetail() {
     } catch (error) {
       console.error('Failed to toggle favorite:', error)
       setFavoriteError('Failed to update favorite status. Please try again.')
+      // Clear error after 5 seconds
+      setTimeout(() => {
+        setFavoriteError(null)
+      }, 5000)
     }
   }
 
@@ -147,7 +151,7 @@ export default function RecipeDetail() {
           isFavorited={isFavorited}
           onFavoriteToggle={handleFavoriteToggle}
           onAddToMealPlan={handleAddToMealPlan}
-          isLoading={rateRecipeMutation.isPending}
+          isLoading={rateRecipeMutation.isPending || isLoadingRating}
         />
       </>
     </>

--- a/frontend/src/pages/RecipeDetail.tsx
+++ b/frontend/src/pages/RecipeDetail.tsx
@@ -1,23 +1,144 @@
+import { useState } from 'react'
 import { useParams } from 'react-router-dom'
 import PageContainer from '../components/layout/PageContainer'
+import RecipeHeader from '../components/recipe/RecipeHeader'
+import ServingsControl from '../components/recipe/ServingsControl'
+import TabBar, { TabType } from '../components/recipe/TabBar'
+import IngredientsTab from '../components/recipe/IngredientsTab'
+import CookTab from '../components/recipe/CookTab'
+import NutritionTab from '../components/recipe/NutritionTab'
+import ActionBar from '../components/recipe/ActionBar'
+import Pill from '../components/ui/Pill'
+import { useRecipe, useMyRecipeRating, useRateRecipe } from '../api/hooks/useRecipes'
+import { useAuth } from '../contexts/AuthContext'
 
 export default function RecipeDetail() {
   const { id } = useParams<{ id: string }>()
+  const { currentUser } = useAuth()
+
+  const [activeTab, setActiveTab] = useState<TabType>('ingredients')
+  const [selectedServings, setSelectedServings] = useState<2 | 4 | 6>(2)
+
+  const { data: recipe, isLoading: isLoadingRecipe, isError: isRecipeError } = useRecipe(id!, {
+    enabled: !!id,
+  })
+
+  const { data: myRating } = useMyRecipeRating(id!, {
+    enabled: !!id,
+    retry: false,
+  })
+
+  const rateRecipeMutation = useRateRecipe()
+
+  const handleFavoriteToggle = async () => {
+    if (!id) return
+
+    try {
+      // Toggle favorite status via rate endpoint (upsert behavior)
+      // Preserve existing rating value while toggling is_favorite
+      await rateRecipeMutation.mutateAsync({
+        recipeId: id,
+        data: {
+          rating: myRating?.rating || 0,
+          is_favorite: !myRating?.is_favorite,
+        },
+      })
+    } catch (error) {
+      console.error('Failed to toggle favorite:', error)
+    }
+  }
+
+  const handleAddToMealPlan = () => {
+    console.log('Add to meal plan clicked - Phase 2 feature')
+  }
+
+  if (isLoadingRecipe) {
+    return (
+      <PageContainer>
+        <div className="py-8 text-center text-text-secondary">
+          Loading recipe...
+        </div>
+      </PageContainer>
+    )
+  }
+
+  if (isRecipeError || !recipe) {
+    return (
+      <PageContainer>
+        <div className="py-8 text-center">
+          <p className="text-text-primary font-medium mb-2">Recipe not found</p>
+          <p className="text-text-secondary">The recipe you're looking for doesn't exist or has been removed.</p>
+        </div>
+      </PageContainer>
+    )
+  }
+
+  // Calculate servings multiplier based on base recipe (assumes 2 servings as base)
+  // Selected 2 = 1x, Selected 4 = 2x, Selected 6 = 3x
+  const servingsMultiplier = selectedServings / 2
+
+  const cookTime = recipe.cook_time_minutes
+  const prepTime = recipe.prep_time_minutes
+  const totalTime = (cookTime || 0) + (prepTime || 0)
+
+  const isFavorited = myRating?.is_favorite || false
 
   return (
-    <PageContainer>
-      <div className="py-8">
-        <h1 className="text-4xl font-bold text-text-primary mb-4">Recipe Detail</h1>
-        <p className="text-text-secondary mb-6">
-          Recipe ID: {id}
-        </p>
+    <>
+      <PageContainer>
+        <div className="pb-24">
+          <RecipeHeader
+            title={recipe.name}
+            subtitle={recipe.notes || undefined}
+            imageUrl={undefined}
+          />
 
-        <div className="bg-cream-dark rounded-card border border-warm-border p-6">
-          <p className="text-text-secondary">
-            Recipe ingredients, steps, and nutritional information will appear here.
-          </p>
+          <div className="mb-4 flex flex-wrap gap-2">
+            {isFavorited && currentUser && (
+              <Pill variant="success">In {currentUser.name}'s favs</Pill>
+            )}
+            {totalTime > 0 && (
+              <Pill variant="default">{totalTime} min</Pill>
+            )}
+            {recipe.tags.map((tag) => (
+              <Pill key={tag} variant="default">{tag}</Pill>
+            ))}
+          </div>
+
+          <ServingsControl
+            selectedServings={selectedServings}
+            onServingsChange={setSelectedServings}
+          />
+
+          <TabBar activeTab={activeTab} onTabChange={setActiveTab} />
+
+          <div>
+            {activeTab === 'ingredients' && (
+              <IngredientsTab
+                ingredients={recipe.ingredients}
+                servingsMultiplier={servingsMultiplier}
+              />
+            )}
+            {activeTab === 'cook' && (
+              <CookTab
+                steps={recipe.steps}
+                ingredients={recipe.ingredients}
+                servingsMultiplier={servingsMultiplier}
+              />
+            )}
+            {activeTab === 'nutrition' && (
+              <NutritionTab nutritionalInfo={null} />
+            )}
+          </div>
         </div>
-      </div>
-    </PageContainer>
+      </PageContainer>
+
+      <ActionBar
+        isFavorited={isFavorited}
+        onFavoriteToggle={handleFavoriteToggle}
+        onAddToMealPlan={handleAddToMealPlan}
+        isLoading={rateRecipeMutation.isPending}
+      />
+    </>
   )
 }

--- a/frontend/src/pages/RecipeDetail.tsx
+++ b/frontend/src/pages/RecipeDetail.tsx
@@ -45,11 +45,13 @@ export default function RecipeDetail() {
       })
     } catch (error) {
       console.error('Failed to toggle favorite:', error)
+      // TODO: Add toast notification or error state display for user feedback
+      alert('Failed to update favorite status. Please try again.')
     }
   }
 
   const handleAddToMealPlan = () => {
-    console.log('Add to meal plan clicked - Phase 2 feature')
+    // Phase 2 feature: Add to meal plan functionality
   }
 
   if (isLoadingRecipe) {
@@ -127,7 +129,7 @@ export default function RecipeDetail() {
               />
             )}
             {activeTab === 'nutrition' && (
-              <NutritionTab nutritionalInfo={null} />
+              <NutritionTab nutritionalInfo={recipe.nutritional_info} />
             )}
           </div>
         </div>

--- a/frontend/src/pages/RecipeDetail.tsx
+++ b/frontend/src/pages/RecipeDetail.tsx
@@ -18,6 +18,7 @@ export default function RecipeDetail() {
 
   const [activeTab, setActiveTab] = useState<TabType>('ingredients')
   const [selectedServings, setSelectedServings] = useState<2 | 4 | 6>(2)
+  const [favoriteError, setFavoriteError] = useState<string | null>(null)
 
   const { data: recipe, isLoading: isLoadingRecipe, isError: isRecipeError } = useRecipe(id!, {
     enabled: !!id,
@@ -33,6 +34,8 @@ export default function RecipeDetail() {
   const handleFavoriteToggle = async () => {
     if (!id) return
 
+    setFavoriteError(null)
+
     try {
       // Toggle favorite status via rate endpoint (upsert behavior)
       // Preserve existing rating value while toggling is_favorite
@@ -45,8 +48,7 @@ export default function RecipeDetail() {
       })
     } catch (error) {
       console.error('Failed to toggle favorite:', error)
-      // TODO: Add toast notification or error state display for user feedback
-      alert('Failed to update favorite status. Please try again.')
+      setFavoriteError('Failed to update favorite status. Please try again.')
     }
   }
 
@@ -92,7 +94,7 @@ export default function RecipeDetail() {
           <RecipeHeader
             title={recipe.name}
             subtitle={recipe.notes || undefined}
-            imageUrl={undefined}
+            imageUrl={recipe.source_image || undefined}
           />
 
           <div className="mb-4 flex flex-wrap gap-2">
@@ -135,12 +137,19 @@ export default function RecipeDetail() {
         </div>
       </PageContainer>
 
-      <ActionBar
-        isFavorited={isFavorited}
-        onFavoriteToggle={handleFavoriteToggle}
-        onAddToMealPlan={handleAddToMealPlan}
-        isLoading={rateRecipeMutation.isPending}
-      />
+      <>
+        {favoriteError && (
+          <div className="fixed bottom-20 left-4 right-4 bg-red-50 border border-red-200 rounded-lg p-3 shadow-lg z-40">
+            <p className="text-sm text-red-800">{favoriteError}</p>
+          </div>
+        )}
+        <ActionBar
+          isFavorited={isFavorited}
+          onFavoriteToggle={handleFavoriteToggle}
+          onAddToMealPlan={handleAddToMealPlan}
+          isLoading={rateRecipeMutation.isPending}
+        />
+      </>
     </>
   )
 }


### PR DESCRIPTION
## Work in Progress

Closes #230

[Phase 1-FE] Build Recipe detail view

**Time Estimate**: 2hr

**Description**:
Build the Recipe detail view with tabbed interface (Ingredients, Cook & enjoy!, Nutrition), servings selector, and action bar. Ingredients tab is the default per design decision.

**Claude Context**:
Files to Read:
- docs/FreshUp-Design-System.md (Section 5.2 - Recipe Detail View spec)
- src/routers/recipes.py (get recipe endpoint, ingredients, ratings)

Files to Modify:
- frontend/src/pages/RecipeDetail.tsx (update from placeholder)
- frontend/src/components/recipe/RecipeHeader.tsx (create)
- frontend/src/components/recipe/ServingsControl.tsx (create - segmented control)
- frontend/src/components/recipe/TabBar.tsx (create)
- frontend/src/components/recipe/IngredientsTab.tsx (create)
- frontend/src/components/recipe/CookTab.tsx (create)
- frontend/src/components/recipe/NutritionTab.tsx (create)
- frontend/src/components/recipe/RecipeStep.tsx (create - with inline ingredients)
- frontend/src/components/recipe/ActionBar.tsx (create)

**Acceptance Criteria**:
- [ ] Header: back nav, recipe title (26px/500) with olive period, subtitle, hero image
- [ ] Personalized pills: "In Sarah's favs", "Cooked 7 times" (from times_cooked), cook time, tags
- [ ] ServingsControl: 2/4/6 segmented selector, scales ingredient quantities
- [ ] TabBar: Ingredients (default) | Cook & enjoy! | Nutrition
- [ ] IngredientsTab: grouped by category, shows quantity and unit per ingredient
- [ ] CookTab: numbered steps (olive circles), inline ingredient pills below each step
- [ ] RecipeStep: step number, instruction text, ingredients with step_index shown as pills
- [ ] NutritionTab: displays nutritional_info JSON if available, "Not available" otherwise
- [ ] ActionBar: "Add to meal plan" (primary), favorite heart toggle
- [ ] Favorite toggle calls rate endpoint with is_favorite update

**Verification Commands**:
```bash
cd frontend && npm run dev &
# Manual: navigate to recipe, verify tabs, scaling, favorite toggle
```

**Done Definition**: Done when all three tabs render correctly, servings scaling works, and favorite toggle updates via API.

**Scope Boundary**:
- DO: All tabs per spec
- DO: Servings scaling (client-side math)
- DO: Favorite toggle with API
- DO NOT: "Add missing to list" button (Phase 3A - requires inventory cross-reference)
- DO NOT: "Pantry check" summary card (Phase 3A)
- DO NOT: Timer functionality in cook steps (future enhancement)

**Dependencies**: After "[Phase 1-FE] Create typography and pill components", After "[Phase 1-FE] Implement authentication flow"

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**9** files, **2** commits (+8 added, ~1 modified, -0 deleted)
- `A` frontend/src/components/recipe/ActionBar.tsx
- `A` frontend/src/components/recipe/CookTab.tsx
- `A` frontend/src/components/recipe/IngredientsTab.tsx
- `A` frontend/src/components/recipe/NutritionTab.tsx
- `A` frontend/src/components/recipe/RecipeHeader.tsx
- `A` frontend/src/components/recipe/RecipeStep.tsx
- `A` frontend/src/components/recipe/ServingsControl.tsx
- `A` frontend/src/components/recipe/TabBar.tsx
- `M` frontend/src/pages/RecipeDetail.tsx

### Commits
- ab1434f feat: [Phase 1-FE] Build Recipe detail view
- 753de53 chore: initialize work on #230 [Phase 1-FE] Build Recipe detail view
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues
Created: #267  Updated: #265  Updated: #265 
**From assessment on 2026-03-23T18:15:29Z:**
- Created: #265 
- Updated: none