### PR TITLE
Hardcoded base servings assumption

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -294,6 +294,7 @@ export interface RecipeResponse {
   tags: string[];
   cook_time_minutes: number | null;
   prep_time_minutes: number | null;
+  base_servings: number;
   hellofresh_card_id: string | null;
   variation_groups: Record<string, unknown> | null;
   nutritional_info: Record<string, unknown> | null;
@@ -308,6 +309,7 @@ export interface RecipeListResponse {
   tags: string[];
   cook_time_minutes: number | null;
   prep_time_minutes: number | null;
+  base_servings: number;
 }
 
 export interface RecipeCreate {

--- a/frontend/src/pages/RecipeDetail.tsx
+++ b/frontend/src/pages/RecipeDetail.tsx
@@ -81,9 +81,10 @@ export default function RecipeDetail() {
     )
   }
 
-  // Calculate servings multiplier based on base recipe (assumes 2 servings as base)
-  // Selected 2 = 1x, Selected 4 = 2x, Selected 6 = 3x
-  const servingsMultiplier = selectedServings / 2
+  // Calculate servings multiplier based on recipe's base servings
+  // Example: if base_servings=4 and selectedServings=2, multiplier=0.5 (scale down)
+  // Example: if base_servings=4 and selectedServings=6, multiplier=1.5 (scale up)
+  const servingsMultiplier = selectedServings / recipe.base_servings
 
   const cookTime = recipe.cook_time_minutes
   const prepTime = recipe.prep_time_minutes

--- a/frontend/src/pages/RecipeDetail.tsx
+++ b/frontend/src/pages/RecipeDetail.tsx
@@ -84,7 +84,10 @@ export default function RecipeDetail() {
   // Calculate servings multiplier based on recipe's base servings
   // Example: if base_servings=4 and selectedServings=2, multiplier=0.5 (scale down)
   // Example: if base_servings=4 and selectedServings=6, multiplier=1.5 (scale up)
-  const servingsMultiplier = selectedServings / recipe.base_servings
+  // Guard against division by zero - default to 1 (no scaling) if base_servings is invalid
+  const servingsMultiplier = recipe.base_servings > 0
+    ? selectedServings / recipe.base_servings
+    : 1
 
   const cookTime = recipe.cook_time_minutes
   const prepTime = recipe.prep_time_minutes

--- a/frontend/src/pages/RecipeDetail.tsx
+++ b/frontend/src/pages/RecipeDetail.tsx
@@ -88,7 +88,9 @@ export default function RecipeDetail() {
   const servingsMultiplier = recipe.base_servings > 0
     ? selectedServings / recipe.base_servings
     : (() => {
-        console.warn(`Invalid base_servings value (${recipe.base_servings}) for recipe ${recipe.id}. Defaulting to no scaling (multiplier=1).`)
+        if (import.meta.env.DEV) {
+          console.warn(`Invalid base_servings value (${recipe.base_servings}) for recipe ${recipe.id}. Defaulting to no scaling (multiplier=1).`)
+        }
         return 1
       })()
 

--- a/frontend/src/pages/RecipeDetail.tsx
+++ b/frontend/src/pages/RecipeDetail.tsx
@@ -87,7 +87,10 @@ export default function RecipeDetail() {
   // Guard against division by zero - default to 1 (no scaling) if base_servings is invalid
   const servingsMultiplier = recipe.base_servings > 0
     ? selectedServings / recipe.base_servings
-    : 1
+    : (() => {
+        console.warn(`Invalid base_servings value (${recipe.base_servings}) for recipe ${recipe.id}. Defaulting to no scaling (multiplier=1).`)
+        return 1
+      })()
 
   const cookTime = recipe.cook_time_minutes
   const prepTime = recipe.prep_time_minutes


### PR DESCRIPTION
## Work in Progress

Closes #265

Hardcoded base servings assumption

<!-- sharkrite-source-issue:230 -->## From PR #264 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
The recipe API endpoint and data model need to be examined to determine if `servings` or `base_servings` is available. This is a real bug risk but requires backend coordination to fix properly.

## Context
The issue scope specifies "ServingsControl: 2/4/6 segmented selector, scales ingredient quantities" with "client-side math." The hardcoded assumption is a known limitation that works for the current implementation but will need backend data to fix correctly.

## Defer Reason
Needs separate focused PR - requires backend API verification and potentially schema changes to expose base_servings

---
_Created by Sharkrite assessment on 2026-03-23T18:15:29Z_
_Parent PR: #264_

---

## Additional Assessment (PR #264)

**Severity:** MEDIUM
**Reasoning:** Prior assessment classified this as ACTIONABLE_LATER. Checking if `RecipeDetail.tsx` changed since classification: yes, it is listed as changed. However, examining the finding, the core issue remains the same - the hardcoded `servings / 2` calculation requires backend coordination to provide a `base_servings` field. No evidence that this specific line was modified to address the concern.
**Context:** This is a real bug risk but requires backend API changes to properly expose base servings per recipe. The current implementation matches the acceptance criteria for "Servings scaling (client-side math)" but the underlying assumption needs verification.
**Defer Reason:** Needs separate focused PR with backend coordination to expose recipe base servings

_Added by Sharkrite on 2026-03-23T18:18:33Z_

---

## Additional Assessment (PR #264)

**Severity:** MEDIUM
**Reasoning:** Prior assessment already classified this as ACTIONABLE_LATER. The finding concerns the same hardcoded `servings / 2` calculation. While the file changed, no evidence the specific assumption was addressed. Requires backend coordination to provide `base_servings` field.
**Context:** The issue scope includes "ServingsControl: 2/4/6 segmented selector, scales ingredient quantities" but doesn't specify how base servings should be determined. Backend API changes needed.
**Defer Reason:** Needs separate focused PR with backend coordination to add `base_servings` to recipe API response

_Added by Sharkrite on 2026-03-23T18:23:31Z_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+0 added, ~2 modified, -0 deleted)
- `M` frontend/src/api/types.ts
- `M` frontend/src/pages/RecipeDetail.tsx

### Commits
- e7d4100 feat: Hardcoded base servings assumption
- 3d354c7 chore: initialize work on #265 Hardcoded base servings assumption
<!-- /sharkrite-changes-summary -->