### PR TITLE
No Request Timeout Configuration

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -45,6 +45,10 @@ class Settings(BaseSettings):
     redis_health_check_interval: int = Field(default=30, ge=0)  # Health check interval (seconds, 0=disabled)
     redis_retry_on_timeout: bool = True  # Retry operations that timeout
 
+    # Recipe Scraper Configuration
+    # Timeout for HTTP requests when scraping recipe URLs
+    scraper_request_timeout: float = Field(default=30.0, gt=0)  # Timeout in seconds (default: 30s)
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/src/services/scraper_service.py
+++ b/src/services/scraper_service.py
@@ -11,11 +11,13 @@ from urllib.parse import urlparse
 import re
 import ipaddress
 import socket
+import requests
 import recipe_scrapers
 from recipe_scrapers._exceptions import WebsiteNotImplementedError
 
 from src.schemas.scraper import ScrapedRecipeData
 from src.db.models.recipe import SourceType
+from src.config import get_settings
 
 
 # Custom exceptions for scraping errors
@@ -186,10 +188,29 @@ def scrape_recipe(url: str) -> ScrapedRecipeData:
     except Exception as e:
         raise ScraperError(f"Invalid URL: {str(e)}")
 
+    # Fetch HTML with timeout configuration to prevent indefinite hangs
+    # The recipe_scrapers library doesn't handle HTTP timeouts directly, so we
+    # fetch the HTML ourselves using requests with a configurable timeout
+    settings = get_settings()
+    timeout = settings.scraper_request_timeout
+
+    try:
+        # Fetch the HTML content with timeout
+        response = requests.get(url, timeout=timeout)
+        response.raise_for_status()  # Raise exception for 4xx/5xx status codes
+        html_content = response.content
+    except requests.exceptions.Timeout as e:
+        raise NetworkError(f"Request timed out after {timeout} seconds: {str(e)}")
+    except requests.exceptions.ConnectionError as e:
+        raise NetworkError(f"Network request failed: {str(e)}")
+    except requests.exceptions.RequestException as e:
+        # Catch other requests-related errors (like HTTPError from raise_for_status)
+        raise NetworkError(f"HTTP request failed: {str(e)}")
+
     try:
         # Attempt to scrape the recipe
         scraper = recipe_scrapers.scrape_html(
-            html=None,
+            html=html_content,
             org_url=url,
             wild_mode=False  # Try site-specific scraper first
         )
@@ -197,7 +218,7 @@ def scrape_recipe(url: str) -> ScrapedRecipeData:
         # Site not supported - try wild_mode (JSON-LD extraction)
         try:
             scraper = recipe_scrapers.scrape_html(
-                html=None,
+                html=html_content,
                 org_url=url,
                 wild_mode=True
             )
@@ -207,10 +228,6 @@ def scrape_recipe(url: str) -> ScrapedRecipeData:
             )
         except Exception as e:
             raise ParseError(f"Failed to parse recipe in wild_mode: {str(e)}")
-    except ConnectionError as e:
-        raise NetworkError(f"Network request failed: {str(e)}")
-    except TimeoutError as e:
-        raise NetworkError(f"Request timed out: {str(e)}")
     except Exception as e:
         # Catch other exceptions from recipe-scrapers
         raise ScraperError(f"Failed to scrape recipe: {str(e)}")

--- a/src/services/scraper_service.py
+++ b/src/services/scraper_service.py
@@ -219,9 +219,8 @@ def scrape_recipe(url: str) -> ScrapedRecipeData:
                 ip_with_brackets = validated_ip
 
             # Reconstruct URL with validated IP, preserving port if present
-            if ':' in parsed.netloc and ']' not in parsed.netloc:  # Has port (not IPv6)
-                port = parsed.netloc.split(':')[1]
-                request_url = f"{parsed.scheme}://{ip_with_brackets}:{port}{parsed.path}"
+            if parsed.port:
+                request_url = f"{parsed.scheme}://{ip_with_brackets}:{parsed.port}{parsed.path}"
                 if parsed.query:
                     request_url += f"?{parsed.query}"
             else:
