### PR TITLE
Potential for Zero-Value Confusion in Validation

### DIFF
--- a/src/schemas/scraper.py
+++ b/src/schemas/scraper.py
@@ -43,12 +43,25 @@ class ScrapedRecipeData(BaseModel):
     author: Optional[str] = Field(default=None, description="Recipe author name")
     site_name: Optional[str] = Field(default=None, description="Name of the source website")
 
-    @field_validator('prep_time_minutes', 'cook_time_minutes', 'total_time_minutes', 'servings')
+    @field_validator('prep_time_minutes', 'cook_time_minutes', 'total_time_minutes')
     @classmethod
-    def validate_non_negative(cls, v: Optional[int]) -> Optional[int]:
-        """Ensure time and serving fields are non-negative if provided."""
+    def validate_non_negative_time(cls, v: Optional[int]) -> Optional[int]:
+        """Ensure time fields are non-negative if provided."""
         if v is not None and v < 0:
             raise ValueError("Value must be non-negative")
+        return v
+
+    @field_validator('servings')
+    @classmethod
+    def validate_positive_servings(cls, v: Optional[int]) -> Optional[int]:
+        """
+        Ensure servings is positive if provided (at least 1).
+
+        Zero servings is semantically invalid and could cause division-by-zero
+        errors in downstream calculations (e.g., scaling recipes per-serving).
+        """
+        if v is not None and v <= 0:
+            raise ValueError("servings must be positive (at least 1)")
         return v
 
     @field_validator('title')

--- a/tests/schemas/test_scraper.py
+++ b/tests/schemas/test_scraper.py
@@ -73,26 +73,35 @@ class TestScrapedRecipeData:
 
     def test_negative_servings_validation(self):
         """Test that negative servings are rejected."""
-        with pytest.raises(ValueError, match="Value must be non-negative"):
+        with pytest.raises(ValueError, match="servings must be positive"):
             ScrapedRecipeData(
                 source_url="https://example.com/recipe",
                 source_type="url_import",
                 servings=-2
             )
 
-    def test_zero_values_allowed(self):
-        """Test that zero values are allowed for time and servings."""
+    def test_zero_time_values_allowed(self):
+        """Test that zero values are allowed for time fields (e.g., no-cook recipes)."""
         data = ScrapedRecipeData(
             source_url="https://example.com/recipe",
             source_type="url_import",
             prep_time_minutes=0,
             cook_time_minutes=0,
-            servings=0
+            total_time_minutes=0
         )
 
         assert data.prep_time_minutes == 0
         assert data.cook_time_minutes == 0
-        assert data.servings == 0
+        assert data.total_time_minutes == 0
+
+    def test_zero_servings_rejected(self):
+        """Test that zero servings are rejected (semantically invalid)."""
+        with pytest.raises(ValueError, match="servings must be positive"):
+            ScrapedRecipeData(
+                source_url="https://example.com/recipe",
+                source_type="url_import",
+                servings=0
+            )
 
     def test_title_whitespace_stripping(self):
         """Test that title whitespace is stripped."""


### PR DESCRIPTION
## Work in Progress

Closes #314

Potential for Zero-Value Confusion in Validation

<!-- sharkrite-source-issue:303 -->## From PR #310 Assessment

**Severity:** MEDIUM
**Category:** BugRisk

## Issue
The validator at lines 46-52 in `scraper.py` allows `servings=0` which is semantically invalid for recipes. While this is a real potential bug (downstream division-by-zero), it requires design consideration about whether to enforce at schema level or let consumers handle it. This is a defensive improvement, not a breaking bug in the current PR scope.

## Context
The original issue scope is "returns normalized Pydantic model" — the model currently normalizes without strict semantic validation. This is a valid improvement but outside the explicit acceptance criteria.

## Defer Reason
Needs separate focused PR — requires design decision on validation strategy

---
_Created by Sharkrite assessment on 2026-03-25T06:46:37Z_
_Parent PR: #310_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**9** files, **2** commits (+0 added, ~7 modified, -2 deleted)
- `M` .scratchpad.md
- `M` frontend/src/components/recipe/RecipeHeader.tsx
- `D` frontend/src/components/recipe/RecipeStep.test.tsx
- `M` frontend/src/components/recipe/RecipeStep.tsx
- `D` frontend/src/components/recipe/ServingsControl.test.tsx
- `M` frontend/src/components/recipe/ServingsControl.tsx
- `M` frontend/src/pages/RecipeDetail.tsx
- `M` src/schemas/scraper.py
- `M` tests/schemas/test_scraper.py

### Commits
- 7614ca3 feat: Potential for Zero-Value Confusion in Validation
- 95de8a4 chore: initialize work on #314 Potential for Zero-Value Confusion in Validation
<!-- /sharkrite-changes-summary -->