### PR TITLE
Add test for auth token expiration scenarios

### DIFF
--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Unit tests for API client authentication token handling.
+ *
+ * Tests cover:
+ * - Token storage and retrieval
+ * - Token expiration validation
+ * - API client error handling for expired tokens
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  setAuthToken,
+  getAuthToken,
+  clearAuthToken,
+  isAuthenticated,
+  apiClient,
+  ApiException,
+} from './client'
+
+describe('Auth Token Storage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  describe('setAuthToken', () => {
+    it('stores token in localStorage', () => {
+      const token = 'test-token-123'
+      setAuthToken(token)
+      expect(localStorage.getItem('auth_token')).toBe(token)
+    })
+  })
+
+  describe('getAuthToken', () => {
+    it('retrieves token from localStorage', () => {
+      const token = 'test-token-456'
+      localStorage.setItem('auth_token', token)
+      expect(getAuthToken()).toBe(token)
+    })
+
+    it('returns null when no token exists', () => {
+      expect(getAuthToken()).toBeNull()
+    })
+  })
+
+  describe('clearAuthToken', () => {
+    it('removes token from localStorage', () => {
+      localStorage.setItem('auth_token', 'test-token-789')
+      clearAuthToken()
+      expect(localStorage.getItem('auth_token')).toBeNull()
+    })
+  })
+})
+
+describe('isAuthenticated', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  describe('with no token', () => {
+    it('returns false when no token exists', () => {
+      expect(isAuthenticated()).toBe(false)
+    })
+  })
+
+  describe('with malformed tokens', () => {
+    it('returns false for empty string token', () => {
+      setAuthToken('')
+      expect(isAuthenticated()).toBe(false)
+    })
+
+    it('returns false for token with wrong number of parts', () => {
+      setAuthToken('invalid.token')
+      expect(isAuthenticated()).toBe(false)
+    })
+
+    it('returns false for token with four parts', () => {
+      setAuthToken('invalid.token.with.toomany')
+      expect(isAuthenticated()).toBe(false)
+    })
+
+    it('returns false for token with invalid base64url encoding', () => {
+      // Create a token with invalid base64url in payload section
+      setAuthToken('header.@@@invalid@@@.signature')
+      expect(isAuthenticated()).toBe(false)
+    })
+
+    it('returns false for token with non-JSON payload', () => {
+      // Create a token with valid base64url but invalid JSON
+      // "not-json" in base64url is "bm90LWpzb24"
+      setAuthToken('header.bm90LWpzb24.signature')
+      expect(isAuthenticated()).toBe(false)
+    })
+  })
+
+  describe('with valid token structure', () => {
+    /**
+     * Helper function to create a JWT-like token for testing.
+     * Creates a token with header.payload.signature structure where:
+     * - header: {"alg":"HS256","typ":"JWT"} (standard JWT header)
+     * - payload: contains exp claim with provided timestamp
+     * - signature: fake signature (we're only testing expiration logic)
+     */
+    function createTestToken(expirationTimestamp: number): string {
+      const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+      const payload = btoa(JSON.stringify({ sub: 'user-123', exp: expirationTimestamp }))
+      const signature = 'fake-signature'
+      return `${header}.${payload}.${signature}`
+    }
+
+    it('returns true for valid non-expired token', () => {
+      // Create token that expires 1 hour in the future
+      const futureTime = Math.floor(Date.now() / 1000) + 3600
+      const token = createTestToken(futureTime)
+      setAuthToken(token)
+      expect(isAuthenticated()).toBe(true)
+    })
+
+    it('returns false for expired token', () => {
+      // Create token that expired 1 hour ago
+      const pastTime = Math.floor(Date.now() / 1000) - 3600
+      const token = createTestToken(pastTime)
+      setAuthToken(token)
+      expect(isAuthenticated()).toBe(false)
+    })
+
+    it('returns false for token expiring exactly now', () => {
+      // Create token that expires at current second
+      const currentTime = Math.floor(Date.now() / 1000)
+      const token = createTestToken(currentTime)
+      setAuthToken(token)
+      expect(isAuthenticated()).toBe(false)
+    })
+
+    it('returns false for token expired by 1 second', () => {
+      // Create token that expired 1 second ago
+      const justExpired = Math.floor(Date.now() / 1000) - 1
+      const token = createTestToken(justExpired)
+      setAuthToken(token)
+      expect(isAuthenticated()).toBe(false)
+    })
+
+    it('returns true for token expiring in 1 second', () => {
+      // Create token that expires in 1 second
+      const aboutToExpire = Math.floor(Date.now() / 1000) + 1
+      const token = createTestToken(aboutToExpire)
+      setAuthToken(token)
+      expect(isAuthenticated()).toBe(true)
+    })
+
+    it('returns true for token without exp claim', () => {
+      // Create token without expiration (edge case - shouldn't happen with proper JWTs)
+      const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+      const payload = btoa(JSON.stringify({ sub: 'user-123' }))
+      const signature = 'fake-signature'
+      const token = `${header}.${payload}.${signature}`
+      setAuthToken(token)
+      expect(isAuthenticated()).toBe(true)
+    })
+  })
+
+  describe('with base64url encoding edge cases', () => {
+    /**
+     * JWT uses base64url encoding (RFC 4648), which differs from standard base64:
+     * - Uses '-' instead of '+'
+     * - Uses '_' instead of '/'
+     * - Omits padding '=' characters
+     */
+    it('correctly decodes base64url with special characters', () => {
+      // Create a payload that requires base64url special characters
+      const payload = {
+        sub: 'user-123',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        data: 'test>>data',
+      }
+
+      // Manually encode using base64url
+      const jsonStr = JSON.stringify(payload)
+      const base64 = btoa(jsonStr)
+      const base64url = base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+
+      const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+      const token = `${header}.${base64url}.signature`
+      setAuthToken(token)
+
+      expect(isAuthenticated()).toBe(true)
+    })
+
+    it('handles payload requiring padding', () => {
+      // Create short payload that needs padding when decoded
+      const payload = { sub: 'u1', exp: Math.floor(Date.now() / 1000) + 3600 }
+      const jsonStr = JSON.stringify(payload)
+      const base64 = btoa(jsonStr)
+      const base64url = base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+
+      const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+      const token = `${header}.${base64url}.signature`
+      setAuthToken(token)
+
+      expect(isAuthenticated()).toBe(true)
+    })
+  })
+})
+
+describe('apiClient with expired tokens', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  function createTestToken(expirationTimestamp: number): string {
+    const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+    const payload = btoa(JSON.stringify({ sub: 'user-123', exp: expirationTimestamp }))
+    const signature = 'fake-signature'
+    return `${header}.${payload}.${signature}`
+  }
+
+  describe('token expiration handling', () => {
+    it('clears token on 401 Unauthorized response', async () => {
+      const futureTime = Math.floor(Date.now() / 1000) + 3600
+      const token = createTestToken(futureTime)
+      setAuthToken(token)
+
+      // Mock fetch to return 401
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ detail: 'Token has expired' }),
+      })
+
+      // Verify token exists before request
+      expect(getAuthToken()).toBe(token)
+
+      // Make request that will fail with 401
+      await expect(apiClient('/auth/me')).rejects.toThrow(ApiException)
+
+      // Verify token was cleared after 401 response
+      expect(getAuthToken()).toBeNull()
+    })
+
+    it('does not clear token on other error status codes', async () => {
+      const futureTime = Math.floor(Date.now() / 1000) + 3600
+      const token = createTestToken(futureTime)
+      setAuthToken(token)
+
+      // Mock fetch to return 500 Internal Server Error
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ detail: 'Server error' }),
+      })
+
+      // Verify token exists before request
+      expect(getAuthToken()).toBe(token)
+
+      // Make request that will fail with 500
+      await expect(apiClient('/auth/me')).rejects.toThrow(ApiException)
+
+      // Verify token was NOT cleared after non-401 error
+      expect(getAuthToken()).toBe(token)
+    })
+
+    it('throws ApiException with 401 status for expired token', async () => {
+      const futureTime = Math.floor(Date.now() / 1000) + 3600
+      const token = createTestToken(futureTime)
+      setAuthToken(token)
+
+      // Mock fetch to return 401 with token expired message
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ detail: 'Not authenticated' }),
+      })
+
+      try {
+        await apiClient('/auth/me')
+        expect.fail('Should have thrown ApiException')
+      } catch (error) {
+        expect(error).toBeInstanceOf(ApiException)
+        expect((error as ApiException).status).toBe(401)
+        expect((error as ApiException).message).toBe('Not authenticated')
+      }
+    })
+
+    it('includes error detail in ApiException', async () => {
+      const futureTime = Math.floor(Date.now() / 1000) + 3600
+      const token = createTestToken(futureTime)
+      setAuthToken(token)
+
+      const errorDetail = 'Token signature verification failed'
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ detail: errorDetail }),
+      })
+
+      try {
+        await apiClient('/auth/me')
+        expect.fail('Should have thrown ApiException')
+      } catch (error) {
+        expect(error).toBeInstanceOf(ApiException)
+        expect((error as ApiException).detail).toBe(errorDetail)
+      }
+    })
+  })
+
+  describe('authentication requirements', () => {
+    it('throws error when no token exists for authenticated endpoint', async () => {
+      // No token set
+      expect(getAuthToken()).toBeNull()
+
+      try {
+        await apiClient('/auth/me')
+        expect.fail('Should have thrown ApiException')
+      } catch (error) {
+        expect(error).toBeInstanceOf(ApiException)
+        expect((error as ApiException).status).toBe(401)
+        expect((error as ApiException).message).toBe('Authentication required')
+      }
+    })
+
+    it('allows requests without token when requiresAuth is false', async () => {
+      // No token set
+      expect(getAuthToken()).toBeNull()
+
+      // Mock successful response
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ message: 'success' }),
+      })
+
+      const result = await apiClient('/public/endpoint', { requiresAuth: false })
+      expect(result).toEqual({ message: 'success' })
+    })
+
+    it('includes Authorization header for authenticated requests', async () => {
+      const futureTime = Math.floor(Date.now() / 1000) + 3600
+      const token = createTestToken(futureTime)
+      setAuthToken(token)
+
+      // Mock successful response
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ data: 'protected' }),
+      })
+      global.fetch = mockFetch
+
+      await apiClient('/auth/me')
+
+      // Verify fetch was called with Authorization header
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: `Bearer ${token}`,
+          }),
+        })
+      )
+    })
+  })
+})