@@ -238,7 +237,7 @@ def scrape_recipe(url: str) -> ScrapedRecipeData:
 
         # Fetch the HTML content with timeout and disabled redirects
         # Redirects are disabled to prevent redirect-based SSRF bypasses
-        response = requests.get(request_url, timeout=timeout, headers=headers, allow_redirects=False)
+        response = requests.get(request_url, timeout=timeout, headers=headers, allow_redirects=False, verify=True)
         response.raise_for_status()  # Raise exception for 4xx/5xx status codes
         html_content = response.content
     except requests.exceptions.Timeout as e:

--- a/src/services/scraper_service.py
+++ b/src/services/scraper_service.py
@@ -238,6 +238,16 @@ def scrape_recipe(url: str) -> ScrapedRecipeData:
         # Fetch the HTML content with timeout and disabled redirects
         # Redirects are disabled to prevent redirect-based SSRF bypasses
         response = requests.get(request_url, timeout=timeout, headers=headers, allow_redirects=False, verify=True)
+
+        # Check for redirect responses (3xx status codes)
+        # Since allow_redirects=False, we need to explicitly handle these
+        if 300 <= response.status_code < 400:
+            raise NetworkError(
+                f"URL returned a redirect (HTTP {response.status_code}). "
+                f"Redirects are not followed for security reasons. "
+                f"Please use the final destination URL directly."
+            )
+
         response.raise_for_status()  # Raise exception for 4xx/5xx status codes
         html_content = response.content
     except requests.exceptions.Timeout as e:

--- a/src/services/scraper_service.py
+++ b/src/services/scraper_service.py
@@ -106,6 +106,10 @@ def scrape_recipe(url: str) -> ScrapedRecipeData:
     url = url.strip()
 
     # Validate URL to prevent SSRF attacks
+    # Store the validated IP to use for the request to prevent DNS rebinding TOCTOU
+    validated_ip = None
+    original_hostname = None
+
     try:
         parsed = urlparse(url)
 
@@ -130,6 +134,9 @@ def scrape_recipe(url: str) -> ScrapedRecipeData:
             # For IPv4 or domain names, remove port if present
             hostname = hostname.split(':')[0]
 
+        # Store original hostname for Host header
+        original_hostname = hostname
+
         # Block localhost variants by name
         if hostname in ('localhost', 'localhost.localdomain'):
             raise ScraperError("Access to localhost is not allowed")
@@ -150,6 +157,8 @@ def scrape_recipe(url: str) -> ScrapedRecipeData:
             # Block private, loopback, link-local, multicast, and reserved IP addresses
             if not _is_safe_ip(ip):
                 raise ScraperError("Access to private, loopback, link-local, or reserved IP addresses is not allowed")
+            # Store the validated IP for use in the request
+            validated_ip = hostname
         except ValueError:
             # hostname is a domain name, not an IP address
             # Resolve DNS to prevent DNS rebinding attacks
@@ -157,7 +166,7 @@ def scrape_recipe(url: str) -> ScrapedRecipeData:
                 # Get all IP addresses the hostname resolves to
                 addr_info = socket.getaddrinfo(hostname, None, family=socket.AF_UNSPEC, type=socket.SOCK_STREAM)
 
-                # Check each resolved IP address
+                # Check each resolved IP address and store the first safe one
                 for info in addr_info:
                     resolved_ip_str = info[4][0]
                     # Remove IPv6 scope ID if present (e.g., "fe80::1%eth0" -> "fe80::1")
@@ -170,6 +179,9 @@ def scrape_recipe(url: str) -> ScrapedRecipeData:
                             raise ScraperError(
                                 f"Domain resolves to a private, loopback, link-local, or reserved IP address: {resolved_ip_str}"
                             )
+                        # Store the first validated IP for use in the request
+                        if validated_ip is None:
+                            validated_ip = resolved_ip_str
                     except ValueError:
                         # Should not happen with valid getaddrinfo results, but be defensive
                         raise ScraperError(f"Invalid IP address returned from DNS: {resolved_ip_str}")
@@ -195,8 +207,38 @@ def scrape_recipe(url: str) -> ScrapedRecipeData:
     timeout = settings.scraper_request_timeout
 
     try:
