### PR TITLE
Stale greeting/date values

### DIFF
--- a/frontend/src/components/home/GreetingHeader.tsx
+++ b/frontend/src/components/home/GreetingHeader.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react'
 import { useCurrentUser } from '../../api'
 
 /**
@@ -8,6 +9,7 @@ import { useCurrentUser } from '../../api'
  * - Shows logged-in user's display name
  * - Displays current date in readable format
  * - Morning: 5:00-11:59, Afternoon: 12:00-16:59, Evening: 17:00-4:59
+ * - Automatically refreshes when app regains visibility or every minute
  */
 export default function GreetingHeader() {
   const { data: user, isLoading, isError } = useCurrentUser()
@@ -30,7 +32,37 @@ export default function GreetingHeader() {
     })
   }
 
-  const greeting = getGreeting()
+  // State for greeting and date to enable automatic refresh
+  const [greeting, setGreeting] = useState(() => getGreeting())
+  const [formattedDate, setFormattedDate] = useState(() => formatDate())
+
+  // Update greeting and date values
+  const updateGreetingAndDate = () => {
+    setGreeting(getGreeting())
+    setFormattedDate(formatDate())
+  }
+
+  // Refresh on visibility change (when user returns to app)
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        updateGreetingAndDate()
+      }
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  }, [])
+
+  // Refresh every minute to catch time boundary changes (e.g., 11:59 AM → 12:00 PM, midnight date change)
+  useEffect(() => {
+    const intervalId = setInterval(updateGreetingAndDate, 60000) // 60000ms = 1 minute
+    return () => {
+      clearInterval(intervalId)
+    }
+  }, [])
 
   // Handle loading and error states for user data
   const getDisplayName = () => {
@@ -47,7 +79,7 @@ export default function GreetingHeader() {
         Good {greeting}, {displayName}
         <span className="text-olive">.</span>
       </h1>
-      <p className="text-sm text-text-secondary mt-1">{formatDate()}</p>
+      <p className="text-sm text-text-secondary mt-1">{formattedDate}</p>
     </div>
   )
 }

