### PR TITLE
[ADR] Update Phase 2-4 execution order

### DIFF
--- a/docs/FreshUp-ADR.md
+++ b/docs/FreshUp-ADR.md
@@ -581,6 +581,17 @@ Each phase produces a usable increment of the system. Phases are broken into cle
 
 **Goal:** Populate the recipe database at scale through automated parsing of HelloFresh cards, web scraping, and URL import.
 
+**Note on Execution Order:** While the development areas below are numbered 2A-2D for logical grouping, the recommended execution order differs to prioritize immediate value and manage Ollama dependencies efficiently:
+
+1. **2C (Web Scrapers)** — No Ollama dependency; provides immediate recipe database population
+2. **2A (Ollama Integration Layer)** — LLM infrastructure setup required for subsequent OCR work
+3. **4A (Costco Digital Receipts)** — Receipt ingestion solves a daily pain point; execute before card OCR
+4. **4B (Paper Receipt OCR)** — Extends receipt pipeline to physical receipts
+5. **2B (HelloFresh Card OCR)** — Physical cards are static; can be deferred without urgency
+6. **2D (URL Import & Photo Upload)** — Most URL imports succeed via `recipe-scrapers` wild_mode without LLM
+
+**Rationale:** This order delivers functional value sooner (populated recipe database via 2C, receipt-to-inventory automation via 4A/4B) while deferring lower-urgency OCR work (2B card digitization). The HelloFresh card binder isn't going anywhere; receipt ingestion solves a daily workflow friction point.
+
 **Development Areas:**
 
 #### 2A: Ollama Integration Layer
@@ -788,6 +799,8 @@ The following ideas were generated during brainstorming and are documented for f
 ## 12. Appendix: Development Area Index
 
 For Sharkrite issue generation, each development area maps to a focused set of issues:
+
+**Recommended Execution Order:** While the table below shows logical dependencies and sequential numbering, the recommended execution order for Phases 2 and 4 differs to prioritize immediate-value work and manage dependencies efficiently. Execute in this order: **2C → 2A → 4A → 4B → 2B → 2D**. See Section 8 (Phase 2 — Recipe Ingestion) for detailed rationale.
 
 | Code | Area | Phase | Dependencies |
 |---|---|---|---|


### PR DESCRIPTION
## Work in Progress

Closes #292

[ADR] Update Phase 2-4 execution order

## Summary

<!-- sharkrite-changes-summary -->
## Changes

**1** files, **2** commits (+0 added, ~1 modified, -0 deleted)
- `M` docs/FreshUp-ADR.md

### Commits
- 52c285c wip: auto-commit relevant changes for issue #292 (2026-03-25)
- 72a9ea6 chore: initialize work on #292 [ADR] Update Phase 2-4 execution order
<!-- /sharkrite-changes-summary -->

Update `docs/FreshUp-ADR.md` to reflect the revised execution order for Phases 2 and 4. The original ADR has Phase 2 as a sequential block (2A → 2B → 2C → 2D) followed by Phase 3, then Phase 4. The revised order prioritizes immediate-value work and defers Ollama-dependent areas.

**Priority:** P1 | **Estimate:** 0.5 hours | **Depends on:** Nothing

## New Execution Order

1. **Phase 2C** (Web Scrapers) — no Ollama dependency, immediate recipe database population
2. **Phase 2A** (Ollama Integration Layer) — LLM infrastructure setup
3. **Phase 4A** (Costco Digital Receipts) — receipt ingestion, daily pain point
4. **Phase 4B** (Paper Receipt OCR) — extends receipt pipeline to physical receipts
5. **Phase 2B** (HelloFresh Card OCR) — digitize recipe binder (lowest urgency, cards aren't going anywhere)
6. **Phase 2D** (URL Import & Photo Upload) — on-demand recipe import with LLM fallback

## Rationale

- 2C has no Ollama dependency and provides immediate value (populated recipe database)
- Receipt ingestion (4A/4B) solves a daily workflow pain point and should come before card OCR
- HelloFresh card OCR (2B) is deferred because the physical cards are static — they'll wait
- 2D is last because `recipe-scrapers` wild_mode covers most URL import cases without LLM

## Where to Update

- **Section 8 (Phase Plan):** Add a note under Phase 2 explaining the execution reorder and rationale
- **Appendix (Development Area Index):** Add a "Recommended Execution Order" note below the table

## Acceptance Criteria

- [ ] Section 8 has reorder note with rationale
- [ ] Appendix has "Recommended Execution Order" note
- [ ] Phase numbering and area codes unchanged (2C is still "Phase 2C", 4A is still "Phase 4A")
- [ ] Dependency table unchanged — only execution sequence changes

## DO NOT Scope

- Changing area codes or phase numbers
- Modifying dependency relationships
- Any code changes

---
_Draft PR created automatically by rite for tracking purposes._