### PR TITLE
Handle stale error state across mutation retries

### DIFF
--- a/frontend/src/components/grocery/GroceryItem.test.tsx
+++ b/frontend/src/components/grocery/GroceryItem.test.tsx
@@ -156,7 +156,12 @@ describe('GroceryItem', () => {
       })
       await user.click(checkbox)
 
-      expect(purchaseMutate).toHaveBeenCalledWith('item-1')
+      expect(purchaseMutate).toHaveBeenCalledWith(
+        'item-1',
+        expect.objectContaining({
+          onError: expect.any(Function),
+        })
+      )
       expect(unpurchaseMutate).not.toHaveBeenCalled()
     })
 
@@ -170,7 +175,12 @@ describe('GroceryItem', () => {
       })
       await user.click(checkbox)
 
-      expect(unpurchaseMutate).toHaveBeenCalledWith('item-1')
+      expect(unpurchaseMutate).toHaveBeenCalledWith(
+        'item-1',
+        expect.objectContaining({
+          onError: expect.any(Function),
+        })
+      )
       expect(purchaseMutate).not.toHaveBeenCalled()
     })
 
@@ -185,7 +195,12 @@ describe('GroceryItem', () => {
       checkbox.focus()
       await user.keyboard('{Enter}')
 
-      expect(purchaseMutate).toHaveBeenCalledWith('item-1')
+      expect(purchaseMutate).toHaveBeenCalledWith(
+        'item-1',
+        expect.objectContaining({
+          onError: expect.any(Function),
+        })
+      )
     })
 
     it('supports keyboard interaction with Space key', async () => {
@@ -199,59 +214,111 @@ describe('GroceryItem', () => {
       checkbox.focus()
       await user.keyboard(' ')
 
-      expect(purchaseMutate).toHaveBeenCalledWith('item-1')
+      expect(purchaseMutate).toHaveBeenCalledWith(
+        'item-1',
+        expect.objectContaining({
+          onError: expect.any(Function),
+        })
+      )
     })
   })
 
   describe('Error Handling', () => {
-    it('displays error banner when purchaseMutation fails', () => {
+    it('displays error banner when purchaseMutation fails', async () => {
+      const purchaseMutate = vi.fn((id, options) => {
+        // Simulate mutation failure by calling onError
+        if (options?.onError) {
+          options.onError()
+        }
+      })
+
       vi.mocked(usePurchaseGroceryItem).mockReturnValue({
         mutate: purchaseMutate,
-        isError: true,
+        isError: false,
         isPending: false,
       } as any)
 
       const item = createMockItem({ purchased: false })
       renderWithProviders(<GroceryItem item={item} />)
 
-      const errorBanner = screen.getByRole('alert')
-      expect(errorBanner).toBeInTheDocument()
-      expect(errorBanner).toHaveTextContent(
-        'Failed to mark item as purchased. Please try again.'
-      )
+      // Click checkbox to trigger error
+      const checkbox = screen.getByRole('button', {
+        name: /Mark Olive oil as purchased/,
+      })
+      fireEvent.click(checkbox)
+
+      // Error banner should appear
+      await waitFor(() => {
+        const errorBanner = screen.getByRole('alert')
+        expect(errorBanner).toBeInTheDocument()
+        expect(errorBanner).toHaveTextContent(
+          'Failed to mark item as purchased. Please try again.'
+        )
+      })
     })
 
-    it('displays error banner when unpurchaseMutation fails', () => {
+    it('displays error banner when unpurchaseMutation fails', async () => {
+      const unpurchaseMutate = vi.fn((id, options) => {
+        // Simulate mutation failure by calling onError
+        if (options?.onError) {
+          options.onError()
+        }
+      })
+
       vi.mocked(useUnpurchaseGroceryItem).mockReturnValue({
         mutate: unpurchaseMutate,
-        isError: true,
+        isError: false,
         isPending: false,
       } as any)
 
       const item = createMockItem({ purchased: true })
       renderWithProviders(<GroceryItem item={item} />)
 
-      const errorBanner = screen.getByRole('alert')
-      expect(errorBanner).toBeInTheDocument()
-      expect(errorBanner).toHaveTextContent(
-        'Failed to unmark item. Please try again.'
-      )
+      // Click checkbox to trigger error
+      const checkbox = screen.getByRole('button', {
+        name: /Unmark Olive oil as purchased/,
+      })
+      fireEvent.click(checkbox)
+
+      // Error banner should appear
+      await waitFor(() => {
+        const errorBanner = screen.getByRole('alert')
+        expect(errorBanner).toBeInTheDocument()
+        expect(errorBanner).toHaveTextContent(
+          'Failed to unmark item. Please try again.'
+        )
+      })
     })
 
     it('auto-dismisses error message after 5 seconds', async () => {
       vi.useFakeTimers()
 
+      const purchaseMutate = vi.fn((id, options) => {
+        // Simulate mutation failure by calling onError
+        if (options?.onError) {
+          options.onError()
+        }
+      })
+
       vi.mocked(usePurchaseGroceryItem).mockReturnValue({
         mutate: purchaseMutate,
-        isError: true,
+        isError: false,
         isPending: false,
       } as any)
 
       const item = createMockItem({ purchased: false })
       renderWithProviders(<GroceryItem item={item} />)
 
+      // Click checkbox to trigger error
+      const checkbox = screen.getByRole('button', {
+        name: /Mark Olive oil as purchased/,
+      })
+      fireEvent.click(checkbox)
+
       // Error should be visible initially
-      expect(screen.getByRole('alert')).toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument()
+      })
 
       // Fast-forward 5 seconds
       vi.advanceTimersByTime(5000)
@@ -266,28 +333,43 @@ describe('GroceryItem', () => {
 
     it('clears error when user retries the action', async () => {
       const user = userEvent.setup()
+      let shouldError = true
 
-      // Start with error state
+      const purchaseMutate = vi.fn((id, options) => {
+        // First call fails, second succeeds
+        if (shouldError && options?.onError) {
+          options.onError()
+        }
+      })
+
       vi.mocked(usePurchaseGroceryItem).mockReturnValue({
         mutate: purchaseMutate,
-        isError: true,
+        isError: false,
         isPending: false,
       } as any)
 
       const item = createMockItem({ purchased: false })
-      const { rerender } = renderWithProviders(<GroceryItem item={item} />)
+      renderWithProviders(<GroceryItem item={item} />)
 
-      // Error should be visible
-      expect(screen.getByRole('alert')).toBeInTheDocument()
-
-      // Click checkbox to retry
+      // Click checkbox to trigger first error
       const checkbox = screen.getByRole('button', {
         name: /Mark Olive oil as purchased/,
       })
       await user.click(checkbox)
 
-      // Error should be cleared (component clears error in handleCheckboxClick)
-      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+      // Error should be visible
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument()
+      })
+
+      // Next click should succeed (no error)
+      shouldError = false
+      await user.click(checkbox)
+
+      // Error should be cleared immediately (component clears error in handleCheckboxClick)
+      await waitFor(() => {
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+      })
     })
   })
 

--- a/frontend/src/components/grocery/GroceryItem.tsx
+++ b/frontend/src/components/grocery/GroceryItem.tsx
@@ -25,17 +25,6 @@ export default function GroceryItem({ item, purchaserName }: GroceryItemProps) {
   const unpurchaseMutation = useUnpurchaseGroceryItem()
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
-  // Track errors from mutations and display them to the user
-  useEffect(() => {
-    if (purchaseMutation.isError) {
-      setErrorMessage('Failed to mark item as purchased. Please try again.')
-    } else if (unpurchaseMutation.isError) {
-      setErrorMessage('Failed to unmark item. Please try again.')
-    } else {
-      setErrorMessage(null)
-    }
-  }, [purchaseMutation.isError, unpurchaseMutation.isError])
-
   // Auto-dismiss error after 5 seconds
   useEffect(() => {
     if (errorMessage) {
@@ -45,15 +34,24 @@ export default function GroceryItem({ item, purchaserName }: GroceryItemProps) {
   }, [errorMessage])
 
   const handleCheckboxClick = () => {
-    // Clear any existing error message
+    // Clear any existing error immediately when user retries to prevent stale error messages
     setErrorMessage(null)
 
-    // Mutations now use optimistic updates configured in the hooks
+    // Mutations use optimistic updates configured in the hooks
     // (see useGrocery.ts lines 200-241 for purchase, 257-286 for unpurchase)
+    // Error handling is done via onError callbacks to avoid timing issues
     if (item.purchased) {
-      unpurchaseMutation.mutate(item.id)
+      unpurchaseMutation.mutate(item.id, {
+        onError: () => {
+          setErrorMessage('Failed to unmark item. Please try again.')
+        },
+      })
     } else {
-      purchaseMutation.mutate(item.id)
+      purchaseMutation.mutate(item.id, {
+        onError: () => {
+          setErrorMessage('Failed to mark item as purchased. Please try again.')
+        },
+      })
     }
   }
 

--- a/frontend/src/components/grocery/GroceryItem.tsx
+++ b/frontend/src/components/grocery/GroceryItem.tsx
@@ -42,13 +42,15 @@ export default function GroceryItem({ item, purchaserName }: GroceryItemProps) {
     // Error handling is done via onError callbacks to avoid timing issues
     if (item.purchased) {
       unpurchaseMutation.mutate(item.id, {
-        onError: () => {
+        onError: (error) => {
+          console.error('Failed to unmark grocery item:', error)
           setErrorMessage('Failed to unmark item. Please try again.')
         },
       })
     } else {
       purchaseMutation.mutate(item.id, {
-        onError: () => {
+        onError: (error) => {
+          console.error('Failed to mark grocery item as purchased:', error)
           setErrorMessage('Failed to mark item as purchased. Please try again.')
         },
       })

--- a/frontend/src/components/inventory/InventoryRow.test.tsx
+++ b/frontend/src/components/inventory/InventoryRow.test.tsx
@@ -261,10 +261,18 @@ describe('InventoryRow', () => {
       const ateItButton = screen.getByRole('button', { name: /Ate it/i })
       await user.click(ateItButton)
 
-      expect(consumeMutate).toHaveBeenCalledWith({
-        amount: 2,
-        delete_when_empty: true,
-      })
+      expect(consumeMutate).toHaveBeenCalledWith(
+        {
+          id: item.id,
+          data: {
+            amount: 2,
+            delete_when_empty: true,
+          },
+        },
+        expect.objectContaining({
+          onError: expect.any(Function),
+        })
+      )
     })
 
     it('calls freeze endpoint when "Freeze" is clicked', async () => {
@@ -279,7 +287,12 @@ describe('InventoryRow', () => {
       const freezeButton = screen.getByRole('button', { name: /Freeze/i })
       await user.click(freezeButton)
 
-      expect(freezeMutate).toHaveBeenCalled()
+      expect(freezeMutate).toHaveBeenCalledWith(
+        item.id,
+        expect.objectContaining({
+          onError: expect.any(Function),
+        })
+      )
     })
 
     it('disables "Freeze" button when item is already in freezer', () => {
@@ -328,9 +341,17 @@ describe('InventoryRow', () => {
       })
       await user.click(storageBadge)
 
-      expect(updateMutate).toHaveBeenCalledWith({
-        storage_location: StorageLocation.FRIDGE,
-      })
+      expect(updateMutate).toHaveBeenCalledWith(
+        {
+          id: item.id,
+          data: {
+            storage_location: StorageLocation.FRIDGE,
+          },
+        },
+        expect.objectContaining({
+          onError: expect.any(Function),
+        })
+      )
     })
 
     it('cycles through storage locations in correct order', async () => {
@@ -344,9 +365,17 @@ describe('InventoryRow', () => {
       await user.click(storageBadge)
 
       // Fridge → Freezer
-      expect(updateMutate).toHaveBeenCalledWith({
-        storage_location: StorageLocation.FREEZER,
-      })
+      expect(updateMutate).toHaveBeenCalledWith(
+        {
+          id: item.id,
+          data: {
+            storage_location: StorageLocation.FREEZER,
+          },
+        },
+        expect.objectContaining({
+          onError: expect.any(Function),
+        })
+      )
     })
 
     it('disables storage badge when mutation is pending', () => {
@@ -367,65 +396,126 @@ describe('InventoryRow', () => {
   })
 
   describe('Error Handling', () => {
-    it('displays error banner when consume mutation fails', () => {
+    it('displays error banner when consume mutation fails', async () => {
+      const consumeMutate = vi.fn((variables, options) => {
+        // Simulate mutation failure by calling onError
+        if (options?.onError) {
+          options.onError()
+        }
+      })
+
       vi.mocked(useConsumeInventoryItem).mockReturnValue({
         mutate: consumeMutate,
         isPending: false,
-        isError: true,
+        isError: false,
       } as any)
 
-      const item = createMockItem()
+      const item = createMockItem({
+        expiration_date: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString(),
+      })
       renderWithProviders(<InventoryRow item={item} />)
 
-      const errorBanner = screen.getByRole('alert')
-      expect(errorBanner).toBeInTheDocument()
-      expect(errorBanner).toHaveTextContent('Failed to consume item. Please try again.')
+      // Click "Ate it" button to trigger mutation
+      const ateItButton = screen.getByRole('button', { name: /ate it/i })
+      fireEvent.click(ateItButton)
+
+      // Error banner should appear
+      await waitFor(() => {
+        const errorBanner = screen.getByRole('alert')
+        expect(errorBanner).toBeInTheDocument()
+        expect(errorBanner).toHaveTextContent('Failed to consume item. Please try again.')
+      })
     })
 
-    it('displays error banner when freeze mutation fails', () => {
+    it('displays error banner when freeze mutation fails', async () => {
+      const freezeMutate = vi.fn((variables, options) => {
+        // Simulate mutation failure by calling onError
+        if (options?.onError) {
+          options.onError()
+        }
+      })
+
       vi.mocked(useFreezeInventoryItem).mockReturnValue({
         mutate: freezeMutate,
         isPending: false,
-        isError: true,
+        isError: false,
       } as any)
 
-      const item = createMockItem()
+      const item = createMockItem({
+        expiration_date: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString(),
+      })
       renderWithProviders(<InventoryRow item={item} />)
 
-      const errorBanner = screen.getByRole('alert')
-      expect(errorBanner).toBeInTheDocument()
-      expect(errorBanner).toHaveTextContent('Failed to freeze item. Please try again.')
+      // Click "Freeze" button to trigger mutation
+      const freezeButton = screen.getByRole('button', { name: /freeze/i })
+      fireEvent.click(freezeButton)
+
+      // Error banner should appear
+      await waitFor(() => {
+        const errorBanner = screen.getByRole('alert')
+        expect(errorBanner).toBeInTheDocument()
+        expect(errorBanner).toHaveTextContent('Failed to freeze item. Please try again.')
+      })
     })
 
-    it('displays error banner when update mutation fails', () => {
+    it('displays error banner when update mutation fails', async () => {
+      const updateMutate = vi.fn((variables, options) => {
+        // Simulate mutation failure by calling onError
+        if (options?.onError) {
+          options.onError()
+        }
+      })
+
       vi.mocked(useUpdateInventoryItem).mockReturnValue({
         mutate: updateMutate,
         isPending: false,
-        isError: true,
+        isError: false,
       } as any)
 
-      const item = createMockItem()
+      const item = createMockItem({ storage_location: StorageLocation.PANTRY })
       renderWithProviders(<InventoryRow item={item} />)
 
-      const errorBanner = screen.getByRole('alert')
-      expect(errorBanner).toBeInTheDocument()
-      expect(errorBanner).toHaveTextContent('Failed to update storage. Please try again.')
+      // Click StorageBadge to trigger update mutation
+      const storageBadge = screen.getByRole('button', { name: /change storage from pantry/i })
+      fireEvent.click(storageBadge)
+
+      // Error banner should appear
+      await waitFor(() => {
+        const errorBanner = screen.getByRole('alert')
+        expect(errorBanner).toBeInTheDocument()
+        expect(errorBanner).toHaveTextContent('Failed to update storage. Please try again.')
+      })
     })
 
     it('auto-dismisses error message after 5 seconds', async () => {
       vi.useFakeTimers()
 
+      const consumeMutate = vi.fn((variables, options) => {
+        // Simulate mutation failure by calling onError
+        if (options?.onError) {
+          options.onError()
+        }
+      })
+
       vi.mocked(useConsumeInventoryItem).mockReturnValue({
         mutate: consumeMutate,
         isPending: false,
-        isError: true,
+        isError: false,
       } as any)
 
-      const item = createMockItem()
+      const item = createMockItem({
+        expiration_date: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString(),
+      })
       renderWithProviders(<InventoryRow item={item} />)
 
+      // Click "Ate it" button to trigger error
+      const ateItButton = screen.getByRole('button', { name: /ate it/i })
+      fireEvent.click(ateItButton)
+
       // Error should be visible initially
-      expect(screen.getByRole('alert')).toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument()
+      })
 
       // Fast-forward 5 seconds
       vi.advanceTimersByTime(5000)

--- a/frontend/src/components/inventory/InventoryRow.tsx
+++ b/frontend/src/components/inventory/InventoryRow.tsx
@@ -94,7 +94,8 @@ export default function InventoryRow({ item }: InventoryRowProps) {
         },
       },
       {
-        onError: () => {
+        onError: (error) => {
+          console.error('Failed to consume inventory item:', error)
           setErrorMessage('Failed to consume item. Please try again.')
         },
       }
@@ -106,7 +107,8 @@ export default function InventoryRow({ item }: InventoryRowProps) {
     // Clear any existing error immediately when user retries to prevent stale error messages
     setErrorMessage(null)
     freezeMutation.mutate(item.id, {
-      onError: () => {
+      onError: (error) => {
+        console.error('Failed to freeze inventory item:', error)
         setErrorMessage('Failed to freeze item. Please try again.')
       },
     })
@@ -124,7 +126,8 @@ export default function InventoryRow({ item }: InventoryRowProps) {
         },
       },
       {
-        onError: () => {
+        onError: (error) => {
+          console.error('Failed to update inventory item storage:', error)
           setErrorMessage('Failed to update storage. Please try again.')
         },
       }

--- a/frontend/src/components/inventory/InventoryRow.tsx
+++ b/frontend/src/components/inventory/InventoryRow.tsx
@@ -26,23 +26,10 @@ export interface InventoryRowProps {
  * - Optimistic updates with error handling
  */
 export default function InventoryRow({ item }: InventoryRowProps) {
-  const consumeMutation = useConsumeInventoryItem(item.id)
-  const freezeMutation = useFreezeInventoryItem(item.id)
-  const updateMutation = useUpdateInventoryItem(item.id)
+  const consumeMutation = useConsumeInventoryItem()
+  const freezeMutation = useFreezeInventoryItem()
+  const updateMutation = useUpdateInventoryItem()
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
-
-  // Track errors from mutations
-  useEffect(() => {
-    if (consumeMutation.isError) {
-      setErrorMessage('Failed to consume item. Please try again.')
-    } else if (freezeMutation.isError) {
-      setErrorMessage('Failed to freeze item. Please try again.')
-    } else if (updateMutation.isError) {
-      setErrorMessage('Failed to update storage. Please try again.')
-    } else {
-      setErrorMessage(null)
-    }
-  }, [consumeMutation.isError, freezeMutation.isError, updateMutation.isError])
 
   // Auto-dismiss error after 5 seconds
   useEffect(() => {
@@ -96,25 +83,52 @@ export default function InventoryRow({ item }: InventoryRowProps) {
 
   // Handle "Ate it" action
   const handleAteIt = () => {
+    // Clear any existing error immediately when user retries to prevent stale error messages
     setErrorMessage(null)
-    consumeMutation.mutate({
-      amount: item.quantity,
-      delete_when_empty: true,
-    })
+    consumeMutation.mutate(
+      {
+        id: item.id,
+        data: {
+          amount: item.quantity,
+          delete_when_empty: true,
+        },
+      },
+      {
+        onError: () => {
+          setErrorMessage('Failed to consume item. Please try again.')
+        },
+      }
+    )
   }
 
   // Handle "Freeze" action
   const handleFreeze = () => {
+    // Clear any existing error immediately when user retries to prevent stale error messages
     setErrorMessage(null)
-    freezeMutation.mutate()
+    freezeMutation.mutate(item.id, {
+      onError: () => {
+        setErrorMessage('Failed to freeze item. Please try again.')
+      },
+    })
   }
 
   // Handle storage location cycle
   const handleStorageCycle = (newLocation: StorageLocation) => {
+    // Clear any existing error immediately when user retries to prevent stale error messages
     setErrorMessage(null)
-    updateMutation.mutate({
-      storage_location: newLocation,
-    })
+    updateMutation.mutate(
+      {
+        id: item.id,
+        data: {
+          storage_location: newLocation,
+        },
+      },
+      {
+        onError: () => {
+          setErrorMessage('Failed to update storage. Please try again.')
+        },
+      }
+    )
   }
 
   const daysUntilExpiration = getDaysUntilExpiration()


### PR DESCRIPTION
## Work in Progress

Closes #255

Handle stale error state across mutation retries

<!-- sharkrite-source-issue:226 -->## From PR #254 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
This is a minor UX edge case (flickering error messages) that doesn't break core functionality. The current implementation works for the happy path and most error scenarios. Refactoring to onError callbacks is a pattern improvement that warrants separate focus.

## Context
The acceptance criteria requires "Both actions use optimistic updates" - the optimistic update pattern is implemented. Error handling refinement is functional polish beyond the core requirement.

## Defer Reason
Needs separate focused PR - refactoring error handling patterns should be done consistently across all mutation hooks in the codebase

---
_Created by Sharkrite assessment on 2026-03-23T17:09:54Z_
_Parent PR: #254_

---

## Additional Assessment (PR #254)

**Severity:** MEDIUM
**Reasoning:** This is a duplicate of the prior assessment "Error state may persist incorrectly across mutation retries" which was already classified as ACTIONABLE_LATER. The finding describes the same UX edge case about error message timing with React Query mutations.
**Context:** The prior assessment correctly identified this as a minor UX edge case that doesn't break core functionality. The current implementation works for happy path and most error scenarios.
**Defer Reason:** Scope exceeds time budget

_Added by Sharkrite on 2026-03-23T17:17:38Z_

---

## Additional Assessment (PR #257)

**Severity:** MEDIUM
**Reasoning:** This is the same concern as "Repeated Error UI Pattern Could Be Extracted" previously classified as DISMISSED. However, this finding focuses on user-facing message quality and potential information leakage rather than code reuse. The error handling pattern uses a fallback but could expose confusing technical messages. This is a real UX concern but not blocking.
**Context:** The original issue requires "loading states" but does not specify error message formatting standards. Creating a shared error utility affects multiple components and should be done consistently across the app.
**Defer Reason:** Scope exceeds time budget

_Added by Sharkrite on 2026-03-23T17:47:25Z_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**20** files, **3** commits (+0 added, ~18 modified, -2 deleted)
- `M` Dockerfile
- `D` alembic/versions/c1d2e3f4g5h6_merge_heads.py
- `M` docker-compose.yml
- `M` docs/FreshUp-ADR.md
- `D` docs/FreshUp-Design-System.md
- `M` frontend/src/components/auth/UserSwitcher.tsx
- `M` frontend/src/components/grocery/GroceryItem.test.tsx
- `M` frontend/src/components/grocery/GroceryItem.tsx
- `M` frontend/src/components/inventory/InventoryRow.test.tsx
- `M` frontend/src/components/inventory/InventoryRow.tsx
- `M` frontend/src/index.css
- `M` frontend/src/pages/Grocery.tsx
- `M` frontend/src/pages/IShopped.tsx
- `M` frontend/src/pages/Login.tsx
- `M` frontend/src/pages/NotFound.tsx
- `M` frontend/src/pages/Pantry.tsx
- `M` frontend/src/pages/Plan.tsx
- `M` frontend/src/pages/Profile.tsx
- `M` frontend/tailwind.config.js
- `M` src/db/seed.py

### Commits
- b5a3dcd fix: Handle stale error state across mutation retries
- f6d3e4a Merge remote-tracking branch 'origin/main' into fix/error-state-may-persist-incorrectly-across
- 5f994d9 chore: initialize work on #255 Error state may persist incorrectly across
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-03-23T23:19:44Z:**
- Created: #276 
- Updated: none