--- a/frontend/src/api/hooks/useAuth.test.ts
+++ b/frontend/src/api/hooks/useAuth.test.ts
@@ -1,0 +1,469 @@
+/**
+ * Integration tests for authentication hooks with token expiration scenarios.
+ *
+ * Tests cover:
+ * - useCurrentUser with expired tokens
+ * - useLogin token lifecycle
+ * - Token expiration during active session
+ * - Hook behavior when token is cleared
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useCurrentUser, useLogin, useLogout } from './useAuth'
+import { setAuthToken, clearAuthToken, getAuthToken } from '../client'
+import type { ReactNode } from 'react'
+
+/**
+ * Helper function to create a JWT-like token for testing.
+ * Creates a token with header.payload.signature structure.
+ */
+function createTestToken(expirationTimestamp: number): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+  const payload = btoa(JSON.stringify({ sub: 'user-123', exp: expirationTimestamp }))
+  const signature = 'fake-signature'
+  return `${header}.${payload}.${signature}`
+}
+
+/**
+ * Wrapper component that provides React Query context for testing hooks.
+ */
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false, // Disable retries for faster tests
+        gcTime: 0, // Disable garbage collection for predictable tests
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  })
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+describe('useCurrentUser with token expiration', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  describe('expired token scenarios', () => {
+    it('does not fetch when token is expired', async () => {
+      // Create expired token (expired 1 hour ago)
+      const pastTime = Math.floor(Date.now() / 1000) - 3600
+      const expiredToken = createTestToken(pastTime)
+      setAuthToken(expiredToken)
+
+      const mockFetch = vi.fn()
+      global.fetch = mockFetch
+
+      const wrapper = createWrapper()
+      const { result } = renderHook(() => useCurrentUser(), { wrapper })
+
+      // Wait briefly to ensure query has time to potentially run
+      await waitFor(
+        () => {
+          // Query should not be enabled, so fetch should not be called
+          expect(mockFetch).not.toHaveBeenCalled()
+        },
+        { timeout: 500 }
+      )
+
+      // Query should be disabled
+      expect(result.current.data).toBeUndefined()
+    })
+
+    it('does not fetch when no token exists', async () => {
+      // Ensure no token exists
+      clearAuthToken()
+
+      const mockFetch = vi.fn()
+      global.fetch = mockFetch
+
+      const wrapper = createWrapper()
+      const { result } = renderHook(() => useCurrentUser(), { wrapper })
+
+      // Wait briefly to ensure query has time to potentially run
+      await waitFor(
+        () => {
+          expect(mockFetch).not.toHaveBeenCalled()
+        },
+        { timeout: 500 }
+      )
+
+      expect(result.current.data).toBeUndefined()
+    })
+
+    it('fetches successfully when token is valid', async () => {
+      // Create valid token (expires 1 hour in future)
+      const futureTime = Math.floor(Date.now() / 1000) + 3600
+      const validToken = createTestToken(futureTime)
+      setAuthToken(validToken)
+
+      const mockUserData = {
+        id: 'user-123',
+        email: 'test@example.com',
+        name: 'Test User',
+        role: 'user',
+      }
+
+      // Mock successful API response
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => mockUserData,
+      })
+
+      const wrapper = createWrapper()
+      const { result } = renderHook(() => useCurrentUser(), { wrapper })
+
+      // Wait for query to complete
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true)
+      })
+
+      expect(result.current.data).toEqual(mockUserData)
+    })
+
+    it('handles 401 error when server rejects expired token', async () => {
+      // Create token that appears valid client-side but server rejects
+      const futureTime = Math.floor(Date.now() / 1000) + 3600
+      const token = createTestToken(futureTime)
+      setAuthToken(token)
+
+      // Mock 401 response from server
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ detail: 'Token has expired' }),
+      })
+
+      const wrapper = createWrapper()
+      const { result } = renderHook(() => useCurrentUser(), { wrapper })
+
+      // Wait for query to complete
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true)
+      })
+
+      // Verify token was cleared on 401
+      expect(getAuthToken()).toBeNull()
+    })
+  })
+
+  describe('token state changes during active session', () => {
+    it('re-evaluates enabled state when token changes', async () => {
+      // Start with no token
+      clearAuthToken()
+
+      const wrapper = createWrapper()
+      const { result, rerender } = renderHook(() => useCurrentUser(), { wrapper })
+
+      // Initially no data
+      expect(result.current.data).toBeUndefined()
+
+      // Add a valid token
+      const futureTime = Math.floor(Date.now() / 1000) + 3600
+      const validToken = createTestToken(futureTime)
+      setAuthToken(validToken)
+
+      const mockUserData = {
+        id: 'user-456',
+        email: 'newuser@example.com',
+        name: 'New User',
+        role: 'user',
+      }
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => mockUserData,
+      })
+
+      // Trigger re-evaluation
+      rerender()
+
+      // Query should now fetch data
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true)
+      })
+
+      expect(result.current.data).toEqual(mockUserData)
+    })
+  })
+})
+
+describe('useLogin token lifecycle', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  describe('successful login', () => {
+    it('stores token in localStorage after successful login', async () => {
+      expect(getAuthToken()).toBeNull()
+
+      // Mock successful login response with token
+      const mockToken = createTestToken(Math.floor(Date.now() / 1000) + 3600)
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ access_token: mockToken }),
+      })
+
+      const wrapper = createWrapper()
+      const { result } = renderHook(() => useLogin(), { wrapper })
+
+      // Execute login mutation
+      await result.current.mutateAsync({
+        email: 'test@example.com',
+        password: 'password123',
+      })
+
+      // Verify token was stored
+      expect(getAuthToken()).toBe(mockToken)
+    })
+
+    it('invalidates current user query after login', async () => {
+      // Mock login response
+      const mockToken = createTestToken(Math.floor(Date.now() / 1000) + 3600)
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ access_token: mockToken }),
+      })
+
+      const wrapper = createWrapper()
+      const { result: loginResult } = renderHook(() => useLogin(), { wrapper })
+
+      // Execute login
+      await loginResult.current.mutateAsync({
+        email: 'test@example.com',
+        password: 'password123',
+      })
+
+      // After login, verify token exists
+      expect(getAuthToken()).toBe(mockToken)
+    })
+  })
+
+  describe('failed login', () => {
+    it('does not store token when login fails', async () => {
+      expect(getAuthToken()).toBeNull()
+
+      // Mock failed login response
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ detail: 'Invalid credentials' }),
+      })
+
+      const wrapper = createWrapper()
+      const { result } = renderHook(() => useLogin(), { wrapper })
+
+      // Execute login mutation and expect it to fail
+      try {
+        await result.current.mutateAsync({
+          email: 'test@example.com',
+          password: 'wrongpassword',
+        })
+        expect.fail('Should have thrown error')
+      } catch (error) {
+        // Expected to fail
+      }
+
+      // Verify no token was stored
+      expect(getAuthToken()).toBeNull()
+    })
+  })
+})
+
+describe('useLogout token cleanup', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  describe('logout behavior', () => {
+    it('clears token from localStorage', async () => {
+      // Set up a token
+      const token = createTestToken(Math.floor(Date.now() / 1000) + 3600)
+      setAuthToken(token)
+      expect(getAuthToken()).toBe(token)
+
+      const wrapper = createWrapper()
+      const { result } = renderHook(() => useLogout(), { wrapper })
+
+      // Execute logout
+      await result.current.mutateAsync()
+
+      // Verify token was cleared
+      expect(getAuthToken()).toBeNull()
+    })
+
+    it('works when no token exists', async () => {
+      // Ensure no token exists
+      clearAuthToken()
+      expect(getAuthToken()).toBeNull()
+
+      const wrapper = createWrapper()
+      const { result } = renderHook(() => useLogout(), { wrapper })
+
+      // Execute logout (should not throw)
+      await result.current.mutateAsync()
+
+      // Verify still no token
+      expect(getAuthToken()).toBeNull()
+    })
+  })
+})
+
+describe('Token expiration edge cases', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  describe('boundary conditions', () => {
+    it('treats token expiring exactly now as expired', async () => {
+      // Create token expiring at current second
+      const currentTime = Math.floor(Date.now() / 1000)
+      const token = createTestToken(currentTime)
+      setAuthToken(token)
+
+      const mockFetch = vi.fn()
+      global.fetch = mockFetch
+
+      const wrapper = createWrapper()
+      renderHook(() => useCurrentUser(), { wrapper })
+
+      // Query should not fetch with expired token
+      await waitFor(
+        () => {
+          expect(mockFetch).not.toHaveBeenCalled()
+        },
+        { timeout: 500 }
+      )
+    })
+
+    it('treats token expiring in 1 second as valid', async () => {
+      // Create token expiring in 1 second
+      const futureTime = Math.floor(Date.now() / 1000) + 1
+      const token = createTestToken(futureTime)
+      setAuthToken(token)
+
+      const mockUserData = {
+        id: 'user-789',
+        email: 'expiring@example.com',
+        name: 'Expiring User',
+        role: 'user',
+      }
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => mockUserData,
+      })
+
+      const wrapper = createWrapper()
+      const { result } = renderHook(() => useCurrentUser(), { wrapper })
+
+      // Query should fetch with valid token
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true)
+      })
+
+      expect(result.current.data).toEqual(mockUserData)
+    })
+  })
+
+  describe('malformed token handling', () => {
+    it('does not fetch with malformed token', async () => {
+      // Set malformed token
+      setAuthToken('invalid.token')
+
+      const mockFetch = vi.fn()
+      global.fetch = mockFetch
+
+      const wrapper = createWrapper()
+      renderHook(() => useCurrentUser(), { wrapper })
+
+      // Query should not fetch with invalid token
+      await waitFor(
+        () => {
+          expect(mockFetch).not.toHaveBeenCalled()
+        },
+        { timeout: 500 }
+      )
+    })
+
+    it('does not fetch with token missing exp claim', async () => {
+      // Create token without exp claim (edge case)
+      const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+      const payload = btoa(JSON.stringify({ sub: 'user-123' }))
+      const signature = 'fake-signature'
+      const token = `${header}.${payload}.${signature}`
+      setAuthToken(token)
+
+      const mockUserData = {
+        id: 'user-no-exp',
+        email: 'noexp@example.com',
+        name: 'No Expiry User',
+        role: 'user',
+      }
+
+      // Token without exp is treated as valid by isAuthenticated()
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => mockUserData,
+      })
+
+      const wrapper = createWrapper()
+      const { result } = renderHook(() => useCurrentUser(), { wrapper })
+
+      // Query should fetch (token treated as valid when no exp)
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true)
+      })
+
+      expect(result.current.data).toEqual(mockUserData)
+    })
+  })
+})


### PR DESCRIPTION
## Work in Progress

Closes #278

Add test for auth token expiration scenarios

<!-- sharkrite-source-issue:248 -->## From PR #269 Assessment

**Severity:** MEDIUM
**Category:** Security

## Issue
Token expiration testing is a valid security-relevant concern for authentication code. However, the original issue scope is about adding test coverage for routing and components, not implementing comprehensive authentication edge case testing. Token refresh flows are a distinct concern requiring understanding of the auth implementation.

## Context
The issue explicitly notes that comprehensive test coverage exceeds the 1hr time budget and is not in acceptance criteria. Token expiration scenarios require understanding the refresh token implementation and designing appropriate test fixtures.

## Defer Reason
Scope exceeds time budget - requires designing test fixtures for token lifecycle scenarios

---
_Created by Sharkrite assessment on 2026-03-24T21:45:13Z_
_Parent PR: #269_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+2 added, ~0 modified, -0 deleted)
- `A` frontend/src/api/client.test.ts
- `A` frontend/src/api/hooks/useAuth.test.ts

### Commits
- 68eb4b0 test: Add test for auth token expiration scenarios
- 173870c chore: initialize work on #278 Add test for auth token expiration scenarios
<!-- /sharkrite-changes-summary -->