### PR TITLE
Missing Error Boundary for Auth Context

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,8 @@ import Grocery from './pages/Grocery'
 import IShopped from './pages/IShopped'
 import Profile from './pages/Profile'
 import NotFound from './pages/NotFound'
+import { ErrorBoundary } from './components/errors'
+import AuthErrorFallback from './components/errors/AuthErrorFallback'
 
 function AppContent() {
   const location = useLocation()
@@ -98,9 +100,11 @@ function AppContent() {
 function App() {
   return (
     <BrowserRouter>
-      <AuthProvider>
-        <AppContent />
-      </AuthProvider>
+      <ErrorBoundary fallback={(error, resetError) => <AuthErrorFallback error={error} resetError={resetError} />}>
+        <AuthProvider>
+          <AppContent />
+        </AuthProvider>
+      </ErrorBoundary>
     </BrowserRouter>
   )
 }

--- a/frontend/src/components/errors/AuthErrorFallback.test.tsx
+++ b/frontend/src/components/errors/AuthErrorFallback.test.tsx
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AuthErrorFallback from './AuthErrorFallback';
+
+describe('AuthErrorFallback', () => {
+  const mockError = new Error('Test authentication error');
+  const mockResetError = vi.fn();
+
+  // Mock window.location.href
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    originalLocation = window.location;
+    delete (window as any).location;
+    window.location = { href: '' } as Location;
+    mockResetError.mockClear();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.location = originalLocation;
+  });
+
+  describe('Rendering', () => {
+    it('renders the error fallback UI with appropriate messaging', () => {
+      render(<AuthErrorFallback error={mockError} resetError={mockResetError} />);
+
+      // Check for main heading
+      expect(screen.getByRole('heading', { name: 'Authentication Error' })).toBeInTheDocument();
+
+      // Check for user-friendly description
+      expect(screen.getByText('Something went wrong while loading your session')).toBeInTheDocument();
+
+      // Check for generic error message (should NOT display raw error.message)
+      expect(screen.getByText(/We're having trouble loading your authentication session/i)).toBeInTheDocument();
+
+      // Verify raw error message is NOT displayed (security check)
+      expect(screen.queryByText('Test authentication error')).not.toBeInTheDocument();
+    });
+
+    it('displays action buttons', () => {
+      render(<AuthErrorFallback error={mockError} resetError={mockResetError} />);
+
+      expect(screen.getByRole('button', { name: 'Try Again' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Return to Login' })).toBeInTheDocument();
+    });
+
+    it('displays contact support message', () => {
+      render(<AuthErrorFallback error={mockError} resetError={mockResetError} />);
+
+      expect(
+        screen.getByText('If this problem persists, please contact your household coordinator.')
+      ).toBeInTheDocument();
+    });
+
+    it('renders warning emoji', () => {
+      render(<AuthErrorFallback error={mockError} resetError={mockResetError} />);
+
+      expect(screen.getByText('⚠️')).toBeInTheDocument();
+    });
+  });
+
+  describe('Error Message Security', () => {
+    it('does not leak internal error details to users', () => {
+      const sensitiveError = new Error('Database connection failed: postgresql://user:password@host/db');
+      render(<AuthErrorFallback error={sensitiveError} resetError={mockResetError} />);
+
+      // Verify the sensitive error message is not displayed
+      expect(screen.queryByText(/Database connection failed/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/postgresql/i)).not.toBeInTheDocument();
+
+      // Verify only generic message is shown
+      expect(screen.getByText(/We're having trouble loading your authentication session/i)).toBeInTheDocument();
+    });
+
+    it('displays generic message for different error types', () => {
+      const errors = [
+        new Error('Network timeout'),
+        new Error('Invalid token signature'),
+        new Error('User not found in database'),
+      ];
+
+      errors.forEach((error) => {
+        const { unmount } = render(<AuthErrorFallback error={error} resetError={mockResetError} />);
+
+        // All errors should show the same generic message
+        expect(screen.getByText(/We're having trouble loading your authentication session/i)).toBeInTheDocument();
+
+        // Verify specific error messages are not shown (if non-empty)
+        if (error.message) {
+          expect(screen.queryByText(error.message)).not.toBeInTheDocument();
+        }
+
+        unmount();
+      });
+    });
+  });
+
+  describe('Try Again Button', () => {
+    it('calls resetError when Try Again button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<AuthErrorFallback error={mockError} resetError={mockResetError} />);
+
+      const tryAgainButton = screen.getByRole('button', { name: 'Try Again' });
+      await user.click(tryAgainButton);
+
+      expect(mockResetError).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not clear localStorage when Try Again is clicked', async () => {
+      const user = userEvent.setup();
+      localStorage.setItem('access_token', 'test-token');
+
+      render(<AuthErrorFallback error={mockError} resetError={mockResetError} />);
+
+      await user.click(screen.getByRole('button', { name: 'Try Again' }));
+
+      // Token should still be present after trying again
+      expect(localStorage.getItem('access_token')).toBe('test-token');
+    });
+  });
+
+  describe('Return to Login Button', () => {
+    it('clears access token from localStorage when Return to Login is clicked', async () => {
+      const user = userEvent.setup();
+      localStorage.setItem('access_token', 'test-token');
+
+      render(<AuthErrorFallback error={mockError} resetError={mockResetError} />);
+
+      await user.click(screen.getByRole('button', { name: 'Return to Login' }));
+
+      expect(localStorage.getItem('access_token')).toBeNull();
+    });
+
+    it('redirects to /login when Return to Login is clicked', async () => {
+      const user = userEvent.setup();
+      render(<AuthErrorFallback error={mockError} resetError={mockResetError} />);
+
+      await user.click(screen.getByRole('button', { name: 'Return to Login' }));
+
+      expect(window.location.href).toBe('/login');
+    });
+
+    it('clears token before redirecting (correct order)', async () => {
+      const user = userEvent.setup();
+      localStorage.setItem('access_token', 'test-token');
+
+      render(<AuthErrorFallback error={mockError} resetError={mockResetError} />);
+
+      await user.click(screen.getByRole('button', { name: 'Return to Login' }));
+
+      // Verify both operations completed
+      expect(localStorage.getItem('access_token')).toBeNull();
+      expect(window.location.href).toBe('/login');
+    });
+
+    it('does not call resetError when Return to Login is clicked', async () => {
+      const user = userEvent.setup();
+      render(<AuthErrorFallback error={mockError} resetError={mockResetError} />);
+
+      await user.click(screen.getByRole('button', { name: 'Return to Login' }));
+
+      expect(mockResetError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Styling and Accessibility', () => {
+    it('uses appropriate ARIA roles for interactive elements', () => {
+      render(<AuthErrorFallback error={mockError} resetError={mockResetError} />);
+
+      const buttons = screen.getAllByRole('button');
+      expect(buttons).toHaveLength(2);
+    });
+
+    it('has accessible button labels', () => {
+      render(<AuthErrorFallback error={mockError} resetError={mockResetError} />);
+
+      expect(screen.getByRole('button', { name: 'Try Again' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Return to Login' })).toBeInTheDocument();
+    });
+
+    it('renders with proper class structure for responsive design', () => {
+      const { container } = render(<AuthErrorFallback error={mockError} resetError={mockResetError} />);
+
+      // Check for responsive container classes
+      const mainContainer = container.firstChild as HTMLElement;
+      expect(mainContainer.className).toContain('min-h-screen');
+      expect(mainContainer.className).toContain('flex');
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('handles missing error message gracefully', () => {
+      const emptyError = new Error();
+      render(<AuthErrorFallback error={emptyError} resetError={mockResetError} />);
+
+      // Should still render generic message
+      expect(screen.getByText(/We're having trouble loading your authentication session/i)).toBeInTheDocument();
+    });
+
+    it('handles multiple rapid clicks on Try Again', async () => {
+      const user = userEvent.setup();
+      render(<AuthErrorFallback error={mockError} resetError={mockResetError} />);
+
+      const tryAgainButton = screen.getByRole('button', { name: 'Try Again' });
+
+      await user.click(tryAgainButton);
+      await user.click(tryAgainButton);
+      await user.click(tryAgainButton);
+
+      expect(mockResetError).toHaveBeenCalledTimes(3);
+    });
+
+    it('handles case when access_token does not exist in localStorage', async () => {
+      const user = userEvent.setup();
+      render(<AuthErrorFallback error={mockError} resetError={mockResetError} />);
+
+      // Ensure no token exists
+      expect(localStorage.getItem('access_token')).toBeNull();
+
+      // Should not throw error when trying to remove non-existent token
+      await user.click(screen.getByRole('button', { name: 'Return to Login' }));
+
+      expect(window.location.href).toBe('/login');
+    });
+  });
+});

--- a/frontend/src/components/errors/AuthErrorFallback.tsx
+++ b/frontend/src/components/errors/AuthErrorFallback.tsx
@@ -34,7 +34,9 @@ export default function AuthErrorFallback({ error, resetError }: AuthErrorFallba
         <div className="bg-white rounded-card border border-warm-border p-8">
           {/* Error Message */}
           <div className="rounded-button border border-terra bg-terra/10 p-4 mb-6">
-            <p className="text-sm text-terra-dark font-medium">{error.message}</p>
+            <p className="text-sm text-terra-dark font-medium">
+              We're having trouble loading your authentication session. Please try again or return to the login page.
+            </p>
           </div>
 
           {/* Action Buttons */}

--- a/frontend/src/components/errors/AuthErrorFallback.tsx
+++ b/frontend/src/components/errors/AuthErrorFallback.tsx
@@ -13,7 +13,7 @@ interface AuthErrorFallbackProps {
   resetError: () => void;
 }
 
-export default function AuthErrorFallback({ error, resetError }: AuthErrorFallbackProps) {
+export default function AuthErrorFallback({ error: _error, resetError }: AuthErrorFallbackProps) {
   const handleReturnToLogin = () => {
     // Clear any stale auth tokens before redirecting
     localStorage.removeItem('access_token');

--- a/frontend/src/components/errors/AuthErrorFallback.tsx
+++ b/frontend/src/components/errors/AuthErrorFallback.tsx
@@ -1,0 +1,65 @@
+/**
+ * Fallback UI component displayed when the AuthContext encounters an error.
+ *
+ * Provides user-friendly error message and recovery options:
+ * - Try Again: Resets the error boundary to retry loading auth state
+ * - Return to Login: Navigates to the login page for re-authentication
+ *
+ * Matches the app's design system (cream/olive/terra colors).
+ */
+
+interface AuthErrorFallbackProps {
+  error: Error;
+  resetError: () => void;
+}
+
+export default function AuthErrorFallback({ error, resetError }: AuthErrorFallbackProps) {
+  const handleReturnToLogin = () => {
+    // Clear any stale auth tokens before redirecting
+    localStorage.removeItem('access_token');
+    window.location.href = '/login';
+  };
+
+  return (
+    <div className="min-h-screen bg-cream flex items-center justify-center px-4">
+      <div className="w-full max-w-md">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <div className="text-6xl mb-4">⚠️</div>
+          <h1 className="text-2xl font-bold text-text-primary mb-2">Authentication Error</h1>
+          <p className="text-text-secondary">Something went wrong while loading your session</p>
+        </div>
+
+        {/* Error Card */}
+        <div className="bg-white rounded-card border border-warm-border p-8">
+          {/* Error Message */}
+          <div className="rounded-button border border-terra bg-terra/10 p-4 mb-6">
+            <p className="text-sm text-terra-dark font-medium">{error.message}</p>
+          </div>
+
+          {/* Action Buttons */}
+          <div className="space-y-3">
+            <button
+              onClick={resetError}
+              className="w-full py-3 px-4 rounded-button bg-olive text-cream font-medium hover:bg-olive-dark focus:outline-none focus:ring-2 focus:ring-olive focus:ring-offset-2 focus:ring-offset-cream transition-colors"
+            >
+              Try Again
+            </button>
+
+            <button
+              onClick={handleReturnToLogin}
+              className="w-full py-3 px-4 rounded-button bg-cream text-olive font-medium border border-olive hover:bg-olive/10 focus:outline-none focus:ring-2 focus:ring-olive focus:ring-offset-2 focus:ring-offset-cream transition-colors"
+            >
+              Return to Login
+            </button>
+          </div>
+        </div>
+
+        {/* Footer Note */}
+        <p className="text-center text-sm text-text-tertiary mt-6">
+          If this problem persists, please contact your household coordinator.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/errors/ErrorBoundary.test.tsx
+++ b/frontend/src/components/errors/ErrorBoundary.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ErrorBoundary } from './ErrorBoundary';
+
+// Test component that throws an error when shouldThrow is true
+function ThrowError({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error('Test error message');
+  }
+  return <div>Normal content</div>;
+}
+
+describe('ErrorBoundary', () => {
+  // Suppress console.error in tests to avoid cluttering test output
+  const originalError = console.error;
+  beforeAll(() => {
+    console.error = vi.fn();
+  });
+
+  afterAll(() => {
+    console.error = originalError;
+  });
+
+  it('renders children when there is no error', () => {
+    render(
+      <ErrorBoundary fallback={() => <div>Error occurred</div>}>
+        <ThrowError shouldThrow={false} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Normal content')).toBeInTheDocument();
+    expect(screen.queryByText('Error occurred')).not.toBeInTheDocument();
+  });
+
+  it('renders fallback when an error is thrown', () => {
+    render(
+      <ErrorBoundary fallback={(error) => <div>Error: {error.message}</div>}>
+        <ThrowError shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Error: Test error message')).toBeInTheDocument();
+    expect(screen.queryByText('Normal content')).not.toBeInTheDocument();
+  });
+
+  it('passes error to fallback function', () => {
+    const fallbackFn = vi.fn(() => <div>Fallback</div>);
+
+    render(
+      <ErrorBoundary fallback={fallbackFn}>
+        <ThrowError shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(fallbackFn).toHaveBeenCalled();
+    const error = fallbackFn.mock.calls[0][0];
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe('Test error message');
+  });
+
+  it('calls resetError when reset function is invoked', async () => {
+    const user = userEvent.setup();
+
+    const FallbackWithReset = ({ error, resetError }: { error: Error; resetError: () => void }) => (
+      <div>
+        <div>Error: {error.message}</div>
+        <button onClick={resetError}>Reset</button>
+      </div>
+    );
+
+    // Start with error state
+    const { rerender } = render(
+      <ErrorBoundary fallback={(error, resetError) => <FallbackWithReset error={error} resetError={resetError} />}>
+        <ThrowError shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Error: Test error message')).toBeInTheDocument();
+
+    // Click reset - this will reset the error boundary but children still throw
+    // So we need to provide non-throwing children after reset
+    await user.click(screen.getByText('Reset'));
+
+    // After reset, rerender with non-throwing children
+    rerender(
+      <ErrorBoundary fallback={(error, resetError) => <FallbackWithReset error={error} resetError={resetError} />}>
+        <ThrowError shouldThrow={false} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Normal content')).toBeInTheDocument();
+  });
+
+  it('logs error to console', () => {
+    const consoleSpy = vi.spyOn(console, 'error');
+
+    render(
+      <ErrorBoundary fallback={() => <div>Error</div>}>
+        <ThrowError shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  it('handles different error types', () => {
+    function ThrowCustomError() {
+      throw new Error('Custom error type');
+    }
+
+    render(
+      <ErrorBoundary fallback={(error) => <div>Caught: {error.message}</div>}>
+        <ThrowCustomError />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Caught: Custom error type')).toBeInTheDocument();
+  });
+
+  it('renders custom fallback UI', () => {
+    const CustomFallback = ({ error }: { error: Error }) => (
+      <div className="custom-error">
+        <h1>Oops!</h1>
+        <p>{error.message}</p>
+      </div>
+    );
+
+    render(
+      <ErrorBoundary fallback={(error) => <CustomFallback error={error} />}>
+        <ThrowError shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByRole('heading', { name: 'Oops!' })).toBeInTheDocument();
+    expect(screen.getByText('Test error message')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/errors/ErrorBoundary.tsx
+++ b/frontend/src/components/errors/ErrorBoundary.tsx
@@ -1,0 +1,51 @@
+import { Component, ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback: (error: Error, resetError: () => void) => ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+/**
+ * Generic error boundary component that catches errors in child components.
+ *
+ * React error boundaries must be class components as they use lifecycle methods
+ * (getDerivedStateFromError and componentDidCatch) that are not available in hooks.
+ *
+ * Usage:
+ * ```tsx
+ * <ErrorBoundary fallback={(error, reset) => <div>Error: {error.message}</div>}>
+ *   <YourComponent />
+ * </ErrorBoundary>
+ * ```
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    console.error('ErrorBoundary caught an error:', error, errorInfo);
+  }
+
+  resetError = (): void => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render(): ReactNode {
+    if (this.state.hasError && this.state.error) {
+      return this.props.fallback(this.state.error, this.resetError);
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/errors/index.ts
+++ b/frontend/src/components/errors/index.ts
@@ -1,0 +1,2 @@
+export { ErrorBoundary } from './ErrorBoundary';
+export { default as AuthErrorFallback } from './AuthErrorFallback';

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -17,8 +17,6 @@ import { useNavigate } from 'react-router-dom';
 import { useCurrentUser, useLogin, useLogout, useSwitchUser } from '../api/hooks/useAuth';
 import { isAuthenticated as checkIsAuthenticated } from '../api/client';
 import type { LoginRequest, UserResponse, SwitchUserRequest } from '../api/types';
-import { ErrorBoundary } from '../components/errors';
-import AuthErrorFallback from '../components/errors/AuthErrorFallback';
 
 interface AuthContextType {
   currentUser: UserResponse | undefined;
@@ -104,9 +102,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   };
 
   return (
-    <ErrorBoundary fallback={(error, resetError) => <AuthErrorFallback error={error} resetError={resetError} />}>
-      <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
-    </ErrorBoundary>
+    <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
   );
 }
 

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -8,6 +8,8 @@
  * - login: Function to authenticate with email/password
  * - logout: Function to clear authentication and redirect to login
  * - switchUser: Function to switch to another household member (shared device)
+ *
+ * Wrapped with ErrorBoundary to catch and handle errors gracefully.
  */
 
 import { createContext, useContext, ReactNode } from 'react';
@@ -15,6 +17,8 @@ import { useNavigate } from 'react-router-dom';
 import { useCurrentUser, useLogin, useLogout, useSwitchUser } from '../api/hooks/useAuth';
 import { isAuthenticated as checkIsAuthenticated } from '../api/client';
 import type { LoginRequest, UserResponse, SwitchUserRequest } from '../api/types';
+import { ErrorBoundary } from '../components/errors';
+import AuthErrorFallback from '../components/errors/AuthErrorFallback';
 
 interface AuthContextType {
   currentUser: UserResponse | undefined;
@@ -99,7 +103,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
     switchUser,
   };
 
-  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+  return (
+    <ErrorBoundary fallback={(error, resetError) => <AuthErrorFallback error={error} resetError={resetError} />}>
+      <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+    </ErrorBoundary>
+  );
 }
 
 /**


### PR DESCRIPTION
## Work in Progress

Closes #250

Missing Error Boundary for Auth Context

<!-- sharkrite-source-issue:222 -->## From PR #249 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
React Query errors are handled via `isUserError` flag, not thrown exceptions. However, adding an error boundary around AuthProvider children is a valid defensive pattern that improves resilience. This is a real improvement but outside the scope of authentication flow implementation.

## Context


## Defer Reason
Scope exceeds time budget - requires creating/importing error boundary component and designing fallback UI

---
_Created by Sharkrite assessment on 2026-03-23T09:02:33Z_
_Parent PR: #249_

---

## Additional Assessment (PR #268)

**Severity:** MEDIUM
**Reasoning:** Error boundaries are a defensive pattern for production robustness, but this PR's scope is building the Pantry view structure. The feature works correctly without error boundaries, and adding them requires deciding on a project-wide error boundary strategy.
**Context:** The issue scope focuses on building the view with tabs, stat cards, and triage sections. Error boundary implementation is a cross-cutting concern that should be applied consistently across the app, not added ad-hoc to one page.
**Defer Reason:** Needs separate focused PR to establish consistent error boundary pattern across the application

_Added by Sharkrite on 2026-03-23T23:03:14Z_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**5** files, **3** commits (+4 added, ~1 modified, -0 deleted)
- `A` frontend/src/components/errors/AuthErrorFallback.tsx
- `A` frontend/src/components/errors/ErrorBoundary.test.tsx
- `A` frontend/src/components/errors/ErrorBoundary.tsx
- `A` frontend/src/components/errors/index.ts
- `M` frontend/src/contexts/AuthContext.tsx

### Commits
- 1deb3aa fix: Missing Error Boundary for Auth Context
- 9da1191 Merge remote-tracking branch 'origin/main' into fix/missing-error-boundary-for-auth-context
- 4840d53 chore: initialize work on #250 Missing Error Boundary for Auth Context
<!-- /sharkrite-changes-summary -->