### PR TITLE
Hardcoded Filter Options

### DIFF
--- a/frontend/src/components/recipe/FilterChips.tsx
+++ b/frontend/src/components/recipe/FilterChips.tsx
@@ -1,4 +1,12 @@
 import { X } from 'lucide-react'
+import {
+  SOURCE_TYPE_OPTIONS,
+  COOK_TIME_OPTIONS,
+  TAG_OPTIONS,
+  getSourceTypeLabel,
+  getCookTimeLabel,
+  getTagLabel,
+} from '../../constants/recipeFilters'
 
 export interface RecipeFilters {
   source_type?: string
@@ -46,9 +54,11 @@ export default function FilterChips({ filters, onFilterChange }: FilterChipsProp
           className="px-3 py-1.5 rounded-full border border-warm-border bg-white text-xs text-text-primary focus:outline-none focus:ring-2 focus:ring-olive focus:border-transparent"
         >
           <option value="">All sources</option>
-          <option value="manual">My recipes</option>
-          <option value="hellofresh_card">HelloFresh</option>
-          <option value="ad_hoc">Ad-hoc</option>
+          {SOURCE_TYPE_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
         </select>
 
         {/* Cook time filter */}
@@ -58,10 +68,11 @@ export default function FilterChips({ filters, onFilterChange }: FilterChipsProp
           className="px-3 py-1.5 rounded-full border border-warm-border bg-white text-xs text-text-primary focus:outline-none focus:ring-2 focus:ring-olive focus:border-transparent"
         >
           <option value="">Any time</option>
-          <option value="15">15 min or less</option>
-          <option value="30">30 min or less</option>
-          <option value="45">45 min or less</option>
-          <option value="60">1 hour or less</option>
+          {COOK_TIME_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
         </select>
 
         {/* Tag filter */}
@@ -71,15 +82,11 @@ export default function FilterChips({ filters, onFilterChange }: FilterChipsProp
           className="px-3 py-1.5 rounded-full border border-warm-border bg-white text-xs text-text-primary focus:outline-none focus:ring-2 focus:ring-olive focus:border-transparent"
         >
           <option value="">All cuisines</option>
-          <option value="italian">Italian</option>
-          <option value="mexican">Mexican</option>
-          <option value="asian">Asian</option>
-          <option value="american">American</option>
-          <option value="mediterranean">Mediterranean</option>
-          <option value="indian">Indian</option>
-          <option value="thai">Thai</option>
-          <option value="vegan">Vegan</option>
-          <option value="vegetarian">Vegetarian</option>
+          {TAG_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
         </select>
       </div>
 
@@ -94,13 +101,13 @@ export default function FilterChips({ filters, onFilterChange }: FilterChipsProp
           )}
           {filters.tag && (
             <FilterChip
-              label={`Cuisine: ${filters.tag}`}
+              label={`Cuisine: ${getTagLabel(filters.tag)}`}
               onRemove={() => removeFilter('tag')}
             />
           )}
           {filters.max_cook_time && (
             <FilterChip
-              label={`Max ${filters.max_cook_time} min`}
+              label={`Max ${getCookTimeLabel(filters.max_cook_time)}`}
               onRemove={() => removeFilter('max_cook_time')}
             />
           )}
@@ -130,15 +137,3 @@ function FilterChip({ label, onRemove }: FilterChipProps) {
   )
 }
 
-function getSourceTypeLabel(sourceType: string): string {
-  switch (sourceType) {
-    case 'manual':
-      return 'My recipes'
-    case 'hellofresh_card':
-      return 'HelloFresh'
-    case 'ad_hoc':
-      return 'Ad-hoc'
-    default:
-      return sourceType
-  }
-}

--- a/frontend/src/constants/recipeFilters.test.ts
+++ b/frontend/src/constants/recipeFilters.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest'
+import {
+  SOURCE_TYPE_OPTIONS,
+  COOK_TIME_OPTIONS,
+  TAG_OPTIONS,
+  getSourceTypeLabel,
+  getCookTimeLabel,
+  getTagLabel,
+} from './recipeFilters'
+
+describe('recipeFilters', () => {
+  describe('SOURCE_TYPE_OPTIONS', () => {
+    it('contains expected source type options', () => {
+      expect(SOURCE_TYPE_OPTIONS).toHaveLength(3)
+      expect(SOURCE_TYPE_OPTIONS).toEqual([
+        { value: 'manual', label: 'My recipes' },
+        { value: 'hellofresh_card', label: 'HelloFresh' },
+        { value: 'ad_hoc', label: 'Ad-hoc' },
+      ])
+    })
+  })
+
+  describe('COOK_TIME_OPTIONS', () => {
+    it('contains expected cook time options', () => {
+      expect(COOK_TIME_OPTIONS).toHaveLength(4)
+      expect(COOK_TIME_OPTIONS).toEqual([
+        { value: 15, label: '15 min or less' },
+        { value: 30, label: '30 min or less' },
+        { value: 45, label: '45 min or less' },
+        { value: 60, label: '1 hour or less' },
+      ])
+    })
+  })
+
+  describe('TAG_OPTIONS', () => {
+    it('contains expected tag options', () => {
+      expect(TAG_OPTIONS).toHaveLength(9)
+      expect(TAG_OPTIONS).toEqual([
+        { value: 'italian', label: 'Italian' },
+        { value: 'mexican', label: 'Mexican' },
+        { value: 'asian', label: 'Asian' },
+        { value: 'american', label: 'American' },
+        { value: 'mediterranean', label: 'Mediterranean' },
+        { value: 'indian', label: 'Indian' },
+        { value: 'thai', label: 'Thai' },
+        { value: 'vegan', label: 'Vegan' },
+        { value: 'vegetarian', label: 'Vegetarian' },
+      ])
+    })
+  })
+
+  describe('getSourceTypeLabel', () => {
+    it('returns correct label for known source types', () => {
+      expect(getSourceTypeLabel('manual')).toBe('My recipes')
+      expect(getSourceTypeLabel('hellofresh_card')).toBe('HelloFresh')
+      expect(getSourceTypeLabel('ad_hoc')).toBe('Ad-hoc')
+    })
+
+    it('returns the input value as fallback for unknown source types', () => {
+      expect(getSourceTypeLabel('unknown')).toBe('unknown')
+      expect(getSourceTypeLabel('custom_source')).toBe('custom_source')
+      expect(getSourceTypeLabel('imported')).toBe('imported')
+    })
+
+    it('handles empty string', () => {
+      expect(getSourceTypeLabel('')).toBe('')
+    })
+
+    it('is case-sensitive', () => {
+      expect(getSourceTypeLabel('Manual')).toBe('Manual')
+      expect(getSourceTypeLabel('MANUAL')).toBe('MANUAL')
+    })
+  })
+
+  describe('getCookTimeLabel', () => {
+    describe('with numeric input', () => {
+      it('returns correct label for known cook times', () => {
+        expect(getCookTimeLabel(15)).toBe('15 min or less')
+        expect(getCookTimeLabel(30)).toBe('30 min or less')
+        expect(getCookTimeLabel(45)).toBe('45 min or less')
+        expect(getCookTimeLabel(60)).toBe('1 hour or less')
+      })
+
+      it('returns fallback format for unknown cook times', () => {
+        expect(getCookTimeLabel(10)).toBe('10 min')
+        expect(getCookTimeLabel(20)).toBe('20 min')
+        expect(getCookTimeLabel(90)).toBe('90 min')
+        expect(getCookTimeLabel(120)).toBe('120 min')
+      })
+
+      it('handles zero', () => {
+        expect(getCookTimeLabel(0)).toBe('0 min')
+      })
+
+      it('handles negative numbers', () => {
+        expect(getCookTimeLabel(-5)).toBe('-5 min')
+      })
+    })
+
+    describe('with string input', () => {
+      it('converts string to number and returns correct label for known cook times', () => {
+        expect(getCookTimeLabel('15')).toBe('15 min or less')
+        expect(getCookTimeLabel('30')).toBe('30 min or less')
+        expect(getCookTimeLabel('45')).toBe('45 min or less')
+        expect(getCookTimeLabel('60')).toBe('1 hour or less')
+      })
+
+      it('converts string to number and returns fallback for unknown cook times', () => {
+        expect(getCookTimeLabel('10')).toBe('10 min')
+        expect(getCookTimeLabel('90')).toBe('90 min')
+      })
+
+      it('handles string zero', () => {
+        expect(getCookTimeLabel('0')).toBe('0 min')
+      })
+
+      it('handles invalid numeric strings (NaN)', () => {
+        expect(getCookTimeLabel('invalid')).toBe('NaN min')
+        expect(getCookTimeLabel('abc')).toBe('NaN min')
+      })
+
+      it('handles empty string', () => {
+        expect(getCookTimeLabel('')).toBe('0 min')
+      })
+
+      it('handles decimal strings', () => {
+        expect(getCookTimeLabel('15.5')).toBe('15.5 min')
+        expect(getCookTimeLabel('30.7')).toBe('30.7 min')
+      })
+    })
+
+    describe('type coercion edge cases', () => {
+      it('handles whitespace in strings', () => {
+        expect(getCookTimeLabel(' 15 ')).toBe('15 min or less')
+        expect(getCookTimeLabel('  30  ')).toBe('30 min or less')
+      })
+
+      it('handles scientific notation strings', () => {
+        expect(getCookTimeLabel('1e2')).toBe('100 min')
+      })
+    })
+  })
+
+  describe('getTagLabel', () => {
+    it('returns correct label for known tags', () => {
+      expect(getTagLabel('italian')).toBe('Italian')
+      expect(getTagLabel('mexican')).toBe('Mexican')
+      expect(getTagLabel('asian')).toBe('Asian')
+      expect(getTagLabel('american')).toBe('American')
+      expect(getTagLabel('mediterranean')).toBe('Mediterranean')
+      expect(getTagLabel('indian')).toBe('Indian')
+      expect(getTagLabel('thai')).toBe('Thai')
+      expect(getTagLabel('vegan')).toBe('Vegan')
+      expect(getTagLabel('vegetarian')).toBe('Vegetarian')
+    })
+
+    it('returns the input value as fallback for unknown tags', () => {
+      expect(getTagLabel('french')).toBe('french')
+      expect(getTagLabel('chinese')).toBe('chinese')
+      expect(getTagLabel('custom-tag')).toBe('custom-tag')
+    })
+
+    it('handles empty string', () => {
+      expect(getTagLabel('')).toBe('')
+    })
+
+    it('is case-sensitive', () => {
+      expect(getTagLabel('Italian')).toBe('Italian')
+      expect(getTagLabel('VEGAN')).toBe('VEGAN')
+    })
+
+    it('preserves capitalization of unknown tags', () => {
+      expect(getTagLabel('French Cuisine')).toBe('French Cuisine')
+      expect(getTagLabel('Gluten-Free')).toBe('Gluten-Free')
+    })
+  })
+})

--- a/frontend/src/constants/recipeFilters.test.ts
+++ b/frontend/src/constants/recipeFilters.test.ts
@@ -114,9 +114,9 @@ describe('recipeFilters', () => {
         expect(getCookTimeLabel('0')).toBe('0 min')
       })
 
-      it('handles invalid numeric strings (NaN)', () => {
-        expect(getCookTimeLabel('invalid')).toBe('NaN min')
-        expect(getCookTimeLabel('abc')).toBe('NaN min')
+      it('handles invalid numeric strings gracefully', () => {
+        expect(getCookTimeLabel('invalid')).toBe('invalid')
+        expect(getCookTimeLabel('abc')).toBe('abc')
       })
 
       it('handles empty string', () => {
@@ -137,6 +137,11 @@ describe('recipeFilters', () => {
 
       it('handles scientific notation strings', () => {
         expect(getCookTimeLabel('1e2')).toBe('100 min')
+      })
+
+      it('handles Infinity', () => {
+        expect(getCookTimeLabel(Infinity)).toBe('Infinity')
+        expect(getCookTimeLabel(-Infinity)).toBe('-Infinity')
       })
     })
   })

--- a/frontend/src/constants/recipeFilters.ts
+++ b/frontend/src/constants/recipeFilters.ts
@@ -72,6 +72,12 @@ export function getSourceTypeLabel(sourceType: string): string {
  */
 export function getCookTimeLabel(cookTime: number | string): string {
   const numericCookTime = typeof cookTime === 'string' ? Number(cookTime) : cookTime
+
+  // Handle invalid numeric values (NaN, Infinity, etc.)
+  if (!Number.isFinite(numericCookTime)) {
+    return String(cookTime)
+  }
+
   const option = COOK_TIME_OPTIONS.find((opt) => opt.value === numericCookTime)
   return option?.label || `${numericCookTime} min`
 }

--- a/frontend/src/constants/recipeFilters.ts
+++ b/frontend/src/constants/recipeFilters.ts
@@ -1,0 +1,84 @@
+/**
+ * Centralized constants for recipe filter options
+ *
+ * This file defines all available filter options for the recipe browse interface.
+ * Centralizing these values ensures consistency across the application and makes
+ * it easier to add, remove, or modify filter options.
+ */
+
+export interface FilterOption {
+  value: string
+  label: string
+}
+
+export interface CookTimeOption {
+  value: number
+  label: string
+}
+
+/**
+ * Source type filter options
+ *
+ * Note: This is a subset of the SourceType enum in the backend.
+ * Not all source types are exposed as filter options in the UI.
+ */
+export const SOURCE_TYPE_OPTIONS: FilterOption[] = [
+  { value: 'manual', label: 'My recipes' },
+  { value: 'hellofresh_card', label: 'HelloFresh' },
+  { value: 'ad_hoc', label: 'Ad-hoc' },
+]
+
+/**
+ * Cook time filter options (in minutes)
+ *
+ * These represent maximum cook time filters that users can select.
+ */
+export const COOK_TIME_OPTIONS: CookTimeOption[] = [
+  { value: 15, label: '15 min or less' },
+  { value: 30, label: '30 min or less' },
+  { value: 45, label: '45 min or less' },
+  { value: 60, label: '1 hour or less' },
+]
+
+/**
+ * Tag/cuisine filter options
+ *
+ * These represent recipe tags that users can filter by.
+ * Tags are stored as free-form strings in the database but
+ * the UI exposes a curated list of common options.
+ */
+export const TAG_OPTIONS: FilterOption[] = [
+  { value: 'italian', label: 'Italian' },
+  { value: 'mexican', label: 'Mexican' },
+  { value: 'asian', label: 'Asian' },
+  { value: 'american', label: 'American' },
+  { value: 'mediterranean', label: 'Mediterranean' },
+  { value: 'indian', label: 'Indian' },
+  { value: 'thai', label: 'Thai' },
+  { value: 'vegan', label: 'Vegan' },
+  { value: 'vegetarian', label: 'Vegetarian' },
+]
+
+/**
+ * Helper function to get the label for a source type value
+ */
+export function getSourceTypeLabel(sourceType: string): string {
+  const option = SOURCE_TYPE_OPTIONS.find((opt) => opt.value === sourceType)
+  return option?.label || sourceType
+}
+
+/**
+ * Helper function to get the label for a cook time value
+ */
+export function getCookTimeLabel(cookTime: number): string {
+  const option = COOK_TIME_OPTIONS.find((opt) => opt.value === cookTime)
+  return option?.label || `${cookTime} min`
+}
+
+/**
+ * Helper function to get the label for a tag value
+ */
+export function getTagLabel(tag: string): string {
+  const option = TAG_OPTIONS.find((opt) => opt.value === tag)
+  return option?.label || tag
+}

--- a/frontend/src/constants/recipeFilters.ts
+++ b/frontend/src/constants/recipeFilters.ts
@@ -70,9 +70,10 @@ export function getSourceTypeLabel(sourceType: string): string {
 /**
  * Helper function to get the label for a cook time value
  */
-export function getCookTimeLabel(cookTime: number): string {
-  const option = COOK_TIME_OPTIONS.find((opt) => opt.value === cookTime)
-  return option?.label || `${cookTime} min`
+export function getCookTimeLabel(cookTime: number | string): string {
+  const numericCookTime = typeof cookTime === 'string' ? Number(cookTime) : cookTime
+  const option = COOK_TIME_OPTIONS.find((opt) => opt.value === numericCookTime)
+  return option?.label || `${numericCookTime} min`
 }
 
 /**


### PR DESCRIPTION
## Work in Progress

Closes #263

Hardcoded Filter Options

<!-- sharkrite-source-issue:229 -->## From PR #261 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
This is a maintainability concern that could cause data inconsistency, but the fix requires either new API endpoints or architectural decisions about centralized constants. Not blocking for Phase 1.

## Context
The acceptance criteria specifies filter chips for source_type, cook_time, tag. Hardcoded values satisfy the requirement; dynamic fetching is an enhancement.

## Defer Reason
Needs separate focused PR

---
_Created by Sharkrite assessment on 2026-03-23T17:55:43Z_
_Parent PR: #261_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+1 added, ~1 modified, -0 deleted)
- `M` frontend/src/components/recipe/FilterChips.tsx
- `A` frontend/src/constants/recipeFilters.ts

### Commits
- ddc358e feat: Hardcoded Filter Options
- d7ef107 chore: initialize work on #263 Hardcoded Filter Options
<!-- /sharkrite-changes-summary -->