### PR TITLE
formatRelativeDate doesn't handle future dates

### DIFF
--- a/frontend/src/utils/dateUtils.test.ts
+++ b/frontend/src/utils/dateUtils.test.ts
@@ -160,6 +160,29 @@ describe('dateUtils', () => {
       expect(formatRelativeDate('2026-03-20T14:30:00Z')).toBe('today')
       expect(formatRelativeDate('2026-03-19T08:00:00Z')).toBe('yesterday')
     })
+
+    it('returns "tomorrow" for one day in future', () => {
+      expect(formatRelativeDate('2026-03-21')).toBe('tomorrow')
+    })
+
+    it('returns "in Nd" for 2-7 days in future', () => {
+      expect(formatRelativeDate('2026-03-22')).toBe('in 2d')
+      expect(formatRelativeDate('2026-03-25')).toBe('in 5d')
+      expect(formatRelativeDate('2026-03-27')).toBe('in 7d')
+    })
+
+    it('returns formatted date for 8+ days in future', () => {
+      const result = formatRelativeDate('2026-03-30')
+      expect(result).toBe('Mar 30')
+
+      const aprResult = formatRelativeDate('2026-04-15')
+      expect(aprResult).toBe('Apr 15')
+    })
+
+    it('handles future dates with ISO datetime strings', () => {
+      expect(formatRelativeDate('2026-03-21T14:30:00Z')).toBe('tomorrow')
+      expect(formatRelativeDate('2026-03-22T08:00:00Z')).toBe('in 2d')
+    })
   })
 
   describe('formatExpirationBadge', () => {

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -93,11 +93,17 @@ export function getDaysSinceDate(dateString: string): number {
 /**
  * Format a date string as a relative time description.
  *
- * Examples:
+ * Examples (past dates):
  * - 0 days ago: "today"
  * - 1 day ago: "yesterday"
  * - 2-7 days ago: "2d ago", "3d ago", etc.
  * - 8+ days ago: "Mar 15", "Jan 3", etc.
+ *
+ * Examples (future dates):
+ * - 0 days from now: "today"
+ * - 1 day from now: "tomorrow"
+ * - 2-7 days from now: "in 2d", "in 3d", etc.
+ * - 8+ days from now: "Mar 25", "Apr 10", etc.
  *
  * @param dateString - Date string in YYYY-MM-DD or ISO 8601 format
  * @returns Human-readable relative date string
@@ -105,11 +111,18 @@ export function getDaysSinceDate(dateString: string): number {
 export function formatRelativeDate(dateString: string): string {
   const daysSince = getDaysSinceDate(dateString)
 
+  // Handle today
   if (daysSince === 0) return 'today'
+
+  // Handle past dates
   if (daysSince === 1) return 'yesterday'
   if (daysSince >= 2 && daysSince <= 7) return `${daysSince}d ago`
 
-  // For older dates, show "Mon DD" format
+  // Handle future dates
+  if (daysSince === -1) return 'tomorrow'
+  if (daysSince <= -2 && daysSince >= -7) return `in ${Math.abs(daysSince)}d`
+
+  // For dates beyond 7 days (past or future), show "Mon DD" format
   const date = parseDateOnly(dateString)
   return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
 }


### PR DESCRIPTION
## Work in Progress

Closes #280

formatRelativeDate doesn't handle future dates

<!-- sharkrite-source-issue:258 -->## From PR #279 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
This is a defensive coding improvement for edge cases. The function is new in this PR, but adding future date handling expands scope beyond the core date-parsing-without-timezone issue and requires deciding on UI behavior for an edge case that may not occur in practice.

## Context
The original issue focuses on timezone handling for existing date formats. Future date handling is a separate concern that would benefit from product input on desired behavior.

## Defer Reason
Needs separate focused PR

---
_Created by Sharkrite assessment on 2026-03-24T22:01:28Z_
_Parent PR: #279_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+0 added, ~2 modified, -0 deleted)
- `M` frontend/src/utils/dateUtils.test.ts
- `M` frontend/src/utils/dateUtils.ts

### Commits
- e8a6011 feat: formatRelativeDate doesn't handle future dates
- 2277f27 chore: initialize work on #280 formatRelativeDate doesn't handle future dates
<!-- /sharkrite-changes-summary -->