### PR TITLE
[1-FE] Home screen — full implementation

### DIFF
--- a/frontend/src/components/home/ExpirationAlerts.tsx
+++ b/frontend/src/components/home/ExpirationAlerts.tsx
@@ -23,7 +23,7 @@ export default function ExpirationAlerts() {
 
   return (
     <section>
-      <SectionHeader>Expiring Soon</SectionHeader>
+      <SectionHeader linkTo="/pantry">Expiring Soon</SectionHeader>
 
       <div className="mt-3">
         {isLoading && (

--- a/frontend/src/components/home/GreetingHeader.tsx
+++ b/frontend/src/components/home/GreetingHeader.tsx
@@ -10,7 +10,7 @@ import { useCurrentUser } from '../../api'
  * - Morning: 5:00-11:59, Afternoon: 12:00-16:59, Evening: 17:00-4:59
  */
 export default function GreetingHeader() {
-  const { data: user } = useCurrentUser()
+  const { data: user, isLoading, isError } = useCurrentUser()
 
   // Get time-based greeting
   const getGreeting = () => {
@@ -31,7 +31,15 @@ export default function GreetingHeader() {
   }
 
   const greeting = getGreeting()
-  const displayName = user?.display_name || user?.username || 'there'
+
+  // Handle loading and error states for user data
+  const getDisplayName = () => {
+    if (isLoading) return '...'
+    if (isError) return 'there'
+    return user?.display_name || user?.username || 'there'
+  }
+
+  const displayName = getDisplayName()
 
   return (
     <div className="mb-2">

--- a/frontend/src/components/home/GreetingHeader.tsx
+++ b/frontend/src/components/home/GreetingHeader.tsx
@@ -1,0 +1,45 @@
+import { useCurrentUser } from '../../api'
+
+/**
+ * GreetingHeader displays personalized greeting based on time of day
+ *
+ * Features:
+ * - Time-based greeting: "Good morning/afternoon/evening"
+ * - Shows logged-in user's display name
+ * - Displays current date in readable format
+ * - Morning: 5:00-11:59, Afternoon: 12:00-16:59, Evening: 17:00-4:59
+ */
+export default function GreetingHeader() {
+  const { data: user } = useCurrentUser()
+
+  // Get time-based greeting
+  const getGreeting = () => {
+    const hour = new Date().getHours()
+    if (hour >= 5 && hour < 12) return 'morning'
+    if (hour >= 12 && hour < 17) return 'afternoon'
+    return 'evening'
+  }
+
+  // Format current date
+  const formatDate = () => {
+    const now = new Date()
+    return now.toLocaleDateString('en-US', {
+      weekday: 'long',
+      month: 'long',
+      day: 'numeric',
+    })
+  }
+
+  const greeting = getGreeting()
+  const displayName = user?.display_name || user?.username || 'there'
+
+  return (
+    <div className="mb-2">
+      <h1 className="text-[22px] font-medium text-text-primary leading-tight">
+        Good {greeting}, {displayName}
+        <span className="text-olive">.</span>
+      </h1>
+      <p className="text-sm text-text-secondary mt-1">{formatDate()}</p>
+    </div>
+  )
+}

--- a/frontend/src/components/home/QuickActionCard.tsx
+++ b/frontend/src/components/home/QuickActionCard.tsx
@@ -13,12 +13,13 @@ export interface QuickActionCardProps {
  * Features:
  * - Icon container: 32x32px square with 8px border radius and cream background
  * - Icon: 18px, olive green stroke (styled by parent)
- * - Title: 14px font weight 500
- * - Description: 12px secondary text color
- * - Card: white background with 12px border radius
+ * - Title: 13px font weight 500
+ * - Description: 11px secondary text color
+ * - Card: white background with 12px border radius and warm border
  * - Hover state: background shifts to #f4f2ea
  * - Fully accessible with semantic button element
  * - 2-column grid layout handled by parent container
+ * - Minimum 44x44px touch target for accessibility
  *
  * @example
  * ```tsx
@@ -42,18 +43,18 @@ export default function QuickActionCard({
     <button
       type="button"
       onClick={onClick}
-      className="w-full bg-white rounded-card p-4 text-left transition-colors duration-200 hover:bg-[#f4f2ea] focus:outline-none focus:ring-2 focus:ring-olive focus:ring-offset-2"
+      className="w-full bg-white rounded-card border border-warm-border p-4 text-left transition-colors duration-200 hover:bg-[#f4f2ea] focus:outline-none focus:ring-2 focus:ring-olive focus:ring-offset-2"
     >
       {/* Icon container: 32x32px, rounded 8px, cream background */}
       <div className="w-8 h-8 rounded-button bg-cream flex items-center justify-center mb-3">
         {icon}
       </div>
 
-      {/* Title: 14px/500 */}
-      <h3 className="text-sm font-medium text-text-primary mb-1">{title}</h3>
+      {/* Title: 13px/500 */}
+      <h3 className="text-[13px] font-medium text-text-primary mb-1">{title}</h3>
 
-      {/* Description: 12px secondary text */}
-      <p className="text-xs text-text-secondary">{description}</p>
+      {/* Description: 11px secondary text */}
+      <p className="text-[11px] text-text-secondary">{description}</p>
     </button>
   )
 }

--- a/frontend/src/components/home/QuickActionsGrid.tsx
+++ b/frontend/src/components/home/QuickActionsGrid.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom'
-import { ShoppingBag, Snowflake, Cookie, Search } from 'lucide-react'
+import { ShoppingBag, Snowflake, Cookie, UtensilsCrossed } from 'lucide-react'
 import QuickActionCard from './QuickActionCard'
 
 /**
@@ -9,7 +9,7 @@ import QuickActionCard from './QuickActionCard'
  * - "I shopped": Navigate to /shopped (bulk purchase flow)
  * - "I froze/thawed": Navigate to /pantry (storage management)
  * - "I ate snacks": Navigate to /pantry with category filter (snack tracking)
- * - "What's around?": Navigate to /pantry (inventory overview)
+ * - "What's for dinner?": Navigate to /plan (meal planning)
  */
 export default function QuickActionsGrid() {
   const navigate = useNavigate()
@@ -35,10 +35,10 @@ export default function QuickActionsGrid() {
         onClick={() => navigate('/pantry')}
       />
       <QuickActionCard
-        icon={<Search size={18} className="stroke-olive" strokeWidth={2} />}
-        title="What's around?"
-        description="View all inventory"
-        onClick={() => navigate('/pantry')}
+        icon={<UtensilsCrossed size={18} className="stroke-olive" strokeWidth={2} />}
+        title="What's for dinner?"
+        description="Plan your meals"
+        onClick={() => navigate('/plan')}
       />
     </div>
   )

--- a/frontend/src/components/home/ReadyToEat.tsx
+++ b/frontend/src/components/home/ReadyToEat.tsx
@@ -25,7 +25,7 @@ export default function ReadyToEat() {
       aria-roledescription="carousel"
       aria-label="Ready to Eat"
     >
-      <SectionHeader>Ready to Eat</SectionHeader>
+      <SectionHeader linkTo="/pantry">Ready to Eat</SectionHeader>
 
       <div className="mt-3">
         {isLoading && (
@@ -51,8 +51,12 @@ export default function ReadyToEat() {
             role="list"
             aria-label="Prepared foods carousel"
           >
-            {items.map((item) => (
-              <PreparedFoodCard key={item.id} item={item} />
+            {items.map((item, index) => (
+              <PreparedFoodCard
+                key={item.id}
+                item={item}
+                isLast={index === items.length - 1}
+              />
             ))}
           </div>
         )}
@@ -63,12 +67,15 @@ export default function ReadyToEat() {
 
 interface PreparedFoodCardProps {
   item: PreparedFoodListResponse
+  isLast?: boolean
 }
 
-function PreparedFoodCard({ item }: PreparedFoodCardProps) {
+function PreparedFoodCard({ item, isLast = false }: PreparedFoodCardProps) {
   return (
     <div
-      className="flex-shrink-0 w-[240px] bg-white rounded-card p-4 border border-warm-border"
+      className={`flex-shrink-0 w-[240px] bg-white rounded-card p-4 border border-warm-border ${
+        isLast ? 'opacity-70' : ''
+      }`}
       role="listitem"
     >
       <div className="flex items-start justify-between mb-2">

--- a/frontend/src/components/ui/SectionHeader.tsx
+++ b/frontend/src/components/ui/SectionHeader.tsx
@@ -1,19 +1,35 @@
 import { ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { ChevronRight } from 'lucide-react'
 
 interface SectionHeaderProps {
   children: ReactNode
+  linkTo?: string
+  linkText?: string
 }
 
 /**
  * SectionHeader renders medium section headings with the signature olive period
  * Typography: 15px / font-medium (500)
  * Usage: <SectionHeader>Fresh Items</SectionHeader> → "Fresh Items."
+ * Optional "See all" link can be added via linkTo and linkText props
  */
-export default function SectionHeader({ children }: SectionHeaderProps) {
+export default function SectionHeader({ children, linkTo, linkText = 'See all' }: SectionHeaderProps) {
   return (
-    <h2 className="text-[15px] font-medium text-text-primary leading-tight">
-      {children}
-      <span className="text-olive">.</span>
-    </h2>
+    <div className="flex items-center justify-between">
+      <h2 className="text-[15px] font-medium text-text-primary leading-tight">
+        {children}
+        <span className="text-olive">.</span>
+      </h2>
+      {linkTo && (
+        <Link
+          to={linkTo}
+          className="flex items-center gap-1 text-xs text-olive hover:text-olive-dark transition-colors"
+        >
+          {linkText}
+          <ChevronRight size={14} />
+        </Link>
+      )}
+    </div>
   )
 }

--- a/frontend/src/components/ui/SectionHeader.tsx
+++ b/frontend/src/components/ui/SectionHeader.tsx
@@ -25,6 +25,7 @@ export default function SectionHeader({ children, linkTo, linkText = 'See all' }
         <Link
           to={linkTo}
           className="flex items-center gap-1 text-xs text-olive hover:text-olive-dark transition-colors"
+          aria-label={`${linkText} ${children}`}
         >
           {linkText}
           <ChevronRight size={14} />

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import PageContainer from '../components/layout/PageContainer'
-import PageTitle from '../components/ui/PageTitle'
+import GreetingHeader from '../components/home/GreetingHeader'
 import QuickActionsGrid from '../components/home/QuickActionsGrid'
 import ExpirationAlerts from '../components/home/ExpirationAlerts'
 import GroceryPreview from '../components/home/GroceryPreview'
@@ -9,7 +9,7 @@ import ReadyToEat from '../components/home/ReadyToEat'
  * Home screen - Primary entry point showing triage-first information
  *
  * Sections:
- * 1. Page title: "Home" with olive period
+ * 1. Greeting header: "Good [morning/afternoon/evening], [name]" with current date
  * 2. Quick actions grid: 4 common actions in 2x2 grid
  * 3. Expiration alerts: Items expiring within 3 days with inline actions
  * 4. Grocery preview: Count of unpurchased items with link to grocery list
@@ -21,8 +21,8 @@ export default function Home() {
   return (
     <PageContainer>
       <div className="py-6 space-y-6">
-        {/* Page title */}
-        <PageTitle>Home</PageTitle>
+        {/* Greeting header */}
+        <GreetingHeader />
 
         {/* Quick actions grid */}
         <QuickActionsGrid />


### PR DESCRIPTION
## Work in Progress

Closes #294

[1-FE] Home screen — full implementation

## Summary

<!-- sharkrite-changes-summary -->
## Changes

**7** files, **2** commits (+1 added, ~6 modified, -0 deleted)
- `M` frontend/src/components/home/ExpirationAlerts.tsx
- `A` frontend/src/components/home/GreetingHeader.tsx
- `M` frontend/src/components/home/QuickActionCard.tsx
- `M` frontend/src/components/home/QuickActionsGrid.tsx
- `M` frontend/src/components/home/ReadyToEat.tsx
- `M` frontend/src/components/ui/SectionHeader.tsx
- `M` frontend/src/pages/Home.tsx

### Commits
- a922236 feat: [1-FE] Home screen — full implementation
- 7a8ff2d chore: initialize work on #294 [1-FE] Home screen — full implementation
<!-- /sharkrite-changes-summary -->

The Home screen is the daily-driver landing page. Implement all 5 sections with real API data: greeting header, quick actions grid, expiring soon carousel, grocery preview, and ready-to-eat carousel. Every section must match `docs/FreshUp-Design-System.md` exactly.

**Priority:** P0 | **Estimate:** 2–2.5 hours | **Depends on:** #282 (Infrastructure/CORS)

## Design References

- Design System Section 6 (Home)
- Design System Section 5.4 (Carousel Pattern)
- ADR Section 5.1 (Quick Actions)

## Implementation

### 1. Greeting Header
"Good [morning/afternoon/evening], [name]" with current date.

### 2. Quick Actions Grid
4 cards in a 2×2 grid:
- "I shopped" → `/shopped`
- "I froze/thawed" → `/pantry` with freeze/thaw context
- "I ate snacks" → `/pantry` with snack consumption context
- "What's for dinner?" → `/plan`

Each card: `rounded-xl`, lucide-react icon, title (13px/500), subtitle (11px secondary), `bg-cream` with `border` in `warm-border`, full-card tap target (min 44×44px).

### 3. Expiring Soon Section
Carousel of inventory items expiring within 3 days via `useInventoryList` with expiration filter. Item name, expiration date, storage badge. "See all →" links to Pantry.

### 4. Grocery Preview Section
Summary card showing unchecked grocery item count by store. "View full list →" to `/grocery`.

### 5. Ready to Eat Section
Carousel of PreparedFood items via `usePreparedFoodList`. Name, date prepared, portions. "See all →" links to prepared foods view.

### Carousel Pattern (all sections)
Per Design System Section 5.4: title with olive period accent, subtitle, "See all →" link, horizontal scroll with `gap: 10px`, last card at `opacity: 0.7`.

## Acceptance Criteria

- [ ] All 5 sections render with real API data
- [ ] Empty states for no-data sections (not blank — descriptive message)
- [ ] Quick action cards navigate to correct routes
- [ ] Carousels scroll horizontally on mobile
- [ ] Greeting reflects time of day and logged-in user's display name
- [ ] Carousel last-card uses `opacity: 0.7`
- [ ] Section titles have olive period accent
- [ ] Cards use `bg-white` on `bg-cream` background
- [ ] Touch targets minimum 44×44px

## DO NOT Scope

- "What's around?" quick action (Phase 3A)
- "Tonight's dinner" MealPlanEntry card (Phase 3C — meal plan data doesn't exist yet)
- Bottom sheets or modals — simple navigation only

---
_Draft PR created automatically by rite for tracking purposes._

---

## Follow-up Issues

**From assessment on 2026-03-25T06:42:03Z:**
- Created: #313 
- Updated: none