### PR TITLE
[1-FE] Recipe browse & grid screen

### DIFF
--- a/frontend/src/components/recipe/__tests__/FilterChips.test.tsx
+++ b/frontend/src/components/recipe/__tests__/FilterChips.test.tsx
@@ -1,0 +1,344 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import FilterChips, { type RecipeFilters } from '../FilterChips'
+
+describe('FilterChips', () => {
+  const mockOnFilterChange = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('filter dropdowns', () => {
+    it('renders all three filter dropdowns', () => {
+      render(<FilterChips filters={{}} onFilterChange={mockOnFilterChange} />)
+
+      expect(screen.getByDisplayValue('All sources')).toBeInTheDocument()
+      expect(screen.getByDisplayValue('Any time')).toBeInTheDocument()
+      expect(screen.getByDisplayValue('All cuisines')).toBeInTheDocument()
+    })
+
+    it('renders source type dropdown with all options', () => {
+      render(<FilterChips filters={{}} onFilterChange={mockOnFilterChange} />)
+      const sourceSelect = screen.getByDisplayValue('All sources') as HTMLSelectElement
+
+      const options = Array.from(sourceSelect.options).map((opt) => opt.text)
+      expect(options).toContain('All sources')
+      expect(options).toContain('My recipes')
+      expect(options).toContain('HelloFresh')
+      expect(options).toContain('Ad-hoc')
+    })
+
+    it('renders cook time dropdown with all options', () => {
+      render(<FilterChips filters={{}} onFilterChange={mockOnFilterChange} />)
+      const cookTimeSelect = screen.getByDisplayValue('Any time') as HTMLSelectElement
+
+      const options = Array.from(cookTimeSelect.options).map((opt) => opt.text)
+      expect(options).toContain('Any time')
+      expect(options).toContain('15 min or less')
+      expect(options).toContain('30 min or less')
+      expect(options).toContain('45 min or less')
+      expect(options).toContain('1 hour or less')
+    })
+
+    it('renders cuisine/tag dropdown with all options', () => {
+      render(<FilterChips filters={{}} onFilterChange={mockOnFilterChange} />)
+      const tagSelect = screen.getByDisplayValue('All cuisines') as HTMLSelectElement
+
+      const options = Array.from(tagSelect.options).map((opt) => opt.text)
+      expect(options).toContain('All cuisines')
+      expect(options).toContain('Italian')
+      expect(options).toContain('Mexican')
+      expect(options).toContain('Asian')
+      expect(options).toContain('Vegan')
+      expect(options).toContain('Vegetarian')
+    })
+  })
+
+  describe('filter selection', () => {
+    it('calls onFilterChange when source type is selected', async () => {
+      const user = userEvent.setup()
+      render(<FilterChips filters={{}} onFilterChange={mockOnFilterChange} />)
+      const sourceSelect = screen.getByDisplayValue('All sources')
+
+      await user.selectOptions(sourceSelect, 'manual')
+
+      expect(mockOnFilterChange).toHaveBeenCalledWith({
+        source_type: 'manual',
+      })
+    })
+
+    it('calls onFilterChange when cook time is selected', async () => {
+      const user = userEvent.setup()
+      render(<FilterChips filters={{}} onFilterChange={mockOnFilterChange} />)
+      const cookTimeSelect = screen.getByDisplayValue('Any time')
+
+      await user.selectOptions(cookTimeSelect, '30')
+
+      expect(mockOnFilterChange).toHaveBeenCalledWith({
+        max_cook_time: 30,
+      })
+    })
+
+    it('calls onFilterChange when tag is selected', async () => {
+      const user = userEvent.setup()
+      render(<FilterChips filters={{}} onFilterChange={mockOnFilterChange} />)
+      const tagSelect = screen.getByDisplayValue('All cuisines')
+
+      await user.selectOptions(tagSelect, 'italian')
+
+      expect(mockOnFilterChange).toHaveBeenCalledWith({
+        tag: 'italian',
+      })
+    })
+
+    it('preserves existing filters when adding new filter', async () => {
+      const user = userEvent.setup()
+      const existingFilters: RecipeFilters = {
+        source_type: 'manual',
+        max_cook_time: 30,
+      }
+      render(<FilterChips filters={existingFilters} onFilterChange={mockOnFilterChange} />)
+      const tagSelect = screen.getByDisplayValue('All cuisines')
+
+      await user.selectOptions(tagSelect, 'mexican')
+
+      expect(mockOnFilterChange).toHaveBeenCalledWith({
+        source_type: 'manual',
+        max_cook_time: 30,
+        tag: 'mexican',
+      })
+    })
+
+    it('removes filter when selecting default option (empty value)', async () => {
+      const user = userEvent.setup()
+      const existingFilters: RecipeFilters = {
+        source_type: 'manual',
+      }
+      render(<FilterChips filters={existingFilters} onFilterChange={mockOnFilterChange} />)
+      const sourceSelect = screen.getByDisplayValue('My recipes')
+
+      await user.selectOptions(sourceSelect, '')
+
+      expect(mockOnFilterChange).toHaveBeenCalledWith({})
+    })
+  })
+
+  describe('active filter chips', () => {
+    it('does not render chips when no filters are active', () => {
+      render(<FilterChips filters={{}} onFilterChange={mockOnFilterChange} />)
+      expect(screen.queryByText(/Source:/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Cuisine:/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Max/)).not.toBeInTheDocument()
+    })
+
+    it('renders chip for source_type filter', () => {
+      const filters: RecipeFilters = { source_type: 'manual' }
+      render(<FilterChips filters={filters} onFilterChange={mockOnFilterChange} />)
+      expect(screen.getByText('Source: My recipes')).toBeInTheDocument()
+    })
+
+    it('renders chip for tag filter', () => {
+      const filters: RecipeFilters = { tag: 'italian' }
+      render(<FilterChips filters={filters} onFilterChange={mockOnFilterChange} />)
+      expect(screen.getByText('Cuisine: Italian')).toBeInTheDocument()
+    })
+
+    it('renders chip for max_cook_time filter', () => {
+      const filters: RecipeFilters = { max_cook_time: 30 }
+      render(<FilterChips filters={filters} onFilterChange={mockOnFilterChange} />)
+      expect(screen.getByText('Max 30 min or less')).toBeInTheDocument()
+    })
+
+    it('renders all chips when multiple filters are active', () => {
+      const filters: RecipeFilters = {
+        source_type: 'hellofresh_card',
+        tag: 'mexican',
+        max_cook_time: 45,
+      }
+      render(<FilterChips filters={filters} onFilterChange={mockOnFilterChange} />)
+
+      expect(screen.getByText('Source: HelloFresh')).toBeInTheDocument()
+      expect(screen.getByText('Cuisine: Mexican')).toBeInTheDocument()
+      expect(screen.getByText('Max 45 min or less')).toBeInTheDocument()
+    })
+  })
+
+  describe('chip removal', () => {
+    it('renders remove button for each active chip', () => {
+      const filters: RecipeFilters = {
+        source_type: 'manual',
+        tag: 'italian',
+      }
+      render(<FilterChips filters={filters} onFilterChange={mockOnFilterChange} />)
+
+      expect(screen.getByLabelText('Remove Source: My recipes filter')).toBeInTheDocument()
+      expect(screen.getByLabelText('Remove Cuisine: Italian filter')).toBeInTheDocument()
+    })
+
+    it('removes source_type filter when chip remove button is clicked', async () => {
+      const user = userEvent.setup()
+      const filters: RecipeFilters = {
+        source_type: 'manual',
+        tag: 'italian',
+      }
+      render(<FilterChips filters={filters} onFilterChange={mockOnFilterChange} />)
+
+      const removeButton = screen.getByLabelText('Remove Source: My recipes filter')
+      await user.click(removeButton)
+
+      expect(mockOnFilterChange).toHaveBeenCalledWith({
+        tag: 'italian',
+      })
+    })
+
+    it('removes tag filter when chip remove button is clicked', async () => {
+      const user = userEvent.setup()
+      const filters: RecipeFilters = {
+        source_type: 'manual',
+        tag: 'italian',
+      }
+      render(<FilterChips filters={filters} onFilterChange={mockOnFilterChange} />)
+
+      const removeButton = screen.getByLabelText('Remove Cuisine: Italian filter')
+      await user.click(removeButton)
+
+      expect(mockOnFilterChange).toHaveBeenCalledWith({
+        source_type: 'manual',
+      })
+    })
+
+    it('removes max_cook_time filter when chip remove button is clicked', async () => {
+      const user = userEvent.setup()
+      const filters: RecipeFilters = {
+        max_cook_time: 30,
+        tag: 'vegan',
+      }
+      render(<FilterChips filters={filters} onFilterChange={mockOnFilterChange} />)
+
+      const removeButton = screen.getByLabelText('Remove Max 30 min or less filter')
+      await user.click(removeButton)
+
+      expect(mockOnFilterChange).toHaveBeenCalledWith({
+        tag: 'vegan',
+      })
+    })
+
+    it('removes all filters when last chip is removed', async () => {
+      const user = userEvent.setup()
+      const filters: RecipeFilters = { tag: 'asian' }
+      render(<FilterChips filters={filters} onFilterChange={mockOnFilterChange} />)
+
+      const removeButton = screen.getByLabelText('Remove Cuisine: Asian filter')
+      await user.click(removeButton)
+
+      expect(mockOnFilterChange).toHaveBeenCalledWith({})
+    })
+  })
+
+  describe('filter dropdown and chip synchronization', () => {
+    it('shows selected value in dropdown when filter is active', () => {
+      const filters: RecipeFilters = { source_type: 'manual' }
+      render(<FilterChips filters={filters} onFilterChange={mockOnFilterChange} />)
+
+      const sourceSelect = screen.getByDisplayValue('My recipes') as HTMLSelectElement
+      expect(sourceSelect.value).toBe('manual')
+    })
+
+    it('updates chip when filter is changed via dropdown', async () => {
+      const user = userEvent.setup()
+      const filters: RecipeFilters = { source_type: 'manual' }
+      const { rerender } = render(<FilterChips filters={filters} onFilterChange={mockOnFilterChange} />)
+
+      const sourceSelect = screen.getByDisplayValue('My recipes')
+      await user.selectOptions(sourceSelect, 'hellofresh_card')
+
+      // Simulate parent updating filters prop
+      rerender(
+        <FilterChips
+          filters={{ source_type: 'hellofresh_card' }}
+          onFilterChange={mockOnFilterChange}
+        />
+      )
+
+      expect(screen.getByText('Source: HelloFresh')).toBeInTheDocument()
+      expect(screen.queryByText('Source: My recipes')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('styling', () => {
+    it('applies correct chip styling (olive theme)', () => {
+      const filters: RecipeFilters = { tag: 'italian' }
+      const { container } = render(<FilterChips filters={filters} onFilterChange={mockOnFilterChange} />)
+
+      const chip = container.querySelector('.bg-olive\\/10')
+      expect(chip).toBeInTheDocument()
+      expect(chip).toHaveClass('text-olive')
+      expect(chip).toHaveClass('border-olive/20')
+    })
+
+    it('applies rounded-full styling to filter dropdowns', () => {
+      render(<FilterChips filters={{}} onFilterChange={mockOnFilterChange} />)
+      const sourceSelect = screen.getByDisplayValue('All sources')
+      expect(sourceSelect).toHaveClass('rounded-full')
+    })
+
+    it('applies focus ring to dropdowns', () => {
+      render(<FilterChips filters={{}} onFilterChange={mockOnFilterChange} />)
+      const sourceSelect = screen.getByDisplayValue('All sources')
+      expect(sourceSelect).toHaveClass('focus:ring-2')
+      expect(sourceSelect).toHaveClass('focus:ring-olive')
+    })
+  })
+
+  describe('accessibility', () => {
+    it('chip remove buttons have descriptive aria-labels', () => {
+      const filters: RecipeFilters = {
+        source_type: 'manual',
+        tag: 'italian',
+        max_cook_time: 30,
+      }
+      render(<FilterChips filters={filters} onFilterChange={mockOnFilterChange} />)
+
+      expect(screen.getByLabelText('Remove Source: My recipes filter')).toBeInTheDocument()
+      expect(screen.getByLabelText('Remove Cuisine: Italian filter')).toBeInTheDocument()
+      expect(screen.getByLabelText('Remove Max 30 min or less filter')).toBeInTheDocument()
+    })
+
+    it('dropdowns are keyboard accessible', async () => {
+      const user = userEvent.setup()
+      render(<FilterChips filters={{}} onFilterChange={mockOnFilterChange} />)
+
+      await user.tab()
+      const sourceSelect = screen.getByDisplayValue('All sources')
+      expect(sourceSelect).toHaveFocus()
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles unknown source_type gracefully', () => {
+      const filters: RecipeFilters = { source_type: 'unknown_source' }
+      render(<FilterChips filters={filters} onFilterChange={mockOnFilterChange} />)
+
+      // Should display the raw value if not found in options
+      expect(screen.getByText('Source: unknown_source')).toBeInTheDocument()
+    })
+
+    it('handles unknown tag gracefully', () => {
+      const filters: RecipeFilters = { tag: 'unknown_cuisine' }
+      render(<FilterChips filters={filters} onFilterChange={mockOnFilterChange} />)
+
+      // Should display the raw value if not found in options
+      expect(screen.getByText('Cuisine: unknown_cuisine')).toBeInTheDocument()
+    })
+
+    it('handles non-standard cook time values', () => {
+      const filters: RecipeFilters = { max_cook_time: 90 }
+      render(<FilterChips filters={filters} onFilterChange={mockOnFilterChange} />)
+
+      // Should display the numeric value with "min" suffix
+      expect(screen.getByText('Max 90 min')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/components/recipe/__tests__/RecipeGrid.test.tsx
+++ b/frontend/src/components/recipe/__tests__/RecipeGrid.test.tsx
@@ -1,0 +1,609 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+import userEvent from '@testing-library/user-event'
+import RecipeGrid from '../RecipeGrid'
+import { useRecipeList } from '../../../api'
+import type { RecipeFilters } from '../FilterChips'
+
+// Mock the API hook
+vi.mock('../../../api', () => ({
+  useRecipeList: vi.fn(),
+}))
+
+// Helper to render component with Router context
+const renderWithRouter = (ui: React.ReactElement) => {
+  return render(<BrowserRouter>{ui}</BrowserRouter>)
+}
+
+describe('RecipeGrid', () => {
+  const mockOnFilterChange = vi.fn()
+  const mockOnBack = vi.fn()
+
+  const mockRecipes = [
+    {
+      id: 'recipe-1',
+      name: 'Pasta Carbonara',
+      source_type: 'manual',
+      cook_time_minutes: 20,
+      prep_time_minutes: 10,
+      tags: ['italian'],
+      created_at: '2024-01-01',
+      base_servings: 4,
+    },
+    {
+      id: 'recipe-2',
+      name: 'Chicken Tacos',
+      source_type: 'hellofresh_card',
+      cook_time_minutes: 25,
+      prep_time_minutes: 15,
+      tags: ['mexican'],
+      created_at: '2024-01-02',
+      base_servings: 2,
+    },
+  ]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('basic rendering', () => {
+    it('renders back button', () => {
+      vi.mocked(useRecipeList).mockReturnValue({
+        data: [],
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      renderWithRouter(
+        <RecipeGrid
+          searchQuery=""
+          filters={{}}
+          onFilterChange={mockOnFilterChange}
+          onBack={mockOnBack}
+        />
+      )
+
+      expect(screen.getByRole('button', { name: 'Back to browse view' })).toBeInTheDocument()
+    })
+
+    it('renders FilterChips component', () => {
+      vi.mocked(useRecipeList).mockReturnValue({
+        data: [],
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      renderWithRouter(
+        <RecipeGrid
+          searchQuery=""
+          filters={{}}
+          onFilterChange={mockOnFilterChange}
+          onBack={mockOnBack}
+        />
+      )
+
+      // FilterChips renders dropdowns
+      expect(screen.getByDisplayValue('All sources')).toBeInTheDocument()
+    })
+
+    it('calls onBack when back button is clicked', async () => {
+      const user = userEvent.setup()
+      vi.mocked(useRecipeList).mockReturnValue({
+        data: [],
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      renderWithRouter(
+        <RecipeGrid
+          searchQuery=""
+          filters={{}}
+          onFilterChange={mockOnFilterChange}
+          onBack={mockOnBack}
+        />
+      )
+
+      const backButton = screen.getByRole('button', { name: 'Back to browse view' })
+      await user.click(backButton)
+
+      expect(mockOnBack).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('loading state', () => {
+    it('displays loading message when initial load', () => {
+      vi.mocked(useRecipeList).mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        isError: false,
+        error: null,
+      } as any)
+
+      renderWithRouter(
+        <RecipeGrid
+          searchQuery=""
+          filters={{}}
+          onFilterChange={mockOnFilterChange}
+          onBack={mockOnBack}
+        />
+      )
+
+      expect(screen.getByText('Loading recipes...')).toBeInTheDocument()
+    })
+
+    it('does not display loading message during pagination', () => {
+      vi.mocked(useRecipeList).mockReturnValue({
+        data: mockRecipes,
+        isLoading: true,
+        isError: false,
+        error: null,
+      } as any)
+
+      renderWithRouter(
+        <RecipeGrid
+          searchQuery=""
+          filters={{}}
+          onFilterChange={mockOnFilterChange}
+          onBack={mockOnBack}
+        />
+      )
+
+      // Should not show main loading message when data exists
+      expect(screen.queryByText('Loading recipes...')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('error state', () => {
+    it('displays error message when isError is true', () => {
+      vi.mocked(useRecipeList).mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        error: new Error('Network error'),
+      } as any)
+
+      renderWithRouter(
+        <RecipeGrid
+          searchQuery=""
+          filters={{}}
+          onFilterChange={mockOnFilterChange}
+          onBack={mockOnBack}
+        />
+      )
+
+      expect(screen.getByText(/failed to load recipes/i)).toBeInTheDocument()
+      expect(screen.getByText(/network error/i)).toBeInTheDocument()
+    })
+
+    it('displays generic error message when error is not an Error instance', () => {
+      vi.mocked(useRecipeList).mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        error: 'Unknown error',
+      } as any)
+
+      renderWithRouter(
+        <RecipeGrid
+          searchQuery=""
+          filters={{}}
+          onFilterChange={mockOnFilterChange}
+          onBack={mockOnBack}
+        />
+      )
+
+      expect(screen.getByText(/failed to load recipes/i)).toBeInTheDocument()
+      expect(screen.getByText(/please try again/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('empty state', () => {
+    it('displays empty message when no recipes match filters', () => {
+      vi.mocked(useRecipeList).mockReturnValue({
+        data: [],
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      renderWithRouter(
+        <RecipeGrid
+          searchQuery=""
+          filters={{}}
+          onFilterChange={mockOnFilterChange}
+          onBack={mockOnBack}
+        />
+      )
+
+      expect(screen.getByText('No recipes found')).toBeInTheDocument()
+      expect(screen.getByText('Try adjusting your search or filters')).toBeInTheDocument()
+    })
+  })
+
+  describe('recipe grid display', () => {
+    it('renders recipes in a 2-column grid', () => {
+      vi.mocked(useRecipeList).mockReturnValue({
+        data: mockRecipes,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      const { container } = renderWithRouter(
+        <RecipeGrid
+          searchQuery=""
+          filters={{}}
+          onFilterChange={mockOnFilterChange}
+          onBack={mockOnBack}
+        />
+      )
+
+      const grid = container.querySelector('.grid-cols-2')
+      expect(grid).toBeInTheDocument()
+    })
+
+    it('renders all recipe cards', () => {
+      vi.mocked(useRecipeList).mockReturnValue({
+        data: mockRecipes,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      renderWithRouter(
+        <RecipeGrid
+          searchQuery=""
+          filters={{}}
+          onFilterChange={mockOnFilterChange}
+          onBack={mockOnBack}
+        />
+      )
+
+      expect(screen.getByText('Pasta Carbonara')).toBeInTheDocument()
+      expect(screen.getByText('Chicken Tacos')).toBeInTheDocument()
+    })
+
+    it('displays recipe count', () => {
+      vi.mocked(useRecipeList).mockReturnValue({
+        data: mockRecipes,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      renderWithRouter(
+        <RecipeGrid
+          searchQuery=""
+          filters={{}}
+          onFilterChange={mockOnFilterChange}
+          onBack={mockOnBack}
+        />
+      )
+
+      expect(screen.getByText('2 recipes found')).toBeInTheDocument()
+    })
+
+    it('displays singular form for single recipe', () => {
+      vi.mocked(useRecipeList).mockReturnValue({
+        data: [mockRecipes[0]],
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      renderWithRouter(
+        <RecipeGrid
+          searchQuery=""
+          filters={{}}
+          onFilterChange={mockOnFilterChange}
+          onBack={mockOnBack}
+        />
+      )
+
+      expect(screen.getByText('1 recipe found')).toBeInTheDocument()
+    })
+  })
+
+  describe('search and filter integration', () => {
+    it('passes search query to useRecipeList hook', () => {
+      vi.mocked(useRecipeList).mockReturnValue({
+        data: [],
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      renderWithRouter(
+        <RecipeGrid
+          searchQuery="pasta"
+          filters={{}}
+          onFilterChange={mockOnFilterChange}
+          onBack={mockOnBack}
+        />
+      )
+
+      expect(useRecipeList).toHaveBeenCalledWith(
+        expect.objectContaining({
+          search: 'pasta',
+        })
+      )
+    })
+
+    it('passes filters to useRecipeList hook', () => {
+      vi.mocked(useRecipeList).mockReturnValue({
+        data: [],
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      const filters: RecipeFilters = {
+        source_type: 'manual',
+        tag: 'italian',
+        max_cook_time: 30,
+      }
+
+      renderWithRouter(
+        <RecipeGrid
+          searchQuery=""
+          filters={filters}
+          onFilterChange={mockOnFilterChange}
+          onBack={mockOnBack}
+        />
+      )
+
+      expect(useRecipeList).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source_type: 'manual',
+          tag: 'italian',
+          max_cook_time: 30,
+        })
+      )
+    })
+
+    it('combines search query and filters', () => {
+      vi.mocked(useRecipeList).mockReturnValue({
+        data: [],
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      const filters: RecipeFilters = { tag: 'mexican' }
+
+      renderWithRouter(
+        <RecipeGrid
+          searchQuery="taco"
+          filters={filters}
+          onFilterChange={mockOnFilterChange}
+          onBack={mockOnBack}
+        />
+      )
+
+      expect(useRecipeList).toHaveBeenCalledWith(
+        expect.objectContaining({
+          search: 'taco',
+          tag: 'mexican',
+        })
+      )
+    })
+
+    it('omits search from API call when empty', () => {
+      vi.mocked(useRecipeList).mockReturnValue({
+        data: [],
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      renderWithRouter(
+        <RecipeGrid
+          searchQuery=""
+          filters={{}}
+          onFilterChange={mockOnFilterChange}
+          onBack={mockOnBack}
+        />
+      )
+
+      expect(useRecipeList).toHaveBeenCalledWith(
+        expect.objectContaining({
+          search: undefined,
+        })
+      )
+    })
+  })
+
+  describe('pagination', () => {
+    it('includes limit and offset in API call', () => {
+      vi.mocked(useRecipeList).mockReturnValue({
+        data: [],
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      renderWithRouter(
+        <RecipeGrid
+          searchQuery=""
+          filters={{}}
+          onFilterChange={mockOnFilterChange}
+          onBack={mockOnBack}
+        />
+      )
+
+      expect(useRecipeList).toHaveBeenCalledWith(
+        expect.objectContaining({
+          limit: 100,
+          offset: 0,
+        })
+      )
+    })
+
+    it('shows "Load More" button when full page of recipes returned', () => {
+      // Create 100 recipes (full page)
+      const fullPageRecipes = Array.from({ length: 100 }, (_, i) => ({
+        id: `recipe-${i}`,
+        name: `Recipe ${i}`,
+        source_type: 'manual',
+        cook_time_minutes: 30,
+        prep_time_minutes: 10,
+        tags: ['test'],
+        created_at: '2024-01-01',
+        base_servings: 4,
+      }))
+
+      vi.mocked(useRecipeList).mockReturnValue({
+        data: fullPageRecipes,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      renderWithRouter(
+        <RecipeGrid
+          searchQuery=""
+          filters={{}}
+          onFilterChange={mockOnFilterChange}
+          onBack={mockOnBack}
+        />
+      )
+
+      expect(screen.getByRole('button', { name: 'Load More Recipes' })).toBeInTheDocument()
+    })
+
+    it('does not show "Load More" button when fewer than full page returned', () => {
+      vi.mocked(useRecipeList).mockReturnValue({
+        data: mockRecipes, // Only 2 recipes, less than 100
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      renderWithRouter(
+        <RecipeGrid
+          searchQuery=""
+          filters={{}}
+          onFilterChange={mockOnFilterChange}
+          onBack={mockOnBack}
+        />
+      )
+
+      expect(screen.queryByRole('button', { name: 'Load More Recipes' })).not.toBeInTheDocument()
+    })
+
+    it('shows pagination loading message when loading more recipes', () => {
+      // First render with recipes
+      vi.mocked(useRecipeList).mockReturnValue({
+        data: mockRecipes,
+        isLoading: true,
+        isError: false,
+        error: null,
+      } as any)
+
+      renderWithRouter(
+        <RecipeGrid
+          searchQuery=""
+          filters={{}}
+          onFilterChange={mockOnFilterChange}
+          onBack={mockOnBack}
+        />
+      )
+
+      // Note: This will only show if offset > 0, which requires state management
+      // The test captures the intended behavior
+      expect(screen.queryByText('Loading more recipes...')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('accessibility', () => {
+    it('has aria-live region for results count', () => {
+      vi.mocked(useRecipeList).mockReturnValue({
+        data: mockRecipes,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      const { container } = renderWithRouter(
+        <RecipeGrid
+          searchQuery=""
+          filters={{}}
+          onFilterChange={mockOnFilterChange}
+          onBack={mockOnBack}
+        />
+      )
+
+      const resultsCount = container.querySelector('[aria-live="polite"]')
+      expect(resultsCount).toBeInTheDocument()
+    })
+
+    it('back button has proper aria-label', () => {
+      vi.mocked(useRecipeList).mockReturnValue({
+        data: [],
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      renderWithRouter(
+        <RecipeGrid
+          searchQuery=""
+          filters={{}}
+          onFilterChange={mockOnFilterChange}
+          onBack={mockOnBack}
+        />
+      )
+
+      const backButton = screen.getByRole('button', { name: 'Back to browse view' })
+      expect(backButton).toHaveAttribute('aria-label', 'Back to browse view')
+    })
+  })
+
+  describe('responsive grid', () => {
+    it('applies 2-column grid layout', () => {
+      vi.mocked(useRecipeList).mockReturnValue({
+        data: mockRecipes,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      const { container } = renderWithRouter(
+        <RecipeGrid
+          searchQuery=""
+          filters={{}}
+          onFilterChange={mockOnFilterChange}
+          onBack={mockOnBack}
+        />
+      )
+
+      const grid = container.querySelector('.grid')
+      expect(grid).toHaveClass('grid-cols-2')
+    })
+
+    it('applies gap between grid items', () => {
+      vi.mocked(useRecipeList).mockReturnValue({
+        data: mockRecipes,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      const { container } = renderWithRouter(
+        <RecipeGrid
+          searchQuery=""
+          filters={{}}
+          onFilterChange={mockOnFilterChange}
+          onBack={mockOnBack}
+        />
+      )
+
+      const grid = container.querySelector('.grid')
+      expect(grid).toHaveClass('gap-3')
+    })
+  })
+})

--- a/frontend/src/components/recipe/__tests__/SearchBar.test.tsx
+++ b/frontend/src/components/recipe/__tests__/SearchBar.test.tsx
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SearchBar from '../SearchBar'
+
+describe('SearchBar', () => {
+  const mockOnChange = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+  })
+
+  describe('basic rendering', () => {
+    it('renders search input with default placeholder', () => {
+      render(<SearchBar value="" onChange={mockOnChange} />)
+      expect(screen.getByPlaceholderText('Search recipes...')).toBeInTheDocument()
+    })
+
+    it('renders search input with custom placeholder', () => {
+      render(<SearchBar value="" onChange={mockOnChange} placeholder="Find a recipe" />)
+      expect(screen.getByPlaceholderText('Find a recipe')).toBeInTheDocument()
+    })
+
+    it('renders with initial value', () => {
+      render(<SearchBar value="pasta" onChange={mockOnChange} />)
+      const input = screen.getByPlaceholderText('Search recipes...') as HTMLInputElement
+      expect(input.value).toBe('pasta')
+    })
+
+    it('renders search icon', () => {
+      const { container } = render(<SearchBar value="" onChange={mockOnChange} />)
+      const searchIcon = container.querySelector('svg')
+      expect(searchIcon).toBeInTheDocument()
+    })
+  })
+
+  describe('input interaction', () => {
+    it('updates local value when typing', async () => {
+      const user = userEvent.setup({ delay: null })
+      render(<SearchBar value="" onChange={mockOnChange} />)
+      const input = screen.getByPlaceholderText('Search recipes...')
+
+      await user.type(input, 'curry')
+
+      expect(input).toHaveValue('curry')
+    })
+
+    it('syncs local value with prop value when changed externally', () => {
+      const { rerender } = render(<SearchBar value="pasta" onChange={mockOnChange} />)
+      const input = screen.getByPlaceholderText('Search recipes...') as HTMLInputElement
+      expect(input.value).toBe('pasta')
+
+      // Parent clears the value
+      rerender(<SearchBar value="" onChange={mockOnChange} />)
+      expect(input.value).toBe('')
+    })
+  })
+
+  describe('debounced onChange', () => {
+    it('calls onChange after debounce delay (default 300ms)', async () => {
+      const user = userEvent.setup({ delay: null })
+      render(<SearchBar value="" onChange={mockOnChange} />)
+      const input = screen.getByPlaceholderText('Search recipes...')
+
+      await user.type(input, 'taco')
+
+      // Should not call immediately
+      expect(mockOnChange).not.toHaveBeenCalled()
+
+      // Fast-forward 300ms
+      vi.advanceTimersByTime(300)
+
+      expect(mockOnChange).toHaveBeenCalledTimes(1)
+      expect(mockOnChange).toHaveBeenCalledWith('taco')
+    })
+
+    it('respects custom debounce delay', async () => {
+      const user = userEvent.setup({ delay: null })
+      render(<SearchBar value="" onChange={mockOnChange} debounceMs={500} />)
+      const input = screen.getByPlaceholderText('Search recipes...')
+
+      await user.type(input, 'burger')
+
+      // Should not call after 300ms (default delay)
+      vi.advanceTimersByTime(300)
+      expect(mockOnChange).not.toHaveBeenCalled()
+
+      // Should call after 500ms (custom delay)
+      vi.advanceTimersByTime(200)
+      expect(mockOnChange).toHaveBeenCalledTimes(1)
+      expect(mockOnChange).toHaveBeenCalledWith('burger')
+    })
+
+    it('debounces multiple rapid keystrokes', async () => {
+      const user = userEvent.setup({ delay: null })
+      render(<SearchBar value="" onChange={mockOnChange} />)
+      const input = screen.getByPlaceholderText('Search recipes...')
+
+      await user.type(input, 'chicken')
+
+      // Fast-forward 299ms (just before debounce)
+      vi.advanceTimersByTime(299)
+      expect(mockOnChange).not.toHaveBeenCalled()
+
+      // Type one more character - should reset timer
+      await user.type(input, ' ')
+
+      // Fast-forward 299ms again
+      vi.advanceTimersByTime(299)
+      expect(mockOnChange).not.toHaveBeenCalled()
+
+      // Fast-forward final 1ms to complete debounce
+      vi.advanceTimersByTime(1)
+      expect(mockOnChange).toHaveBeenCalledTimes(1)
+      expect(mockOnChange).toHaveBeenCalledWith('chicken ')
+    })
+
+    it('does not call onChange if value did not change', async () => {
+      render(<SearchBar value="pizza" onChange={mockOnChange} />)
+
+      // Fast-forward past debounce delay
+      vi.advanceTimersByTime(300)
+
+      // Should not call onChange since value matches prop
+      expect(mockOnChange).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('clear button', () => {
+    it('does not show clear button when input is empty', () => {
+      render(<SearchBar value="" onChange={mockOnChange} />)
+      expect(screen.queryByLabelText('Clear search')).not.toBeInTheDocument()
+    })
+
+    it('shows clear button when input has value', async () => {
+      const user = userEvent.setup({ delay: null })
+      render(<SearchBar value="" onChange={mockOnChange} />)
+      const input = screen.getByPlaceholderText('Search recipes...')
+
+      await user.type(input, 'salad')
+
+      expect(screen.getByLabelText('Clear search')).toBeInTheDocument()
+    })
+
+    it('clears input when clear button is clicked', async () => {
+      const user = userEvent.setup()
+      render(<SearchBar value="pasta" onChange={mockOnChange} />)
+      const input = screen.getByPlaceholderText('Search recipes...') as HTMLInputElement
+      const clearButton = screen.getByLabelText('Clear search')
+
+      await user.click(clearButton)
+
+      expect(input.value).toBe('')
+      expect(mockOnChange).toHaveBeenCalledWith('')
+    })
+
+    it('calls onChange immediately when clear button is clicked (no debounce)', async () => {
+      const user = userEvent.setup()
+      render(<SearchBar value="soup" onChange={mockOnChange} />)
+      const clearButton = screen.getByLabelText('Clear search')
+
+      await user.click(clearButton)
+
+      // Should call immediately without waiting for debounce
+      expect(mockOnChange).toHaveBeenCalledTimes(1)
+      expect(mockOnChange).toHaveBeenCalledWith('')
+    })
+
+    it('hides clear button after clearing', async () => {
+      const user = userEvent.setup()
+      render(<SearchBar value="noodles" onChange={mockOnChange} />)
+      const clearButton = screen.getByLabelText('Clear search')
+
+      await user.click(clearButton)
+
+      await waitFor(() => {
+        expect(screen.queryByLabelText('Clear search')).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('accessibility', () => {
+    it('input is keyboard accessible', async () => {
+      const user = userEvent.setup({ delay: null })
+      render(<SearchBar value="" onChange={mockOnChange} />)
+      const input = screen.getByPlaceholderText('Search recipes...')
+
+      await user.tab()
+      expect(input).toHaveFocus()
+    })
+
+    it('clear button has proper aria-label', () => {
+      render(<SearchBar value="test" onChange={mockOnChange} />)
+      const clearButton = screen.getByLabelText('Clear search')
+      expect(clearButton).toHaveAttribute('aria-label', 'Clear search')
+    })
+  })
+
+  describe('styling', () => {
+    it('applies focus styles when input is focused', async () => {
+      const user = userEvent.setup()
+      render(<SearchBar value="" onChange={mockOnChange} />)
+      const input = screen.getByPlaceholderText('Search recipes...')
+
+      await user.click(input)
+
+      expect(input).toHaveClass('focus:ring-2')
+      expect(input).toHaveClass('focus:ring-olive')
+    })
+
+    it('applies correct padding for icons (left and right)', () => {
+      render(<SearchBar value="test" onChange={mockOnChange} />)
+      const input = screen.getByPlaceholderText('Search recipes...')
+
+      expect(input).toHaveClass('pl-10') // Left padding for search icon
+      expect(input).toHaveClass('pr-10') // Right padding for clear button
+    })
+  })
+})

--- a/frontend/src/components/recipe/__tests__/SearchBar.test.tsx
+++ b/frontend/src/components/recipe/__tests__/SearchBar.test.tsx
@@ -183,6 +183,30 @@ describe('SearchBar', () => {
         expect(screen.queryByLabelText('Clear search')).not.toBeInTheDocument()
       })
     })
+
+    it('prevents stale debounced value after clear button is clicked', async () => {
+      const user = userEvent.setup({ delay: null })
+      render(<SearchBar value="" onChange={mockOnChange} />)
+      const input = screen.getByPlaceholderText('Search recipes...')
+
+      // Type text to trigger debounce
+      await user.type(input, 'pizza')
+
+      // Click clear button before debounce fires
+      const clearButton = screen.getByLabelText('Clear search')
+      await user.click(clearButton)
+
+      // Clear should call onChange immediately with empty string
+      expect(mockOnChange).toHaveBeenCalledTimes(1)
+      expect(mockOnChange).toHaveBeenCalledWith('')
+
+      // Advance past the original debounce delay
+      vi.advanceTimersByTime(300)
+
+      // Should still only have been called once (from clear), not with stale 'pizza' value
+      expect(mockOnChange).toHaveBeenCalledTimes(1)
+      expect(mockOnChange).toHaveBeenCalledWith('')
+    })
   })
 
   describe('accessibility', () => {

--- a/frontend/src/components/recipe/__tests__/SectionNav.test.tsx
+++ b/frontend/src/components/recipe/__tests__/SectionNav.test.tsx
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SectionNav from '../SectionNav'
+
+describe('SectionNav', () => {
+  const mockSections = [
+    { id: 'favorites', label: 'Your favorites' },
+    { id: 'quick-meals', label: 'Quick meals' },
+    { id: 'recently-added', label: 'Recently added' },
+    { id: 'italian', label: 'Italian' },
+    { id: 'mexican', label: 'Mexican' },
+  ]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('basic rendering', () => {
+    it('renders all section buttons', () => {
+      render(<SectionNav sections={mockSections} />)
+
+      expect(screen.getByRole('button', { name: 'Your favorites' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Quick meals' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Recently added' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Italian' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Mexican' })).toBeInTheDocument()
+    })
+
+    it('renders as a nav element', () => {
+      const { container } = render(<SectionNav sections={mockSections} />)
+      const nav = container.querySelector('nav')
+      expect(nav).toBeInTheDocument()
+    })
+
+    it('renders empty nav when sections array is empty', () => {
+      const { container } = render(<SectionNav sections={[]} />)
+      const nav = container.querySelector('nav')
+      expect(nav).toBeInTheDocument()
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('section navigation', () => {
+    it('scrolls to section when button is clicked', async () => {
+      const user = userEvent.setup()
+
+      // Create mock section elements in the DOM
+      document.body.innerHTML = `
+        <div id="favorites">Favorites Section</div>
+        <div id="quick-meals">Quick Meals Section</div>
+      `
+
+      const mockScrollTo = vi.fn()
+      window.scrollTo = mockScrollTo
+
+      render(<SectionNav sections={mockSections} />)
+
+      const favoritesButton = screen.getByRole('button', { name: 'Your favorites' })
+      await user.click(favoritesButton)
+
+      expect(mockScrollTo).toHaveBeenCalledWith({
+        top: expect.any(Number),
+        behavior: 'smooth',
+      })
+    })
+
+    it('calculates correct scroll offset (accounting for nav height + padding)', async () => {
+      const user = userEvent.setup()
+
+      // Create mock section element
+      const mockElement = document.createElement('div')
+      mockElement.id = 'favorites'
+      document.body.appendChild(mockElement)
+
+      const mockScrollTo = vi.fn()
+      window.scrollTo = mockScrollTo
+
+      // Mock getBoundingClientRect to return a known position
+      vi.spyOn(mockElement, 'getBoundingClientRect').mockReturnValue({
+        top: 500,
+        bottom: 600,
+        left: 0,
+        right: 0,
+        width: 0,
+        height: 100,
+        x: 0,
+        y: 500,
+        toJSON: () => ({}),
+      })
+
+      Object.defineProperty(window, 'scrollY', { value: 0, writable: true })
+
+      render(<SectionNav sections={mockSections} />)
+
+      const favoritesButton = screen.getByRole('button', { name: 'Your favorites' })
+      await user.click(favoritesButton)
+
+      // Should scroll to: element position (500) + scrollY (0) - offset (120) = 380
+      expect(mockScrollTo).toHaveBeenCalledWith({
+        top: 380,
+        behavior: 'smooth',
+      })
+
+      document.body.removeChild(mockElement)
+    })
+
+    it('handles missing section elements gracefully', async () => {
+      const user = userEvent.setup()
+
+      const mockScrollTo = vi.fn()
+      window.scrollTo = mockScrollTo
+
+      render(<SectionNav sections={mockSections} />)
+
+      const italianButton = screen.getByRole('button', { name: 'Italian' })
+      await user.click(italianButton)
+
+      // Should not throw error, and should not call scrollTo
+      expect(mockScrollTo).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('styling', () => {
+    it('applies sticky positioning', () => {
+      const { container } = render(<SectionNav sections={mockSections} />)
+      const nav = container.querySelector('nav')
+      expect(nav).toHaveClass('sticky')
+      expect(nav).toHaveClass('top-0')
+    })
+
+    it('applies z-index for stacking context', () => {
+      const { container } = render(<SectionNav sections={mockSections} />)
+      const nav = container.querySelector('nav')
+      expect(nav).toHaveClass('z-10')
+    })
+
+    it('applies background color for contrast', () => {
+      const { container } = render(<SectionNav sections={mockSections} />)
+      const nav = container.querySelector('nav')
+      expect(nav).toHaveClass('bg-cream-light')
+    })
+
+    it('applies border bottom for visual separation', () => {
+      const { container } = render(<SectionNav sections={mockSections} />)
+      const nav = container.querySelector('nav')
+      expect(nav).toHaveClass('border-b')
+      expect(nav).toHaveClass('border-warm-border')
+    })
+
+    it('applies horizontal scroll with hidden scrollbar', () => {
+      const { container } = render(<SectionNav sections={mockSections} />)
+      const scrollContainer = container.querySelector('.overflow-x-auto')
+      expect(scrollContainer).toBeInTheDocument()
+      expect(scrollContainer).toHaveClass('scrollbar-hide')
+    })
+
+    it('applies whitespace-nowrap to prevent button wrapping', () => {
+      render(<SectionNav sections={mockSections} />)
+      const button = screen.getByRole('button', { name: 'Your favorites' })
+      expect(button).toHaveClass('whitespace-nowrap')
+    })
+  })
+
+  describe('button interaction', () => {
+    it('applies hover styles to buttons', () => {
+      render(<SectionNav sections={mockSections} />)
+      const button = screen.getByRole('button', { name: 'Quick meals' })
+
+      expect(button).toHaveClass('hover:text-text-primary')
+      expect(button).toHaveClass('hover:bg-warm-gray')
+    })
+
+    it('buttons are keyboard accessible', async () => {
+      const user = userEvent.setup()
+      render(<SectionNav sections={mockSections} />)
+
+      await user.tab()
+      const firstButton = screen.getByRole('button', { name: 'Your favorites' })
+      expect(firstButton).toHaveFocus()
+
+      await user.tab()
+      const secondButton = screen.getByRole('button', { name: 'Quick meals' })
+      expect(secondButton).toHaveFocus()
+    })
+  })
+
+  describe('accessibility', () => {
+    it('uses semantic nav element', () => {
+      const { container } = render(<SectionNav sections={mockSections} />)
+      const nav = container.querySelector('nav')
+      expect(nav?.tagName).toBe('NAV')
+    })
+
+    it('buttons have clear accessible text', () => {
+      render(<SectionNav sections={mockSections} />)
+
+      mockSections.forEach((section) => {
+        const button = screen.getByRole('button', { name: section.label })
+        expect(button.textContent).toBe(section.label)
+      })
+    })
+  })
+
+  describe('responsiveness', () => {
+    it('applies flex-shrink-0 to buttons for horizontal scrolling', () => {
+      render(<SectionNav sections={mockSections} />)
+      const button = screen.getByRole('button', { name: 'Italian' })
+      expect(button).toHaveClass('flex-shrink-0')
+    })
+
+    it('handles long section labels without breaking layout', () => {
+      const longSections = [
+        { id: 'very-long', label: 'This is a very long section name that should not wrap' },
+      ]
+      render(<SectionNav sections={longSections} />)
+      const button = screen.getByRole('button', {
+        name: 'This is a very long section name that should not wrap',
+      })
+      expect(button).toHaveClass('whitespace-nowrap')
+      expect(button).toHaveClass('flex-shrink-0')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles single section', () => {
+      const singleSection = [{ id: 'only', label: 'Only Section' }]
+      render(<SectionNav sections={singleSection} />)
+      expect(screen.getByRole('button', { name: 'Only Section' })).toBeInTheDocument()
+    })
+
+    it('handles sections with special characters in labels', () => {
+      const specialSections = [
+        { id: 'special', label: "Chef's favorites & specials" },
+      ]
+      render(<SectionNav sections={specialSections} />)
+      expect(screen.getByRole('button', { name: "Chef's favorites & specials" })).toBeInTheDocument()
+    })
+
+    it('handles sections with duplicate labels but unique ids', () => {
+      const duplicateLabelSections = [
+        { id: 'italian-1', label: 'Italian' },
+        { id: 'italian-2', label: 'Italian' },
+      ]
+      render(<SectionNav sections={duplicateLabelSections} />)
+      const buttons = screen.getAllByRole('button', { name: 'Italian' })
+      expect(buttons).toHaveLength(2)
+    })
+  })
+})

--- a/frontend/src/components/recipe/__tests__/SectionNav.test.tsx
+++ b/frontend/src/components/recipe/__tests__/SectionNav.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import SectionNav from '../SectionNav'
 
@@ -14,6 +14,11 @@ describe('SectionNav', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+    document.body.innerHTML = ''
   })
 
   describe('basic rendering', () => {
@@ -101,8 +106,6 @@ describe('SectionNav', () => {
         top: 380,
         behavior: 'smooth',
       })
-
-      document.body.removeChild(mockElement)
     })
 
     it('handles missing section elements gracefully', async () => {

--- a/frontend/src/pages/__tests__/Recipes.test.tsx
+++ b/frontend/src/pages/__tests__/Recipes.test.tsx
@@ -1,0 +1,466 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+import userEvent from '@testing-library/user-event'
+import Recipes from '../Recipes'
+import { useRecipeList } from '../../api'
+
+// Mock the API hook
+vi.mock('../../api', () => ({
+  useRecipeList: vi.fn(),
+}))
+
+// Helper to render component with Router context
+const renderWithRouter = (ui: React.ReactElement) => {
+  return render(<BrowserRouter>{ui}</BrowserRouter>)
+}
+
+describe('Recipes Page', () => {
+  const mockRecipes = [
+    {
+      id: 'recipe-1',
+      name: 'Pasta Carbonara',
+      source_type: 'manual',
+      cook_time_minutes: 20,
+      prep_time_minutes: 10,
+      tags: ['italian'],
+      created_at: '2024-01-01',
+      base_servings: 4,
+    },
+    {
+      id: 'recipe-2',
+      name: 'Chicken Tacos',
+      source_type: 'hellofresh_card',
+      cook_time_minutes: 25,
+      prep_time_minutes: 15,
+      tags: ['mexican'],
+      created_at: '2024-01-02',
+      base_servings: 2,
+    },
+  ]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Default mock: successful recipe load
+    vi.mocked(useRecipeList).mockReturnValue({
+      data: mockRecipes,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any)
+  })
+
+  describe('page structure', () => {
+    it('renders page title', () => {
+      renderWithRouter(<Recipes />)
+      expect(screen.getByText('Recipes')).toBeInTheDocument()
+    })
+
+    it('renders search bar', () => {
+      renderWithRouter(<Recipes />)
+      expect(screen.getByPlaceholderText('Search recipes...')).toBeInTheDocument()
+    })
+
+    it('renders in PageContainer', () => {
+      const { container } = renderWithRouter(<Recipes />)
+      // PageContainer provides consistent layout
+      expect(container.querySelector('.py-6')).toBeInTheDocument()
+    })
+  })
+
+  describe('carousel view (default)', () => {
+    it('displays carousel view by default', () => {
+      renderWithRouter(<Recipes />)
+
+      // Should show section navigation
+      expect(screen.getByRole('button', { name: 'Your favorites' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Quick meals' })).toBeInTheDocument()
+    })
+
+    it('renders all carousel sections', () => {
+      renderWithRouter(<Recipes />)
+
+      // Check for section headers (via SectionHeader component which wraps text)
+      expect(screen.getByText('Your favorites')).toBeInTheDocument()
+      expect(screen.getByText('Quick meals')).toBeInTheDocument()
+      expect(screen.getByText('Recently added')).toBeInTheDocument()
+      expect(screen.getByText('Italian')).toBeInTheDocument()
+      expect(screen.getByText('Mexican')).toBeInTheDocument()
+      expect(screen.getByText('Asian')).toBeInTheDocument()
+      expect(screen.getByText('Vegan')).toBeInTheDocument()
+    })
+
+    it('renders section navigation with all sections', () => {
+      renderWithRouter(<Recipes />)
+
+      // Section nav should have all section links
+      expect(screen.getByRole('button', { name: 'Your favorites' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Quick meals' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Recently added' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Italian' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Mexican' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Asian' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Vegan' })).toBeInTheDocument()
+    })
+
+    it('calls useRecipeList for each carousel section', () => {
+      renderWithRouter(<Recipes />)
+
+      // Should be called 7 times (one for each section)
+      expect(useRecipeList).toHaveBeenCalledTimes(7)
+    })
+
+    it('passes correct filters to each carousel', () => {
+      renderWithRouter(<Recipes />)
+
+      // Verify quick-meals section has max_cook_time filter
+      expect(useRecipeList).toHaveBeenCalledWith(
+        expect.objectContaining({
+          limit: 10,
+          max_cook_time: 30,
+        })
+      )
+
+      // Verify italian section has tag filter
+      expect(useRecipeList).toHaveBeenCalledWith(
+        expect.objectContaining({
+          limit: 10,
+          tag: 'italian',
+        })
+      )
+    })
+
+    it('does not render grid components in carousel view', () => {
+      renderWithRouter(<Recipes />)
+
+      // Grid-specific elements should not be present
+      expect(screen.queryByRole('button', { name: 'Back to browse view' })).not.toBeInTheDocument()
+      expect(screen.queryByDisplayValue('All sources')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('search functionality', () => {
+    it('transitions to grid view when typing in search bar', async () => {
+      const user = userEvent.setup({ delay: null })
+      renderWithRouter(<Recipes />)
+
+      const searchInput = screen.getByPlaceholderText('Search recipes...')
+      await user.type(searchInput, 'pasta')
+
+      // Wait for debounce and state update
+      await waitFor(() => {
+        // Grid view should show back button
+        expect(screen.getByRole('button', { name: 'Back to browse view' })).toBeInTheDocument()
+      })
+    })
+
+    it('maintains grid view while search has value', async () => {
+      const user = userEvent.setup({ delay: null })
+      renderWithRouter(<Recipes />)
+
+      const searchInput = screen.getByPlaceholderText('Search recipes...')
+      await user.type(searchInput, 'taco')
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Back to browse view' })).toBeInTheDocument()
+      })
+
+      // Section nav should not be visible in grid mode
+      expect(screen.queryByRole('button', { name: 'Your favorites' })).not.toBeInTheDocument()
+    })
+
+    it('returns to carousel view when search is cleared and no filters active', async () => {
+      const user = userEvent.setup({ delay: null })
+      renderWithRouter(<Recipes />)
+
+      const searchInput = screen.getByPlaceholderText('Search recipes...')
+
+      // Type and then clear
+      await user.type(searchInput, 'soup')
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Back to browse view' })).toBeInTheDocument()
+      })
+
+      // Clear the search
+      await user.clear(searchInput)
+
+      // Should return to carousel view
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Your favorites' })).toBeInTheDocument()
+      })
+    })
+
+    it('does not return to carousel if filters are still active', async () => {
+      const user = userEvent.setup({ delay: null })
+      renderWithRouter(<Recipes />)
+
+      // Type in search to enter grid mode
+      const searchInput = screen.getByPlaceholderText('Search recipes...')
+      await user.type(searchInput, 'pasta')
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Back to browse view' })).toBeInTheDocument()
+      })
+
+      // Add a filter
+      const sourceSelect = screen.getByDisplayValue('All sources')
+      await user.selectOptions(sourceSelect, 'manual')
+
+      // Clear search
+      await user.clear(searchInput)
+
+      // Should stay in grid mode because filter is active
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Back to browse view' })).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('see all functionality', () => {
+    it('transitions to grid view when "See all" is clicked', async () => {
+      const user = userEvent.setup()
+      renderWithRouter(<Recipes />)
+
+      // Find "See all" button for Quick meals section
+      const seeAllButtons = screen.getAllByRole('button', { name: /see all/i })
+      await user.click(seeAllButtons[0])
+
+      // Should show grid view with back button
+      expect(screen.getByRole('button', { name: 'Back to browse view' })).toBeInTheDocument()
+    })
+
+    it('applies section filter when transitioning to grid', async () => {
+      const user = userEvent.setup()
+      renderWithRouter(<Recipes />)
+
+      // Click "See all" on Quick meals (has max_cook_time: 30 filter)
+      const seeAllButtons = screen.getAllByRole('button', { name: /see all/i })
+      const quickMealsSeeAll = seeAllButtons[1] // Second carousel is quick meals
+
+      await user.click(quickMealsSeeAll)
+
+      // Should show grid with filter chip for cook time
+      await waitFor(() => {
+        expect(screen.getByText('Max 30 min or less')).toBeInTheDocument()
+      })
+    })
+
+    it('applies tag filter when "See all" clicked on cuisine section', async () => {
+      const user = userEvent.setup()
+      renderWithRouter(<Recipes />)
+
+      // Click "See all" on Italian section (has tag: 'italian' filter)
+      const seeAllButtons = screen.getAllByRole('button', { name: /see all/i })
+      const italianSeeAll = seeAllButtons[3] // Fourth carousel is Italian
+
+      await user.click(italianSeeAll)
+
+      // Should show grid with cuisine filter chip
+      await waitFor(() => {
+        expect(screen.getByText('Cuisine: Italian')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('back button functionality', () => {
+    it('returns to carousel view when back button is clicked', async () => {
+      const user = userEvent.setup({ delay: null })
+      renderWithRouter(<Recipes />)
+
+      // Enter grid mode via search
+      const searchInput = screen.getByPlaceholderText('Search recipes...')
+      await user.type(searchInput, 'chicken')
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Back to browse view' })).toBeInTheDocument()
+      })
+
+      // Click back button
+      const backButton = screen.getByRole('button', { name: 'Back to browse view' })
+      await user.click(backButton)
+
+      // Should return to carousel view
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Your favorites' })).toBeInTheDocument()
+      })
+    })
+
+    it('clears search and filters when back button is clicked', async () => {
+      const user = userEvent.setup({ delay: null })
+      renderWithRouter(<Recipes />)
+
+      // Enter grid mode and add search + filter
+      const searchInput = screen.getByPlaceholderText('Search recipes...')
+      await user.type(searchInput, 'pasta')
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Back to browse view' })).toBeInTheDocument()
+      })
+
+      const sourceSelect = screen.getByDisplayValue('All sources')
+      await user.selectOptions(sourceSelect, 'manual')
+
+      // Click back
+      const backButton = screen.getByRole('button', { name: 'Back to browse view' })
+      await user.click(backButton)
+
+      // Search should be cleared
+      await waitFor(() => {
+        const clearedInput = screen.getByPlaceholderText('Search recipes...') as HTMLInputElement
+        expect(clearedInput.value).toBe('')
+      })
+
+      // Should be in carousel mode (no filter dropdowns visible)
+      expect(screen.queryByDisplayValue('All sources')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('view mode state management', () => {
+    it('maintains separate state for search query, filters, and view mode', async () => {
+      const user = userEvent.setup({ delay: null })
+      renderWithRouter(<Recipes />)
+
+      // Start in carousel mode
+      expect(screen.getByRole('button', { name: 'Your favorites' })).toBeInTheDocument()
+
+      // Enter search -> grid mode
+      const searchInput = screen.getByPlaceholderText('Search recipes...')
+      await user.type(searchInput, 'curry')
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Back to browse view' })).toBeInTheDocument()
+      })
+
+      // Verify search value is maintained
+      expect(searchInput).toHaveValue('curry')
+    })
+
+    it('handles rapid view mode transitions', async () => {
+      const user = userEvent.setup({ delay: null })
+      renderWithRouter(<Recipes />)
+
+      const searchInput = screen.getByPlaceholderText('Search recipes...')
+
+      // Enter grid mode
+      await user.type(searchInput, 'test')
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Back to browse view' })).toBeInTheDocument()
+      })
+
+      // Back to carousel
+      const backButton = screen.getByRole('button', { name: 'Back to browse view' })
+      await user.click(backButton)
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Your favorites' })).toBeInTheDocument()
+      })
+
+      // Enter grid mode again via "See all"
+      const seeAllButtons = screen.getAllByRole('button', { name: /see all/i })
+      await user.click(seeAllButtons[0])
+
+      // Should be back in grid mode
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Back to browse view' })).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('integration between components', () => {
+    it('SearchBar, SectionNav, and RecipeCarousel work together in carousel view', () => {
+      renderWithRouter(<Recipes />)
+
+      // All three components should be visible
+      expect(screen.getByPlaceholderText('Search recipes...')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Quick meals' })).toBeInTheDocument()
+      expect(screen.getAllByRole('button', { name: /see all/i }).length).toBeGreaterThan(0)
+    })
+
+    it('SearchBar, FilterChips, and RecipeGrid work together in grid view', async () => {
+      const user = userEvent.setup({ delay: null })
+      renderWithRouter(<Recipes />)
+
+      const searchInput = screen.getByPlaceholderText('Search recipes...')
+      await user.type(searchInput, 'burger')
+
+      await waitFor(() => {
+        // All three components should be visible in grid mode
+        expect(screen.getByPlaceholderText('Search recipes...')).toBeInTheDocument()
+        expect(screen.getByDisplayValue('All sources')).toBeInTheDocument() // FilterChips
+        expect(screen.getByRole('button', { name: 'Back to browse view' })).toBeInTheDocument() // RecipeGrid
+      })
+    })
+  })
+
+  describe('accessibility', () => {
+    it('page title is rendered as heading', () => {
+      renderWithRouter(<Recipes />)
+      const heading = screen.getByRole('heading', { name: 'Recipes' })
+      expect(heading).toBeInTheDocument()
+    })
+
+    it('maintains focus management during view transitions', async () => {
+      const user = userEvent.setup({ delay: null })
+      renderWithRouter(<Recipes />)
+
+      const searchInput = screen.getByPlaceholderText('Search recipes...')
+      await user.type(searchInput, 'salad')
+
+      // Input should still be accessible
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Search recipes...')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('carousel section configuration', () => {
+    it('configures favorites section correctly', () => {
+      renderWithRouter(<Recipes />)
+
+      expect(useRecipeList).toHaveBeenCalledWith(
+        expect.objectContaining({
+          limit: 10,
+        })
+      )
+    })
+
+    it('configures quick meals with max_cook_time filter', () => {
+      renderWithRouter(<Recipes />)
+
+      expect(useRecipeList).toHaveBeenCalledWith(
+        expect.objectContaining({
+          limit: 10,
+          max_cook_time: 30,
+        })
+      )
+    })
+
+    it('configures cuisine sections with tag filters', () => {
+      renderWithRouter(<Recipes />)
+
+      // Check Italian section
+      expect(useRecipeList).toHaveBeenCalledWith(
+        expect.objectContaining({
+          limit: 10,
+          tag: 'italian',
+        })
+      )
+
+      // Check Mexican section
+      expect(useRecipeList).toHaveBeenCalledWith(
+        expect.objectContaining({
+          limit: 10,
+          tag: 'mexican',
+        })
+      )
+
+      // Check Asian section
+      expect(useRecipeList).toHaveBeenCalledWith(
+        expect.objectContaining({
+          limit: 10,
+          tag: 'asian',
+        })
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Work in Progress

Closes #296

[1-FE] Recipe browse & grid screen

## Summary

<!-- sharkrite-changes-summary -->
## Changes

**5** files, **2** commits (+5 added, ~0 modified, -0 deleted)
- `A` frontend/src/components/recipe/__tests__/FilterChips.test.tsx
- `A` frontend/src/components/recipe/__tests__/RecipeGrid.test.tsx
- `A` frontend/src/components/recipe/__tests__/SearchBar.test.tsx
- `A` frontend/src/components/recipe/__tests__/SectionNav.test.tsx
- `A` frontend/src/pages/__tests__/Recipes.test.tsx

### Commits
- f4a61a4 feat: [1-FE] Recipe browse & grid screen
- 6129cf6 chore: initialize work on #296 [1-FE] Recipe browse & grid screen
<!-- /sharkrite-changes-summary -->

Two modes on `/recipes` — Spotify-style carousel browse (default) and filtered grid (triggered by search or "See all"). This is where the 200+ recipes from Phase 2C will live in the UI.

**Priority:** P1 | **Estimate:** 2–2.5 hours | **Depends on:** #293 (Infrastructure/CORS)

## Design References

- Design System Section 5.1 (RecipeCard)
- Design System Section 5.4 (Carousel Pattern)
- Design System Section 6 (Browse, Grid, transition)

## Implementation

### Browse Mode (default)
- Search bar at top (typing transitions to grid mode)
- Sticky section nav: "Recent", "Favorites", "Quick meals", "By cuisine" — horizontal scroll, tapping smooth-scrolls to carousel
- Recipe carousels per section using RecipeCard component (Design System Section 5.1):
  - 4:3 image placeholder
  - Name (13px/500)
  - Metadata (cook time · servings · cuisine)
  - Household context ("Cooked 12x" / "Never cooked")
  - Favorite heart overlay (mocha fill if favorited)
  - Last carousel card at `opacity: 0.7`

### Grid Mode (search, "See all", or filter)
- Filter chips (horizontal scroll: cuisine, cook time, dietary)
- Sort dropdown: Relevance, Recently added, Most cooked, Quickest
- 2-column grid of RecipeCard components
- Back to browse: clear search returns to carousels

## Acceptance Criteria

- [ ] Default view shows carousels with data from `useRecipeList`
- [ ] RecipeCard matches Design System Section 5.1 exactly
- [ ] Search transitions to grid mode
- [ ] "See all →" on carousel transitions to grid with pre-applied filter
- [ ] 2-column grid verified at 375px mobile width
- [ ] Tapping RecipeCard navigates to `/recipes/:id`
- [ ] Carousel last-card at `opacity: 0.7`
- [ ] Section titles have olive period accent
- [ ] Cards use `bg-white` on `bg-cream`

## DO NOT Scope

- "Can make now" filtering logic (Phase 3A — the visual toggle is in a later issue)
- Recipe create/edit

---
_Draft PR created automatically by rite for tracking purposes._

---

## Follow-up Issues
 Updated: #323 
**From assessment on 2026-03-25T07:26:15Z:**
- Created: #323 
- Updated: none