### PR TITLE
[1-FE] Pantry screen

### DIFF
--- a/frontend/src/components/inventory/InventoryRow.tsx
+++ b/frontend/src/components/inventory/InventoryRow.tsx
@@ -66,11 +66,11 @@ export default function InventoryRow({ item }: InventoryRowProps) {
   }
 
   // Get expiration color coding per Design System Section 5:
-  // Green >7d, Mocha 3-7d, Terra <3d
+  // Green >7d, Mocha 3-7d, Terra <3d, Terra for expired (food safety)
   const getExpirationColor = (): string => {
     const daysUntil = getDaysUntilExpiration()
     if (daysUntil === null) return 'text-text-primary'
-    if (daysUntil < 0) return 'text-text-primary' // Expired items (default color)
+    if (daysUntil < 0) return 'text-terra' // Expired items (urgent, food safety)
     if (daysUntil <= 3) return 'text-terra' // Urgent: <3 days
     if (daysUntil <= 7) return 'text-mocha' // Attention: 3-7 days
     return 'text-olive' // Healthy: >7 days

--- a/frontend/src/components/inventory/InventoryRow.tsx
+++ b/frontend/src/components/inventory/InventoryRow.tsx
@@ -18,9 +18,13 @@ export interface InventoryRowProps {
 /**
  * InventoryRow component for pantry category lists and snack checklists
  *
- * Features:
- * - Item name: 14px primary text
- * - Expiry badge: relative time ("3d", "tomorrow", "today") in mocha pill
+ * Design System Alignment (Section 5):
+ * - Item name: 13px/500 weight (font-medium)
+ * - Expiration color coding:
+ *   - Green >7 days (healthy)
+ *   - Mocha 3-7 days (attention)
+ *   - Terra <3 days (urgent)
+ * - Expiry badge: relative time ("3d", "tomorrow", "today")
  * - Low stock badge: "low" in terra pill (when below minimum_threshold)
  * - Quantity: right-aligned secondary text (e.g., "2.5 lb")
  * - StorageBadge: tappable, cycles through fridge/freezer/pantry/counter
@@ -59,6 +63,17 @@ export default function InventoryRow({ item }: InventoryRowProps) {
   const shouldShowQuickActions = (): boolean => {
     const daysUntil = getDaysUntilExpiration()
     return daysUntil !== null && daysUntil >= 0 && daysUntil <= 3
+  }
+
+  // Get expiration color coding per Design System Section 5:
+  // Green >7d, Mocha 3-7d, Terra <3d
+  const getExpirationColor = (): string => {
+    const daysUntil = getDaysUntilExpiration()
+    if (daysUntil === null) return 'text-text-primary'
+    if (daysUntil < 0) return 'text-text-primary' // Expired items (default color)
+    if (daysUntil <= 3) return 'text-terra' // Urgent: <3 days
+    if (daysUntil <= 7) return 'text-mocha' // Attention: 3-7 days
+    return 'text-olive' // Healthy: >7 days
   }
 
   // Handle "Ate it" action
@@ -105,10 +120,10 @@ export default function InventoryRow({ item }: InventoryRowProps) {
     )
   }
 
-  const daysUntilExpiration = getDaysUntilExpiration()
   const expiryBadgeText = getExpiryBadgeText()
   const showQuickActions = shouldShowQuickActions()
   const lowStock = isLowStock()
+  const expirationColor = getExpirationColor()
 
   // Check if any mutation is pending
   const isPending =
@@ -122,8 +137,8 @@ export default function InventoryRow({ item }: InventoryRowProps) {
         {/* Item name and badges */}
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
-            {/* Item name: 14px primary text */}
-            <span className="text-[14px] font-normal text-text-primary">
+            {/* Item name: 13px/500 weight with expiration color coding */}
+            <span className={`text-[13px] font-medium ${expirationColor}`}>
               {item.name}
             </span>
 

--- a/frontend/src/components/pantry/StatCards.tsx
+++ b/frontend/src/components/pantry/StatCards.tsx
@@ -8,11 +8,11 @@ interface StatCardsProps {
  * StatCards component displaying pantry statistics
  *
  * Features:
- * - 3-column grid (responsive: stacks on mobile)
- * - Card 1: Total items count
- * - Card 2: Expiring soon count (within 3 days)
- * - Card 3: Low stock count
- * - Cream-dark background with warm-border
+ * - Compact horizontal row layout (3 cards)
+ * - Card 1: Total items count (no accent)
+ * - Card 2: Expiring soon count with terra accent (#c2715a)
+ * - Card 3: Low stock count with mocha accent (#a08b6e)
+ * - Design system alignment per Section 6 (Pantry)
  */
 export default function StatCards({
   totalItems,
@@ -24,33 +24,44 @@ export default function StatCards({
       label: 'Total Items',
       value: totalItems,
       description: 'in pantry',
+      accentColor: null,
     },
     {
       label: 'Expiring Soon',
       value: expiringSoonCount,
       description: 'within 3 days',
+      accentColor: 'terra', // Terra urgency indicator
     },
     {
       label: 'Low Stock',
       value: lowStockCount,
       description: 'staples',
+      accentColor: 'mocha', // Mocha warning indicator
     },
   ]
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+    <div className="grid grid-cols-3 gap-3 mb-6">
       {stats.map((stat) => (
         <div
           key={stat.label}
-          className="bg-cream-dark rounded-card border border-warm-border p-4"
+          className="bg-white rounded-card border border-warm-border p-3"
         >
-          <div className="text-3xl font-medium text-text-primary mb-1">
+          <div
+            className={`text-2xl font-medium mb-1 ${
+              stat.accentColor === 'terra'
+                ? 'text-terra'
+                : stat.accentColor === 'mocha'
+                  ? 'text-mocha'
+                  : 'text-text-primary'
+            }`}
+          >
             {stat.value}
           </div>
-          <div className="text-sm font-medium text-text-primary mb-1">
+          <div className="text-xs font-medium text-text-primary mb-0.5">
             {stat.label}
           </div>
-          <div className="text-xs text-text-secondary">{stat.description}</div>
+          <div className="text-[10px] text-text-secondary">{stat.description}</div>
         </div>
       ))}
     </div>

--- a/frontend/src/pages/Pantry.tsx
+++ b/frontend/src/pages/Pantry.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect, useRef } from 'react'
+import { Link } from 'react-router-dom'
 import PageContainer from '../components/layout/PageContainer'
 import { PageTitle } from '../components/ui'
 import StorageTabs from '../components/pantry/StorageTabs'
@@ -166,12 +167,24 @@ export default function Pantry() {
               <CategoryGroup key={category} category={category} items={items} />
             ))}
           </div>
+        ) : allItems.length === 0 ? (
+          /* Empty state: "Your pantry is empty" with CTA to "I shopped" flow */
+          <div className="bg-white rounded-card border border-warm-border p-8 text-center">
+            <p className="text-text-primary text-base font-medium mb-4">
+              Your pantry is empty
+            </p>
+            <Link
+              to="/shopped"
+              className="inline-block px-6 py-2.5 bg-olive text-cream text-sm font-medium rounded-button hover:bg-olive-dark transition-colors"
+            >
+              I shopped
+            </Link>
+          </div>
         ) : (
+          /* All items are expiring - show message */
           <div className="bg-white rounded-card border border-warm-border p-6">
             <p className="text-text-secondary">
-              {allItems.length === 0
-                ? 'No items in pantry yet. Add items to get started!'
-                : 'All items are expiring soon. Check the triage sections above.'}
+              All items are expiring soon. Check the triage sections above.
             </p>
           </div>
         )}


### PR DESCRIPTION
## Work in Progress

Closes #295

[1-FE] Pantry screen

## Summary

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **2** commits (+0 added, ~3 modified, -0 deleted)
- `M` frontend/src/components/inventory/InventoryRow.tsx
- `M` frontend/src/components/pantry/StatCards.tsx
- `M` frontend/src/pages/Pantry.tsx

### Commits
- 798f14e feat: [1-FE] Pantry screen
- d9e14d1 chore: initialize work on #295 [1-FE] Pantry screen
<!-- /sharkrite-changes-summary -->

Pantry is the most complete screen but needs design system alignment. Polish stat cards, expiring triage section, low stock section, category groups, InventoryRow, and empty state to match `docs/FreshUp-Design-System.md` exactly.

**Priority:** P1 | **Estimate:** 1.5 hours | **Depends on:** #293 (Infrastructure/CORS)

## Design References

- Design System Section 5 (InventoryRow, StorageBadge)
- Design System Section 6 (Pantry)

## Implementation

### 1. Stat Cards
Compact horizontal row: total items, expiring within 3 days (terra accent), low stock (mocha accent).

### 2. Expiring Triage Section
Above full inventory. Items expiring ≤3 days with inline actions (use, freeze, toss). Terra urgency indicator.

### 3. Low Stock Section
Items below staple threshold with progress bar (current/threshold). "Add to grocery list" inline action.

### 4. Category Groups
Verify collapse/expand matches design system. Category name formatting, item count badge, chevron rotation animation.

### 5. InventoryRow
Match Design System Section 5: name (13px/500), quantity+unit, StorageBadge (tappable, cycles locations), expiration color coding (green >7d, mocha 3-7d, terra <3d).

### 6. Empty State
"Your pantry is empty" with CTA to "I shopped" flow.

## Acceptance Criteria

- [ ] Stat cards in horizontal row with correct accent colors (terra for expiring, mocha for low stock)
- [ ] Triage sections appear above full inventory
- [ ] StorageBadge visually distinct per location and cycles on tap
- [ ] Category groups collapse/expand with animation
- [ ] Expiration color coding: green >7d, mocha 3-7d, terra <3d
- [ ] Empty state renders when no inventory
- [ ] All data from existing hooks — no new API endpoints
- [ ] `font-medium` headings, olive period on section titles

## DO NOT Scope

- New API endpoints — all data from existing hooks
- Pantry cross-reference features (Issue #302)

---
_Draft PR created automatically by rite for tracking purposes._