--- a/frontend/src/components/home/__tests__/GreetingHeader.test.tsx
+++ b/frontend/src/components/home/__tests__/GreetingHeader.test.tsx
@@ -1,0 +1,380 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import GreetingHeader from '../GreetingHeader'
+import { useCurrentUser } from '../../../api'
+
+// Mock the API hook
+vi.mock('../../../api', () => ({
+  useCurrentUser: vi.fn(),
+}))
+
+describe('GreetingHeader', () => {
+  const mockUser = {
+    id: 'user-1',
+    username: 'testuser',
+    display_name: 'Test User',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Reset to a known date/time for consistent testing
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('basic rendering', () => {
+    it('renders greeting header with user display name', () => {
+      vi.setSystemTime(new Date('2026-03-25T10:00:00'))
+      vi.mocked(useCurrentUser).mockReturnValue({
+        data: mockUser,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      render(<GreetingHeader />)
+
+      expect(screen.getByText(/Good morning, Test User/i)).toBeInTheDocument()
+    })
+
+    it('renders current date in readable format', () => {
+      vi.setSystemTime(new Date('2026-03-25T10:00:00'))
+      vi.mocked(useCurrentUser).mockReturnValue({
+        data: mockUser,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      render(<GreetingHeader />)
+
+      expect(screen.getByText('Tuesday, March 25')).toBeInTheDocument()
+    })
+
+    it('renders olive period after greeting', () => {
+      vi.setSystemTime(new Date('2026-03-25T10:00:00'))
+      vi.mocked(useCurrentUser).mockReturnValue({
+        data: mockUser,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      const { container } = render(<GreetingHeader />)
+      const period = container.querySelector('.text-olive')
+
+      expect(period).toBeInTheDocument()
+      expect(period?.textContent).toBe('.')
+    })
+  })
+
+  describe('time-based greetings', () => {
+    it('displays "Good morning" between 5:00 and 11:59', () => {
+      vi.setSystemTime(new Date('2026-03-25T08:30:00'))
+      vi.mocked(useCurrentUser).mockReturnValue({
+        data: mockUser,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      render(<GreetingHeader />)
+
+      expect(screen.getByText(/Good morning/i)).toBeInTheDocument()
+    })
+
+    it('displays "Good afternoon" between 12:00 and 16:59', () => {
+      vi.setSystemTime(new Date('2026-03-25T14:30:00'))
+      vi.mocked(useCurrentUser).mockReturnValue({
+        data: mockUser,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      render(<GreetingHeader />)
+
+      expect(screen.getByText(/Good afternoon/i)).toBeInTheDocument()
+    })
+
+    it('displays "Good evening" between 17:00 and 4:59', () => {
+      vi.setSystemTime(new Date('2026-03-25T20:00:00'))
+      vi.mocked(useCurrentUser).mockReturnValue({
+        data: mockUser,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      render(<GreetingHeader />)
+
+      expect(screen.getByText(/Good evening/i)).toBeInTheDocument()
+    })
+
+    it('displays "Good evening" in early morning (before 5:00)', () => {
+      vi.setSystemTime(new Date('2026-03-25T02:00:00'))
+      vi.mocked(useCurrentUser).mockReturnValue({
+        data: mockUser,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      render(<GreetingHeader />)
+
+      expect(screen.getByText(/Good evening/i)).toBeInTheDocument()
+    })
+
+    it('transitions from morning to afternoon at noon boundary', () => {
+      vi.setSystemTime(new Date('2026-03-25T11:59:59'))
+      vi.mocked(useCurrentUser).mockReturnValue({
+        data: mockUser,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      render(<GreetingHeader />)
+      expect(screen.getByText(/Good morning/i)).toBeInTheDocument()
+
+      // Simulate time passing to noon
+      vi.setSystemTime(new Date('2026-03-25T12:00:00'))
+      vi.advanceTimersByTime(60000) // Advance by 1 minute to trigger interval
+
+      waitFor(() => {
+        expect(screen.getByText(/Good afternoon/i)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('user display name handling', () => {
+    it('displays username when display_name is not available', () => {
+      vi.setSystemTime(new Date('2026-03-25T10:00:00'))
+      vi.mocked(useCurrentUser).mockReturnValue({
+        data: { id: 'user-1', username: 'testuser' },
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      render(<GreetingHeader />)
+
+      expect(screen.getByText(/Good morning, testuser/i)).toBeInTheDocument()
+    })
+
+    it('displays "there" when user data is not available', () => {
+      vi.setSystemTime(new Date('2026-03-25T10:00:00'))
+      vi.mocked(useCurrentUser).mockReturnValue({
+        data: null,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      render(<GreetingHeader />)
+
+      expect(screen.getByText(/Good morning, there/i)).toBeInTheDocument()
+    })
+
+    it('displays "..." while loading user data', () => {
+      vi.setSystemTime(new Date('2026-03-25T10:00:00'))
+      vi.mocked(useCurrentUser).mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        isError: false,
+        error: null,
+      } as any)
+
+      render(<GreetingHeader />)
+
+      expect(screen.getByText(/Good morning, \.\.\./i)).toBeInTheDocument()
+    })
+
+    it('displays "there" when there is an error loading user data', () => {
+      vi.setSystemTime(new Date('2026-03-25T10:00:00'))
+      vi.mocked(useCurrentUser).mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        error: new Error('Network error'),
+      } as any)
+
+      render(<GreetingHeader />)
+
+      expect(screen.getByText(/Good morning, there/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('automatic refresh functionality', () => {
+    it('updates greeting after 1 minute interval', async () => {
+      // Start at 11:59 AM (morning)
+      vi.setSystemTime(new Date('2026-03-25T11:59:00'))
+      vi.mocked(useCurrentUser).mockReturnValue({
+        data: mockUser,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      render(<GreetingHeader />)
+      expect(screen.getByText(/Good morning/i)).toBeInTheDocument()
+
+      // Advance time to 12:00 PM (afternoon)
+      vi.setSystemTime(new Date('2026-03-25T12:00:00'))
+      vi.advanceTimersByTime(60000) // Trigger 1-minute interval
+
+      await waitFor(() => {
+        expect(screen.getByText(/Good afternoon/i)).toBeInTheDocument()
+      })
+    })
+
+    it('updates date after midnight', async () => {
+      // Start at 11:59 PM on March 25
+      vi.setSystemTime(new Date('2026-03-25T23:59:00'))
+      vi.mocked(useCurrentUser).mockReturnValue({
+        data: mockUser,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      render(<GreetingHeader />)
+      expect(screen.getByText('Tuesday, March 25')).toBeInTheDocument()
+
+      // Advance time to 12:00 AM on March 26
+      vi.setSystemTime(new Date('2026-03-26T00:00:00'))
+      vi.advanceTimersByTime(60000) // Trigger 1-minute interval
+
+      await waitFor(() => {
+        expect(screen.getByText('Wednesday, March 26')).toBeInTheDocument()
+      })
+    })
+
+    it('updates on visibility change when app regains focus', async () => {
+      // Start at morning
+      vi.setSystemTime(new Date('2026-03-25T10:00:00'))
+      vi.mocked(useCurrentUser).mockReturnValue({
+        data: mockUser,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      render(<GreetingHeader />)
+      expect(screen.getByText(/Good morning/i)).toBeInTheDocument()
+
+      // Simulate time passing while app is in background
+      vi.setSystemTime(new Date('2026-03-25T14:00:00'))
+
+      // Simulate visibility change event
+      Object.defineProperty(document, 'visibilityState', {
+        writable: true,
+        configurable: true,
+        value: 'visible',
+      })
+      document.dispatchEvent(new Event('visibilitychange'))
+
+      await waitFor(() => {
+        expect(screen.getByText(/Good afternoon/i)).toBeInTheDocument()
+      })
+    })
+
+    it('does not update on visibility change when app becomes hidden', async () => {
+      vi.setSystemTime(new Date('2026-03-25T10:00:00'))
+      vi.mocked(useCurrentUser).mockReturnValue({
+        data: mockUser,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      render(<GreetingHeader />)
+      expect(screen.getByText(/Good morning/i)).toBeInTheDocument()
+
+      // Simulate time passing
+      vi.setSystemTime(new Date('2026-03-25T14:00:00'))
+
+      // Simulate app becoming hidden (should not trigger update)
+      Object.defineProperty(document, 'visibilityState', {
+        writable: true,
+        configurable: true,
+        value: 'hidden',
+      })
+      document.dispatchEvent(new Event('visibilitychange'))
+
+      // Should still show morning greeting
+      expect(screen.getByText(/Good morning/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('cleanup on unmount', () => {
+    it('clears interval timer on unmount', () => {
+      vi.setSystemTime(new Date('2026-03-25T10:00:00'))
+      vi.mocked(useCurrentUser).mockReturnValue({
+        data: mockUser,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      const clearIntervalSpy = vi.spyOn(global, 'clearInterval')
+      const { unmount } = render(<GreetingHeader />)
+
+      unmount()
+
+      expect(clearIntervalSpy).toHaveBeenCalled()
+    })
+
+    it('removes visibility change listener on unmount', () => {
+      vi.setSystemTime(new Date('2026-03-25T10:00:00'))
+      vi.mocked(useCurrentUser).mockReturnValue({
+        data: mockUser,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      const removeEventListenerSpy = vi.spyOn(document, 'removeEventListener')
+      const { unmount } = render(<GreetingHeader />)
+
+      unmount()
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
+    })
+  })
+
+  describe('styling', () => {
+    it('applies correct text styles to greeting', () => {
+      vi.setSystemTime(new Date('2026-03-25T10:00:00'))
+      vi.mocked(useCurrentUser).mockReturnValue({
+        data: mockUser,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      const { container } = render(<GreetingHeader />)
+      const heading = container.querySelector('h1')
+
+      expect(heading).toHaveClass('text-[22px]', 'font-medium', 'text-text-primary')
+    })
+
+    it('applies correct text styles to date', () => {
+      vi.setSystemTime(new Date('2026-03-25T10:00:00'))
+      vi.mocked(useCurrentUser).mockReturnValue({
+        data: mockUser,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any)
+
+      const { container } = render(<GreetingHeader />)
+      const date = container.querySelector('p')
+
+      expect(date).toHaveClass('text-sm', 'text-text-secondary', 'mt-1')
+    })
+  })
+})

--- a/frontend/src/components/home/__tests__/GreetingHeader.test.tsx
+++ b/frontend/src/components/home/__tests__/GreetingHeader.test.tsx
@@ -128,7 +128,7 @@ describe('GreetingHeader', () => {
       expect(screen.getByText(/Good evening/i)).toBeInTheDocument()
     })
 
-    it('transitions from morning to afternoon at noon boundary', () => {
+    it('transitions from morning to afternoon at noon boundary', async () => {
       vi.setSystemTime(new Date('2026-03-25T11:59:59'))
       vi.mocked(useCurrentUser).mockReturnValue({
         data: mockUser,
@@ -144,7 +144,7 @@ describe('GreetingHeader', () => {
       vi.setSystemTime(new Date('2026-03-25T12:00:00'))
       vi.advanceTimersByTime(60000) // Advance by 1 minute to trigger interval
 
-      waitFor(() => {
+      await waitFor(() => {
         expect(screen.getByText(/Good afternoon/i)).toBeInTheDocument()
       })
     })


### PR DESCRIPTION
## Work in Progress

Closes #313

Stale greeting/date values

<!-- sharkrite-source-issue:294 -->## From PR #309 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
This is a real bug risk — users keeping the app open across time boundaries will see incorrect information. However, this edge case requires design discussion (which solution: timer, visibility API, or documented behavior?) and is not blocking the core home screen implementation.

## Context


## Defer Reason
Needs design discussion on preferred approach (refresh timer vs visibility change vs acceptance)

---
_Created by Sharkrite assessment on 2026-03-25T06:42:03Z_
_Parent PR: #309_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+1 added, ~1 modified, -0 deleted)
- `M` frontend/src/components/home/GreetingHeader.tsx
- `A` frontend/src/components/home/__tests__/GreetingHeader.test.tsx

### Commits
- 267b462 feat: Stale greeting/date values
- 952188b chore: initialize work on #313 Stale greeting/date values
<!-- /sharkrite-changes-summary -->