-        # Fetch the HTML content with timeout
-        response = requests.get(url, timeout=timeout)
+        # Use the validated IP address if we have one to prevent DNS rebinding TOCTOU
+        # If we don't have a validated IP (e.g., DNS lookup failed), use the original URL
+        if validated_ip and original_hostname:
+            # Build URL with validated IP address
+            parsed = urlparse(url)
+            # Handle IPv6 addresses with brackets
+            if ':' in validated_ip and not validated_ip.startswith('['):
+                ip_with_brackets = f'[{validated_ip}]'
+            else:
+                ip_with_brackets = validated_ip
+
+            # Reconstruct URL with validated IP, preserving port if present
+            if ':' in parsed.netloc and ']' not in parsed.netloc:  # Has port (not IPv6)
+                port = parsed.netloc.split(':')[1]
+                request_url = f"{parsed.scheme}://{ip_with_brackets}:{port}{parsed.path}"
+                if parsed.query:
+                    request_url += f"?{parsed.query}"
+            else:
+                request_url = f"{parsed.scheme}://{ip_with_brackets}{parsed.path}"
+                if parsed.query:
+                    request_url += f"?{parsed.query}"
+
+            # Set Host header to preserve virtual hosting
+            headers = {'Host': original_hostname}
+        else:
+            # Fallback to original URL if no validated IP
+            request_url = url
+            headers = {}
+
+        # Fetch the HTML content with timeout and disabled redirects
+        # Redirects are disabled to prevent redirect-based SSRF bypasses
+        response = requests.get(request_url, timeout=timeout, headers=headers, allow_redirects=False)
         response.raise_for_status()  # Raise exception for 4xx/5xx status codes
         html_content = response.content
     except requests.exceptions.Timeout as e:

--- a/tests/services/test_scraper_service.py
+++ b/tests/services/test_scraper_service.py
@@ -117,8 +117,13 @@ class TestScrapeRecipe:
         assert result.servings == 4
         assert len(result.instructions) == 3  # Split by newline
 
-        # Verify requests.get was called with timeout
-        mock_requests_get.assert_called_once_with(url, timeout=30.0)
+        # Verify requests.get was called with timeout, headers, and allow_redirects=False
+        # The URL will be an IP address due to SSRF protection, with Host header set
+        mock_requests_get.assert_called_once()
+        call_args = mock_requests_get.call_args
+        assert call_args[1]['timeout'] == 30.0
+        assert call_args[1]['headers'] == {'Host': 'www.hellofresh.com'}
+        assert call_args[1]['allow_redirects'] is False
 
         # Verify scrape_html was called with the fetched HTML
         mock_scrape_html.assert_called_once_with(
@@ -250,8 +255,13 @@ class TestScrapeRecipe:
         with pytest.raises(NetworkError, match="Request timed out after 45.0 seconds"):
             scrape_recipe(url)
 
-        # Verify requests.get was called with the configured timeout
-        mock_requests_get.assert_called_once_with(url, timeout=45.0)
+        # Verify requests.get was called with the configured timeout, headers, and allow_redirects=False
+        # The URL will be an IP address due to SSRF protection, with Host header set
+        mock_requests_get.assert_called_once()
+        call_args = mock_requests_get.call_args
+        assert call_args[1]['timeout'] == 45.0
+        assert call_args[1]['headers'] == {'Host': 'www.example.com'}
+        assert call_args[1]['allow_redirects'] is False
 
     @patch('src.services.scraper_service.recipe_scrapers.scrape_html')
     @patch('src.services.scraper_service.requests.get')
@@ -416,8 +426,12 @@ class TestScrapeRecipe:
         # Verify the trimmed URL is used
         assert result.source_url == "https://www.hellofresh.com/recipes/test"
 
-        # Verify requests.get was called with trimmed URL
-        mock_requests_get.assert_called_once_with("https://www.hellofresh.com/recipes/test", timeout=30.0)
+        # Verify requests.get was called with trimmed URL (as IP due to SSRF protection)
+        mock_requests_get.assert_called_once()
+        call_args = mock_requests_get.call_args
+        assert call_args[1]['timeout'] == 30.0
+        assert call_args[1]['headers'] == {'Host': 'www.hellofresh.com'}
+        assert call_args[1]['allow_redirects'] is False
 
         # Verify scrape_html was called with the fetched HTML
         mock_scrape_html.assert_called_once_with(

--- a/tests/services/test_scraper_service.py
+++ b/tests/services/test_scraper_service.py
@@ -15,6 +15,7 @@ Note: All external HTTP requests are mocked - no live site access in unit tests.
 import pytest
 from unittest.mock import Mock, patch, MagicMock
 from recipe_scrapers._exceptions import WebsiteNotImplementedError
+import requests
 
 from src.services.scraper_service import (
     scrape_recipe,
@@ -25,6 +26,14 @@ from src.services.scraper_service import (
     ParseError,
 )
 from src.schemas.scraper import ScrapedRecipeData
+
+
+def _mock_successful_http_response():
+    """Helper to create a mock HTTP response."""
+    mock_response = Mock()
+    mock_response.content = b"<html>Mock HTML content</html>"
+    mock_response.status_code = 200
+    return mock_response
 
 
 class TestDetectSourceType:
@@ -68,8 +77,15 @@ class TestScrapeRecipe:
             scrape_recipe("   ")
 
     @patch('src.services.scraper_service.recipe_scrapers.scrape_html')
-    def test_successful_scrape_hellofresh(self, mock_scrape_html):
+    @patch('src.services.scraper_service.requests.get')
+    def test_successful_scrape_hellofresh(self, mock_requests_get, mock_scrape_html):
         """Test successful scraping of HelloFresh URL."""
+        # Mock the HTTP response
+        mock_response = Mock()
+        mock_response.content = b"<html>Mock HTML content</html>"
+        mock_response.status_code = 200
+        mock_requests_get.return_value = mock_response
+
         # Mock the scraper object returned by recipe_scrapers.scrape_html
         mock_scraper = Mock()
         mock_scraper.title.return_value = "Beef Tacos"
@@ -101,16 +117,26 @@ class TestScrapeRecipe:
         assert result.servings == 4
         assert len(result.instructions) == 3  # Split by newline
 
-        # Verify scrape_html was called correctly
+        # Verify requests.get was called with timeout
+        mock_requests_get.assert_called_once_with(url, timeout=30.0)
+
+        # Verify scrape_html was called with the fetched HTML
         mock_scrape_html.assert_called_once_with(
-            html=None,
+            html=b"<html>Mock HTML content</html>",
             org_url=url,
             wild_mode=False
         )
 
     @patch('src.services.scraper_service.recipe_scrapers.scrape_html')
-    def test_successful_scrape_kitchen_sanctuary(self, mock_scrape_html):
+    @patch('src.services.scraper_service.requests.get')
+    def test_successful_scrape_kitchen_sanctuary(self, mock_requests_get, mock_scrape_html):
         """Test successful scraping of Kitchen Sanctuary URL."""
+        # Mock the HTTP response
+        mock_response = Mock()
+        mock_response.content = b"<html>Mock HTML content</html>"
+        mock_response.status_code = 200
+        mock_requests_get.return_value = mock_response
+
         mock_scraper = Mock()
         mock_scraper.title.return_value = "Chocolate Cake"
         mock_scraper.ingredients.return_value = ["2 cups flour", "1 cup sugar", "1/2 cup cocoa"]
@@ -134,8 +160,12 @@ class TestScrapeRecipe:
         assert result.servings == 8  # Extracted from "8 servings" string
 
     @patch('src.services.scraper_service.recipe_scrapers.scrape_html')
-    def test_wild_mode_fallback_for_unsupported_site(self, mock_scrape_html):
+    @patch('src.services.scraper_service.requests.get')
+    def test_wild_mode_fallback_for_unsupported_site(self, mock_requests_get, mock_scrape_html):
         """Test that wild_mode is attempted for unsupported sites."""
+        # Mock HTTP response
+        mock_requests_get.return_value = _mock_successful_http_response()
+
         # First call raises WebsiteNotImplementedError (site not supported)
         # Second call (with wild_mode=True) succeeds
         mock_scraper = Mock()
@@ -168,8 +198,12 @@ class TestScrapeRecipe:
         assert mock_scrape_html.call_args_list[1][1]["wild_mode"] is True
 
     @patch('src.services.scraper_service.recipe_scrapers.scrape_html')
-    def test_unsupported_site_error_when_wild_mode_fails(self, mock_scrape_html):
+    @patch('src.services.scraper_service.requests.get')
+    def test_unsupported_site_error_when_wild_mode_fails(self, mock_requests_get, mock_scrape_html):
         """Test that UnsupportedSiteError is raised when wild_mode also fails."""
+        # Mock HTTP response
+        mock_requests_get.return_value = _mock_successful_http_response()
+
         mock_scrape_html.side_effect = [
             WebsiteNotImplementedError("Site not supported"),
             WebsiteNotImplementedError("Wild mode also failed")
@@ -179,27 +213,53 @@ class TestScrapeRecipe:
         with pytest.raises(UnsupportedSiteError, match="Site not supported"):
             scrape_recipe(url)
 
-    @patch('src.services.scraper_service.recipe_scrapers.scrape_html')
-    def test_network_error_on_connection_failure(self, mock_scrape_html):
+    @patch('src.services.scraper_service.requests.get')
+    def test_network_error_on_connection_failure(self, mock_requests_get):
         """Test that NetworkError is raised on connection failures."""
-        mock_scrape_html.side_effect = ConnectionError("Failed to connect")
+        mock_requests_get.side_effect = requests.exceptions.ConnectionError("Failed to connect")
 
         url = "https://www.hellofresh.com/recipes/test"
         with pytest.raises(NetworkError, match="Network request failed"):
             scrape_recipe(url)
 
-    @patch('src.services.scraper_service.recipe_scrapers.scrape_html')
-    def test_network_error_on_timeout(self, mock_scrape_html):
+    @patch('src.services.scraper_service.requests.get')
+    def test_network_error_on_timeout(self, mock_requests_get):
         """Test that NetworkError is raised on timeout."""
-        mock_scrape_html.side_effect = TimeoutError("Request timed out")
+        mock_requests_get.side_effect = requests.exceptions.Timeout("Request timed out")
 
         url = "https://www.hellofresh.com/recipes/test"
-        with pytest.raises(NetworkError, match="Request timed out"):
+        with pytest.raises(NetworkError, match="Request timed out after 30.0 seconds"):
             scrape_recipe(url)
 
+    @patch('src.services.scraper_service.requests.get')
+    @patch('src.services.scraper_service.get_settings')
+    def test_uses_configured_timeout(self, mock_get_settings, mock_requests_get):
+        """Test that the configured timeout value is used for HTTP requests."""
+        # Mock settings with custom timeout
+        mock_settings = Mock()
+        mock_settings.scraper_request_timeout = 45.0
+        mock_get_settings.return_value = mock_settings
+
+        # Mock HTTP response
+        mock_requests_get.return_value = _mock_successful_http_response()
+
+        # Trigger a timeout to verify the timeout value is included in error message
+        mock_requests_get.side_effect = requests.exceptions.Timeout("Connection timeout")
+
+        url = "https://www.example.com/recipe"
+        with pytest.raises(NetworkError, match="Request timed out after 45.0 seconds"):
+            scrape_recipe(url)
+
+        # Verify requests.get was called with the configured timeout
+        mock_requests_get.assert_called_once_with(url, timeout=45.0)
+
     @patch('src.services.scraper_service.recipe_scrapers.scrape_html')
-    def test_parse_error_on_data_extraction_failure(self, mock_scrape_html):
+    @patch('src.services.scraper_service.requests.get')
+    def test_parse_error_on_data_extraction_failure(self, mock_requests_get, mock_scrape_html):
         """Test that ParseError is raised when data extraction fails."""
+        # Mock HTTP response
+        mock_requests_get.return_value = _mock_successful_http_response()
+
         mock_scraper = Mock()
         # Make all methods raise exceptions to trigger ParseError
         mock_scraper.title.side_effect = Exception("Parse failed")
@@ -225,8 +285,12 @@ class TestScrapeRecipe:
         assert result.ingredients == []
 
     @patch('src.services.scraper_service.recipe_scrapers.scrape_html')
-    def test_scraper_error_on_generic_failure(self, mock_scrape_html):
+    @patch('src.services.scraper_service.requests.get')
+    def test_scraper_error_on_generic_failure(self, mock_requests_get, mock_scrape_html):
         """Test that ScraperError is raised on generic exceptions."""
+        # Mock HTTP response
+        mock_requests_get.return_value = _mock_successful_http_response()
+
         mock_scrape_html.side_effect = Exception("Generic error")
 
         url = "https://www.hellofresh.com/recipes/test"
@@ -234,8 +298,12 @@ class TestScrapeRecipe:
             scrape_recipe(url)
 
     @patch('src.services.scraper_service.recipe_scrapers.scrape_html')
-    def test_handles_missing_optional_fields(self, mock_scrape_html):
+    @patch('src.services.scraper_service.requests.get')
+    def test_handles_missing_optional_fields(self, mock_requests_get, mock_scrape_html):
         """Test that missing optional fields are handled gracefully."""
+        # Mock HTTP response
+        mock_requests_get.return_value = _mock_successful_http_response()
+
         mock_scraper = Mock()
         mock_scraper.title.return_value = "Minimal Recipe"
         mock_scraper.ingredients.return_value = []
@@ -262,8 +330,12 @@ class TestScrapeRecipe:
         assert result.servings is None
 
     @patch('src.services.scraper_service.recipe_scrapers.scrape_html')
-    def test_instructions_string_split_into_list(self, mock_scrape_html):
+    @patch('src.services.scraper_service.requests.get')
+    def test_instructions_string_split_into_list(self, mock_requests_get, mock_scrape_html):
         """Test that instruction strings are split into lists."""
+        # Mock HTTP response
+        mock_requests_get.return_value = _mock_successful_http_response()
+
         mock_scraper = Mock()
         mock_scraper.title.return_value = "Recipe"
         mock_scraper.ingredients.return_value = []
@@ -288,8 +360,12 @@ class TestScrapeRecipe:
         assert result.instructions[2] == "Step 3: Finish"
 
     @patch('src.services.scraper_service.recipe_scrapers.scrape_html')
-    def test_yields_string_extraction(self, mock_scrape_html):
+    @patch('src.services.scraper_service.requests.get')
+    def test_yields_string_extraction(self, mock_requests_get, mock_scrape_html):
         """Test that servings are extracted from yields strings."""
+        # Mock HTTP response
+        mock_requests_get.return_value = _mock_successful_http_response()
+
         mock_scraper = Mock()
         mock_scraper.title.return_value = "Recipe"
         mock_scraper.ingredients.return_value = []
@@ -310,8 +386,15 @@ class TestScrapeRecipe:
         assert result.servings == 6
 
     @patch('src.services.scraper_service.recipe_scrapers.scrape_html')
-    def test_url_whitespace_trimming(self, mock_scrape_html):
+    @patch('src.services.scraper_service.requests.get')
+    def test_url_whitespace_trimming(self, mock_requests_get, mock_scrape_html):
         """Test that URL whitespace is trimmed."""
+        # Mock HTTP response
+        mock_response = Mock()
+        mock_response.content = b"<html>Mock HTML content</html>"
+        mock_response.status_code = 200
+        mock_requests_get.return_value = mock_response
+
         mock_scraper = Mock()
         mock_scraper.title.return_value = "Recipe"
         mock_scraper.ingredients.return_value = []
@@ -332,8 +415,13 @@ class TestScrapeRecipe:
 
         # Verify the trimmed URL is used
         assert result.source_url == "https://www.hellofresh.com/recipes/test"
+
+        # Verify requests.get was called with trimmed URL
+        mock_requests_get.assert_called_once_with("https://www.hellofresh.com/recipes/test", timeout=30.0)
+
+        # Verify scrape_html was called with the fetched HTML
         mock_scrape_html.assert_called_once_with(
-            html=None,
+            html=b"<html>Mock HTML content</html>",
             org_url="https://www.hellofresh.com/recipes/test",
             wild_mode=False
         )
@@ -479,8 +567,12 @@ class TestSsrfProtection:
         with pytest.raises(ScraperError, match="Invalid URL: missing hostname"):
             scrape_recipe("https://")
 
-    def test_allows_valid_public_urls(self):
+    @patch('src.services.scraper_service.requests.get')
+    def test_allows_valid_public_urls(self, mock_requests_get):
         """Test that valid public URLs are allowed through SSRF checks."""
+        # Mock requests to simulate network errors (we only test SSRF validation)
+        mock_requests_get.side_effect = requests.exceptions.ConnectionError("Simulated network error")
+
         # These should pass SSRF validation (though they'll fail at scraping without mocks)
         # We're only testing that SSRF validation doesn't block them
         test_urls = [
@@ -496,6 +588,10 @@ class TestSsrfProtection:
             try:
                 # We expect these to fail at the scraping stage, not SSRF validation
                 scrape_recipe(url)
+            except NetworkError:
+                # NetworkError is expected (simulated network failure)
+                # The important thing is it passed SSRF validation
+                pass
             except ScraperError as e:
                 # If it's an SSRF-related error, the test should fail
                 error_msg = str(e).lower()
@@ -504,9 +600,6 @@ class TestSsrfProtection:
                 assert "metadata" not in error_msg, f"URL {url} was incorrectly blocked as metadata"
                 assert "scheme" not in error_msg, f"URL {url} was incorrectly blocked for scheme"
                 assert "hostname" not in error_msg, f"URL {url} was incorrectly blocked for hostname"
-            except Exception:
-                # Other exceptions (NetworkError, etc.) are fine - we only care about SSRF validation
-                pass
 
     def test_handles_urls_with_ports(self):
         """Test that SSRF protection works correctly with URLs containing ports."""


### PR DESCRIPTION
## Work in Progress

Closes #315

No Request Timeout Configuration

<!-- sharkrite-source-issue:303 -->## From PR #310 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
This is a real reliability concern — indefinite hangs can exhaust resources. However, investigating recipe_scrapers' timeout support and implementing it requires understanding the library's internals or potentially wrapping calls, which exceeds the scope of this parsing wrapper PR.

## Context
The original issue scope explicitly states "This is a parsing wrapper only" and focuses on error handling for network errors, not timeout configuration. Timeout handling is a valid operational concern but requires investigation of the underlying library's capabilities.

## Defer Reason
Needs separate focused PR — requires investigating recipe_scrapers library timeout support and potentially modifying HTTP client configuration.

---
_Created by Sharkrite assessment on 2026-03-25T06:53:09Z_
_Parent PR: #310_

---

## Additional Assessment (PR #310)

**Severity:** MEDIUM
**Reasoning:** This was previously classified as ACTIONABLE_LATER. Checking if changes address it: the file changed but the review shows the same issue persists (no timeout in scrape_html call). The prior reasoning remains valid — investigating library internals exceeds PR scope.
**Context:** Real reliability concern but requires understanding recipe_scrapers' timeout support or implementing a fetch wrapper, which is architectural work beyond the parsing wrapper scope.
**Defer Reason:** Scope exceeds time budget

_Added by Sharkrite on 2026-03-25T07:10:30Z_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**9** files, **2** commits (+0 added, ~7 modified, -2 deleted)
- `M` frontend/src/api/index.ts
- `M` frontend/src/components/layout/BottomNav.tsx
- `M` frontend/src/pages/Grocery.tsx
- `M` src/config.py
- `M` src/services/crawlers/__init__.py
- `D` src/services/crawlers/kitchen_sanctuary_crawler.py
- `M` src/services/scraper_service.py
- `D` tests/services/crawlers/test_kitchen_sanctuary_crawler.py
- `M` tests/services/test_scraper_service.py

### Commits
- b76acde chore: No Request Timeout Configuration
- cf3c9e6 chore: initialize work on #315 No Request Timeout Configuration
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues
 Updated: #334  Updated: #334  Updated: #334 
**From assessment on 2026-03-25T08:07:33Z:**
- Created: #334 
- Updated: none