### PR TITLE
[1-FE] I Shopped flow screen

### DIFF
--- a/frontend/src/components/shopped/ManualAddTab.test.tsx
+++ b/frontend/src/components/shopped/ManualAddTab.test.tsx
@@ -1,0 +1,393 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { BrowserRouter } from 'react-router-dom'
+import ManualAddTab from './ManualAddTab'
+import { Category, StorageLocation } from '../../api/types'
+
+// Mock the API hooks
+vi.mock('../../api', () => ({
+  useCreateInventoryItem: vi.fn(),
+}))
+
+// Mock useNavigate
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+import { useCreateInventoryItem } from '../../api'
+
+describe('ManualAddTab', () => {
+  let queryClient: QueryClient
+  let mutateAsync: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+
+    mutateAsync = vi.fn().mockResolvedValue({})
+    mockNavigate.mockClear()
+
+    vi.mocked(useCreateInventoryItem).mockReturnValue({
+      mutateAsync,
+      isPending: false,
+      isError: false,
+    } as any)
+  })
+
+  const renderWithProviders = (ui: React.ReactElement) => {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>{ui}</BrowserRouter>
+      </QueryClientProvider>
+    )
+  }
+
+  describe('Form Rendering', () => {
+    it('renders all form fields with correct defaults', () => {
+      renderWithProviders(<ManualAddTab />)
+
+      expect(screen.getByLabelText(/Item name/)).toHaveValue('')
+      expect(screen.getByLabelText(/Quantity/)).toHaveValue(1)
+      expect(screen.getByLabelText(/Unit/)).toHaveValue('unit')
+      expect(screen.getByLabelText(/Category/)).toHaveValue(Category.OTHER)
+      expect(screen.getByLabelText(/Storage location/)).toHaveValue(
+        StorageLocation.PANTRY
+      )
+      expect(screen.getByLabelText(/Store/)).toHaveValue('')
+      expect(screen.getByLabelText(/Expiration date/)).toHaveValue('')
+    })
+
+    it('renders action buttons', () => {
+      renderWithProviders(<ManualAddTab />)
+
+      expect(screen.getByRole('button', { name: /Add another/ })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /Done/ })).toBeInTheDocument()
+    })
+  })
+
+  describe('Form Validation', () => {
+    it('shows validation error when name is empty', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<ManualAddTab />)
+
+      const addButton = screen.getByRole('button', { name: /Add another/ })
+      await user.click(addButton)
+
+      expect(screen.getByRole('alert')).toHaveTextContent('Item name is required')
+      expect(mutateAsync).not.toHaveBeenCalled()
+    })
+
+    it('shows validation error when quantity is 0', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<ManualAddTab />)
+
+      const nameInput = screen.getByLabelText(/Item name/)
+      const quantityInput = screen.getByLabelText(/Quantity/)
+      const addButton = screen.getByRole('button', { name: /Add another/ })
+
+      await user.type(nameInput, 'Olive oil')
+      await user.clear(quantityInput)
+      await user.type(quantityInput, '0')
+      await user.click(addButton)
+
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Quantity must be greater than 0'
+      )
+      expect(mutateAsync).not.toHaveBeenCalled()
+    })
+
+    it('shows validation error when quantity is negative', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<ManualAddTab />)
+
+      const nameInput = screen.getByLabelText(/Item name/)
+      const quantityInput = screen.getByLabelText(/Quantity/)
+      const addButton = screen.getByRole('button', { name: /Add another/ })
+
+      await user.type(nameInput, 'Olive oil')
+      await user.clear(quantityInput)
+      await user.type(quantityInput, '-1')
+      await user.click(addButton)
+
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Quantity must be greater than 0'
+      )
+      expect(mutateAsync).not.toHaveBeenCalled()
+    })
+
+    it('shows validation error when unit is empty', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<ManualAddTab />)
+
+      const nameInput = screen.getByLabelText(/Item name/)
+      const unitInput = screen.getByLabelText(/Unit/)
+      const addButton = screen.getByRole('button', { name: /Add another/ })
+
+      await user.type(nameInput, 'Olive oil')
+      await user.clear(unitInput)
+      await user.click(addButton)
+
+      expect(screen.getByRole('alert')).toHaveTextContent('Unit is required')
+      expect(mutateAsync).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Add Another Functionality', () => {
+    it('creates inventory item and clears form when "Add another" is clicked', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<ManualAddTab />)
+
+      const nameInput = screen.getByLabelText(/Item name/)
+      const quantityInput = screen.getByLabelText(/Quantity/)
+      const addButton = screen.getByRole('button', { name: /Add another/ })
+
+      await user.type(nameInput, 'Olive oil')
+      await user.clear(quantityInput)
+      await user.type(quantityInput, '2')
+      await user.click(addButton)
+
+      // API should be called with correct data
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenCalledWith({
+          name: 'Olive oil',
+          quantity: 2,
+          unit: 'unit',
+          category: Category.OTHER,
+          storage_location: StorageLocation.PANTRY,
+          preferred_store: undefined,
+          expiration_date: undefined,
+        })
+      })
+
+      // Form should be cleared
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Item name/)).toHaveValue('')
+        expect(screen.getByLabelText(/Quantity/)).toHaveValue(1)
+        expect(screen.getByLabelText(/Unit/)).toHaveValue('unit')
+      })
+
+      // Should not navigate
+      expect(mockNavigate).not.toHaveBeenCalled()
+    })
+
+    it('shows success message after adding item', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<ManualAddTab />)
+
+      const nameInput = screen.getByLabelText(/Item name/)
+      const addButton = screen.getByRole('button', { name: /Add another/ })
+
+      await user.type(nameInput, 'Tomatoes')
+      await user.click(addButton)
+
+      await waitFor(() => {
+        expect(screen.getByText(/Tomatoes added to pantry!/)).toBeInTheDocument()
+      })
+    })
+
+    it('handles all optional fields', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<ManualAddTab />)
+
+      const nameInput = screen.getByLabelText(/Item name/)
+      const storeInput = screen.getByLabelText(/Store/)
+      const expirationInput = screen.getByLabelText(/Expiration date/)
+      const categorySelect = screen.getByLabelText(/Category/)
+      const storageSelect = screen.getByLabelText(/Storage location/)
+      const addButton = screen.getByRole('button', { name: /Add another/ })
+
+      await user.type(nameInput, 'Milk')
+      await user.selectOptions(categorySelect, Category.DAIRY)
+      await user.selectOptions(storageSelect, StorageLocation.FRIDGE)
+      await user.type(storeInput, 'Whole Foods')
+      await user.type(expirationInput, '2026-04-01')
+      await user.click(addButton)
+
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenCalledWith({
+          name: 'Milk',
+          quantity: 1,
+          unit: 'unit',
+          category: Category.DAIRY,
+          storage_location: StorageLocation.FRIDGE,
+          preferred_store: 'Whole Foods',
+          expiration_date: '2026-04-01',
+        })
+      })
+    })
+  })
+
+  describe('Done Functionality', () => {
+    it('creates inventory item and navigates to pantry when "Done" is clicked with data', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<ManualAddTab />)
+
+      const nameInput = screen.getByLabelText(/Item name/)
+      const doneButton = screen.getByRole('button', { name: /Done/ })
+
+      await user.type(nameInput, 'Flour')
+      await user.click(doneButton)
+
+      // API should be called
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'Flour',
+          })
+        )
+      })
+
+      // Should navigate to pantry
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/pantry')
+      })
+    })
+
+    it('navigates to pantry immediately when "Done" is clicked with empty form', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<ManualAddTab />)
+
+      const doneButton = screen.getByRole('button', { name: /Done/ })
+      await user.click(doneButton)
+
+      // API should not be called
+      expect(mutateAsync).not.toHaveBeenCalled()
+
+      // Should navigate immediately
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/pantry')
+      })
+    })
+
+    it('does not navigate if submission fails', async () => {
+      const user = userEvent.setup()
+
+      // Mock API to reject
+      mutateAsync.mockRejectedValueOnce(new Error('API Error'))
+
+      vi.mocked(useCreateInventoryItem).mockReturnValue({
+        mutateAsync,
+        isPending: false,
+        isError: true,
+      } as any)
+
+      renderWithProviders(<ManualAddTab />)
+
+      const nameInput = screen.getByLabelText(/Item name/)
+      const doneButton = screen.getByRole('button', { name: /Done/ })
+
+      await user.type(nameInput, 'Rice')
+      await user.click(doneButton)
+
+      // Should not navigate
+      await waitFor(() => {
+        expect(mockNavigate).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('Error Handling', () => {
+    it('displays API error message when mutation fails', async () => {
+      const user = userEvent.setup()
+
+      // Mock API to reject
+      mutateAsync.mockRejectedValueOnce(new Error('API Error'))
+
+      vi.mocked(useCreateInventoryItem).mockReturnValue({
+        mutateAsync,
+        isPending: false,
+        isError: true,
+      } as any)
+
+      renderWithProviders(<ManualAddTab />)
+
+      const nameInput = screen.getByLabelText(/Item name/)
+      const addButton = screen.getByRole('button', { name: /Add another/ })
+
+      await user.type(nameInput, 'Sugar')
+      await user.click(addButton)
+
+      expect(screen.getByText(/Failed to add item. Please try again./)).toBeInTheDocument()
+    })
+  })
+
+  describe('Pending State', () => {
+    it('disables buttons when mutation is pending', () => {
+      vi.mocked(useCreateInventoryItem).mockReturnValue({
+        mutateAsync,
+        isPending: true,
+        isError: false,
+      } as any)
+
+      renderWithProviders(<ManualAddTab />)
+
+      const addButton = screen.getByRole('button', { name: /Adding.../ })
+      const doneButton = screen.getByRole('button', { name: /Done/ })
+
+      expect(addButton).toBeDisabled()
+      expect(doneButton).toBeDisabled()
+    })
+  })
+
+  describe('Form Field Options', () => {
+    it('renders all category options', () => {
+      renderWithProviders(<ManualAddTab />)
+
+      const categorySelect = screen.getByLabelText(/Category/)
+      const options = Array.from(categorySelect.querySelectorAll('option'))
+
+      expect(options).toHaveLength(12) // All Category enum values
+      expect(options.map((o) => o.value)).toContain(Category.PRODUCE)
+      expect(options.map((o) => o.value)).toContain(Category.DAIRY)
+      expect(options.map((o) => o.value)).toContain(Category.PROTEIN)
+    })
+
+    it('renders all storage location options', () => {
+      renderWithProviders(<ManualAddTab />)
+
+      const storageSelect = screen.getByLabelText(/Storage location/)
+      const options = Array.from(storageSelect.querySelectorAll('option'))
+
+      expect(options).toHaveLength(4) // All StorageLocation enum values
+      expect(options.map((o) => o.value)).toContain(StorageLocation.PANTRY)
+      expect(options.map((o) => o.value)).toContain(StorageLocation.FRIDGE)
+      expect(options.map((o) => o.value)).toContain(StorageLocation.FREEZER)
+      expect(options.map((o) => o.value)).toContain(StorageLocation.COUNTER)
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('has proper labels for all form fields', () => {
+      renderWithProviders(<ManualAddTab />)
+
+      expect(screen.getByLabelText(/Item name/)).toBeInTheDocument()
+      expect(screen.getByLabelText(/Quantity/)).toBeInTheDocument()
+      expect(screen.getByLabelText(/Unit/)).toBeInTheDocument()
+      expect(screen.getByLabelText(/Category/)).toBeInTheDocument()
+      expect(screen.getByLabelText(/Storage location/)).toBeInTheDocument()
+      expect(screen.getByLabelText(/Store/)).toBeInTheDocument()
+      expect(screen.getByLabelText(/Expiration date/)).toBeInTheDocument()
+    })
+
+    it('marks required fields with asterisk', () => {
+      renderWithProviders(<ManualAddTab />)
+
+      expect(screen.getByLabelText(/Item name \*/)).toBeInTheDocument()
+      expect(screen.getByLabelText(/Quantity \*/)).toBeInTheDocument()
+      expect(screen.getByLabelText(/Unit \*/)).toBeInTheDocument()
+      expect(screen.getByLabelText(/Category \*/)).toBeInTheDocument()
+      expect(screen.getByLabelText(/Storage location \*/)).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/components/shopped/ManualAddTab.tsx
+++ b/frontend/src/components/shopped/ManualAddTab.tsx
@@ -48,8 +48,11 @@ export default function ManualAddTab() {
       return 'Item name is required'
     }
     const qtyNum = parseFloat(quantity)
-    if (isNaN(qtyNum) || qtyNum <= 0) {
+    if (!Number.isFinite(qtyNum) || qtyNum <= 0) {
       return 'Quantity must be greater than 0'
+    }
+    if (qtyNum > 999999) {
+      return 'Quantity must be less than 1,000,000'
     }
     if (!unit.trim()) {
       return 'Unit is required'
@@ -106,8 +109,9 @@ export default function ManualAddTab() {
 
       return true
     } catch (error) {
-      // Error is handled by mutation's error state
+      // Provide user feedback for submission failure
       console.error('Failed to create inventory item:', error)
+      setValidationError('Failed to add item. Please try again.')
       return false
     }
   }
@@ -331,7 +335,6 @@ export default function ManualAddTab() {
           <div className="flex gap-3">
             <button
               type="submit"
-              onClick={handleAddAnother}
               disabled={createInventoryMutation.isPending}
               className="flex-1 py-3 bg-white text-olive border-2 border-olive rounded-button font-medium hover:bg-cream transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >

--- a/frontend/src/components/shopped/ManualAddTab.tsx
+++ b/frontend/src/components/shopped/ManualAddTab.tsx
@@ -1,4 +1,4 @@
-import { useState, FormEvent } from 'react'
+import { useState, useEffect, useRef, FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useCreateInventoryItem } from '../../api'
 import { Category, StorageLocation } from '../../api/types'
@@ -32,6 +32,18 @@ export default function ManualAddTab() {
   const [showSuccess, setShowSuccess] = useState(false)
   const [lastAddedItemName, setLastAddedItemName] = useState('')
   const [validationError, setValidationError] = useState('')
+
+  // Ref to store timeout ID for cleanup
+  const successToastTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (successToastTimeoutRef.current) {
+        clearTimeout(successToastTimeoutRef.current)
+      }
+    }
+  }, [])
 
   /**
    * Checks if form has any user input (to decide whether "Done" should submit)
@@ -105,7 +117,17 @@ export default function ManualAddTab() {
       // Show success message
       setLastAddedItemName(name.trim())
       setShowSuccess(true)
-      setTimeout(() => setShowSuccess(false), 2000)
+
+      // Clear any existing timeout before setting a new one
+      if (successToastTimeoutRef.current) {
+        clearTimeout(successToastTimeoutRef.current)
+      }
+
+      // Set new timeout and store the ID for cleanup
+      successToastTimeoutRef.current = setTimeout(() => {
+        setShowSuccess(false)
+        successToastTimeoutRef.current = null
+      }, 2000)
 
       return true
     } catch (error) {

--- a/frontend/src/components/shopped/ManualAddTab.tsx
+++ b/frontend/src/components/shopped/ManualAddTab.tsx
@@ -1,0 +1,353 @@
+import { useState, FormEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useCreateInventoryItem } from '../../api'
+import { Category, StorageLocation } from '../../api/types'
+
+/**
+ * ManualAddTab component - Manual inventory item entry form
+ *
+ * Features:
+ * - Form fields: name, quantity, unit, category, storage, store, expiration
+ * - Smart defaults: quantity=1, unit="unit", category=OTHER, storage=PANTRY
+ * - Two action modes:
+ *   - "Add another": Creates item, clears form, stays on page
+ *   - "Done": Creates item (if form has data), navigates to /pantry
+ * - Form validation with user-friendly error messages
+ * - Success feedback for each item added
+ */
+export default function ManualAddTab() {
+  const navigate = useNavigate()
+  const createInventoryMutation = useCreateInventoryItem()
+
+  // Form state
+  const [name, setName] = useState('')
+  const [quantity, setQuantity] = useState('1')
+  const [unit, setUnit] = useState('unit')
+  const [category, setCategory] = useState<Category>(Category.OTHER)
+  const [storageLocation, setStorageLocation] = useState<StorageLocation>(StorageLocation.PANTRY)
+  const [store, setStore] = useState('')
+  const [expirationDate, setExpirationDate] = useState('')
+
+  // UI state
+  const [showSuccess, setShowSuccess] = useState(false)
+  const [lastAddedItemName, setLastAddedItemName] = useState('')
+  const [validationError, setValidationError] = useState('')
+
+  /**
+   * Checks if form has any user input (to decide whether "Done" should submit)
+   */
+  const isFormDirty = (): boolean => {
+    return name.trim().length > 0
+  }
+
+  /**
+   * Validates form and returns error message if invalid, null if valid
+   */
+  const validateForm = (): string | null => {
+    if (!name.trim()) {
+      return 'Item name is required'
+    }
+    const qtyNum = parseFloat(quantity)
+    if (isNaN(qtyNum) || qtyNum <= 0) {
+      return 'Quantity must be greater than 0'
+    }
+    if (!unit.trim()) {
+      return 'Unit is required'
+    }
+    return null
+  }
+
+  /**
+   * Clears all form fields to initial state
+   */
+  const clearForm = () => {
+    setName('')
+    setQuantity('1')
+    setUnit('unit')
+    setCategory(Category.OTHER)
+    setStorageLocation(StorageLocation.PANTRY)
+    setStore('')
+    setExpirationDate('')
+    setValidationError('')
+  }
+
+  /**
+   * Submits the form to create an inventory item
+   */
+  const handleSubmit = async (e?: FormEvent) => {
+    e?.preventDefault()
+
+    // Clear any previous validation errors
+    setValidationError('')
+
+    // Validate form
+    const error = validateForm()
+    if (error) {
+      setValidationError(error)
+      return false
+    }
+
+    try {
+      // Create inventory item via API
+      await createInventoryMutation.mutateAsync({
+        name: name.trim(),
+        quantity: parseFloat(quantity),
+        unit: unit.trim(),
+        category: category,
+        storage_location: storageLocation,
+        preferred_store: store.trim() || undefined,
+        expiration_date: expirationDate || undefined,
+      })
+
+      // Show success message
+      setLastAddedItemName(name.trim())
+      setShowSuccess(true)
+      setTimeout(() => setShowSuccess(false), 2000)
+
+      return true
+    } catch (error) {
+      // Error is handled by mutation's error state
+      console.error('Failed to create inventory item:', error)
+      return false
+    }
+  }
+
+  /**
+   * "Add another" handler: submit form and clear for next entry
+   */
+  const handleAddAnother = async (e: FormEvent) => {
+    e.preventDefault()
+    const success = await handleSubmit()
+    if (success) {
+      clearForm()
+    }
+  }
+
+  /**
+   * "Done" handler: submit form if dirty, then navigate to pantry
+   */
+  const handleDone = async (e: FormEvent) => {
+    e.preventDefault()
+
+    // If form has data, submit it first
+    if (isFormDirty()) {
+      const success = await handleSubmit()
+      if (!success) {
+        // Don't navigate if submission failed
+        return
+      }
+    }
+
+    // Navigate to pantry
+    navigate('/pantry')
+  }
+
+  return (
+    <div className="pb-24">
+      {/* Success toast */}
+      {showSuccess && (
+        <div
+          className="fixed top-4 left-1/2 transform -translate-x-1/2 z-50 bg-olive text-white px-6 py-3 rounded-button shadow-lg"
+          role="alert"
+        >
+          <p className="text-sm font-medium">
+            {lastAddedItemName} added to pantry!
+          </p>
+        </div>
+      )}
+
+      <form onSubmit={handleAddAnother}>
+        <div className="bg-white rounded-card border border-warm-border p-6">
+          <h2 className="text-lg font-medium text-text-primary mb-4">
+            Add item to pantry
+          </h2>
+
+          {/* Item name */}
+          <div className="mb-4">
+            <label
+              htmlFor="item-name"
+              className="block text-sm font-medium text-text-primary mb-1"
+            >
+              Item name *
+            </label>
+            <input
+              type="text"
+              id="item-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full px-3 py-2 border border-warm-border rounded-md focus:outline-none focus:ring-2 focus:ring-olive focus:border-transparent"
+              placeholder="e.g., Olive oil"
+              required
+            />
+          </div>
+
+          {/* Quantity and Unit - side by side */}
+          <div className="grid grid-cols-2 gap-4 mb-4">
+            <div>
+              <label
+                htmlFor="quantity"
+                className="block text-sm font-medium text-text-primary mb-1"
+              >
+                Quantity *
+              </label>
+              <input
+                type="number"
+                id="quantity"
+                value={quantity}
+                onChange={(e) => setQuantity(e.target.value)}
+                className="w-full px-3 py-2 border border-warm-border rounded-md focus:outline-none focus:ring-2 focus:ring-olive focus:border-transparent"
+                min="0.01"
+                step="0.01"
+                required
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="unit"
+                className="block text-sm font-medium text-text-primary mb-1"
+              >
+                Unit *
+              </label>
+              <input
+                type="text"
+                id="unit"
+                value={unit}
+                onChange={(e) => setUnit(e.target.value)}
+                className="w-full px-3 py-2 border border-warm-border rounded-md focus:outline-none focus:ring-2 focus:ring-olive focus:border-transparent"
+                placeholder="e.g., bottle, lb, oz"
+                required
+              />
+            </div>
+          </div>
+
+          {/* Category */}
+          <div className="mb-4">
+            <label
+              htmlFor="category"
+              className="block text-sm font-medium text-text-primary mb-1"
+            >
+              Category *
+            </label>
+            <select
+              id="category"
+              value={category}
+              onChange={(e) => setCategory(e.target.value as Category)}
+              className="w-full px-3 py-2 border border-warm-border rounded-md focus:outline-none focus:ring-2 focus:ring-olive focus:border-transparent"
+              required
+            >
+              <option value={Category.PRODUCE}>Produce</option>
+              <option value={Category.DAIRY}>Dairy</option>
+              <option value={Category.PROTEIN}>Protein</option>
+              <option value={Category.GRAINS}>Grains</option>
+              <option value={Category.CONDIMENTS}>Condiments</option>
+              <option value={Category.SNACKS}>Snacks</option>
+              <option value={Category.BEVERAGES}>Beverages</option>
+              <option value={Category.FROZEN}>Frozen</option>
+              <option value={Category.CANNED}>Canned</option>
+              <option value={Category.BAKING}>Baking</option>
+              <option value={Category.SPICES}>Spices</option>
+              <option value={Category.OTHER}>Other</option>
+            </select>
+          </div>
+
+          {/* Storage location */}
+          <div className="mb-4">
+            <label
+              htmlFor="storage-location"
+              className="block text-sm font-medium text-text-primary mb-1"
+            >
+              Storage location *
+            </label>
+            <select
+              id="storage-location"
+              value={storageLocation}
+              onChange={(e) => setStorageLocation(e.target.value as StorageLocation)}
+              className="w-full px-3 py-2 border border-warm-border rounded-md focus:outline-none focus:ring-2 focus:ring-olive focus:border-transparent"
+              required
+            >
+              <option value={StorageLocation.PANTRY}>Pantry</option>
+              <option value={StorageLocation.FRIDGE}>Fridge</option>
+              <option value={StorageLocation.FREEZER}>Freezer</option>
+              <option value={StorageLocation.COUNTER}>Counter</option>
+            </select>
+          </div>
+
+          {/* Store (optional) */}
+          <div className="mb-4">
+            <label
+              htmlFor="store"
+              className="block text-sm font-medium text-text-primary mb-1"
+            >
+              Store <span className="text-text-tertiary">(optional)</span>
+            </label>
+            <input
+              type="text"
+              id="store"
+              value={store}
+              onChange={(e) => setStore(e.target.value)}
+              className="w-full px-3 py-2 border border-warm-border rounded-md focus:outline-none focus:ring-2 focus:ring-olive focus:border-transparent"
+              placeholder="e.g., Whole Foods"
+            />
+          </div>
+
+          {/* Expiration date (optional) */}
+          <div className="mb-6">
+            <label
+              htmlFor="expiration-date"
+              className="block text-sm font-medium text-text-primary mb-1"
+            >
+              Expiration date <span className="text-text-tertiary">(optional)</span>
+            </label>
+            <input
+              type="date"
+              id="expiration-date"
+              value={expirationDate}
+              onChange={(e) => setExpirationDate(e.target.value)}
+              className="w-full px-3 py-2 border border-warm-border rounded-md focus:outline-none focus:ring-2 focus:ring-olive focus:border-transparent"
+            />
+          </div>
+
+          {/* Validation error */}
+          {validationError && (
+            <div
+              className="mb-4 px-3 py-2 bg-red-50 border border-red-200 rounded-md text-sm text-red-800"
+              role="alert"
+            >
+              {validationError}
+            </div>
+          )}
+
+          {/* API error */}
+          {createInventoryMutation.isError && (
+            <div
+              className="mb-4 px-3 py-2 bg-red-50 border border-red-200 rounded-md text-sm text-red-800"
+              role="alert"
+            >
+              Failed to add item. Please try again.
+            </div>
+          )}
+
+          {/* Action buttons */}
+          <div className="flex gap-3">
+            <button
+              type="submit"
+              onClick={handleAddAnother}
+              disabled={createInventoryMutation.isPending}
+              className="flex-1 py-3 bg-white text-olive border-2 border-olive rounded-button font-medium hover:bg-cream transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {createInventoryMutation.isPending ? 'Adding...' : 'Add another'}
+            </button>
+            <button
+              type="button"
+              onClick={handleDone}
+              disabled={createInventoryMutation.isPending}
+              className="flex-1 py-3 bg-olive text-white rounded-button font-medium hover:bg-olive-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/pages/IShopped.tsx
+++ b/frontend/src/pages/IShopped.tsx
@@ -4,14 +4,16 @@ import PageTitle from '../components/ui/PageTitle'
 import ModeSelector, { type ModeType } from '../components/shopped/ModeSelector'
 import ScanReceiptTab from '../components/shopped/ScanReceiptTab'
 import FromListTab from '../components/shopped/FromListTab'
+import ManualAddTab from '../components/shopped/ManualAddTab'
 
 /**
  * IShopped page - Bulk grocery→inventory conversion flow
  *
  * Features:
- * - Three modes: Scan receipt (coming soon) | From list (functional) | Add manually (coming soon)
+ * - Three modes: Scan receipt (coming soon) | From list (functional) | Add manually (functional)
  * - Default mode: Scan receipt with fallback to From list
  * - From list: Shows grocery items with storage location selection and bulk confirm
+ * - Add manually: Manual inventory entry form with validation
  * - Success flow: Add items to inventory, navigate to pantry
  */
 export default function IShopped() {
@@ -35,16 +37,7 @@ export default function IShopped() {
         {/* Tab content */}
         {activeMode === 'scan' && <ScanReceiptTab onSwitchToList={handleSwitchToList} />}
         {activeMode === 'list' && <FromListTab />}
-        {activeMode === 'manual' && (
-          <div className="flex flex-col items-center justify-center py-12 px-6">
-            <h2 className="text-xl font-medium text-text-primary mb-2 text-center">
-              Manual entry coming soon
-            </h2>
-            <p className="text-sm text-text-secondary text-center max-w-md">
-              For now, use your grocery list to add items to your pantry.
-            </p>
-          </div>
-        )}
+        {activeMode === 'manual' && <ManualAddTab />}
       </div>
     </PageContainer>
   )


### PR DESCRIPTION
## Work in Progress

Closes #299

[1-FE] I Shopped flow screen

## Summary

<!-- sharkrite-changes-summary -->
## Changes

**6** files, **2** commits (+2 added, ~2 modified, -2 deleted)
- `A` frontend/src/components/shopped/ManualAddTab.test.tsx
- `A` frontend/src/components/shopped/ManualAddTab.tsx
- `M` frontend/src/pages/IShopped.tsx
- `M` src/services/crawlers/__init__.py
- `D` src/services/crawlers/kitchen_sanctuary_crawler.py
- `D` tests/services/crawlers/test_kitchen_sanctuary_crawler.py

### Commits
- 2fac587 feat: [1-FE] I Shopped flow screen
- f1e6515 chore: initialize work on #299 [1-FE] I Shopped flow screen
<!-- /sharkrite-changes-summary -->

Three-tab flow at `/shopped`: scan receipt placeholder (Phase 4 readiness), "from grocery list" bulk-add-to-pantry bridge, and manual inventory add. This is the bridge between grocery shopping and pantry management.

**Priority:** P2 | **Estimate:** 1.5 hours | **Depends on:** #298 (Grocery List)

## Design References

- Design System Section 6 ("I Shopped" Flow)

## Implementation

### Tab 1: Scan Receipt (default)
"Coming soon" state with camera icon. "Try manual entry" link → Tab 3. Phase 4 readiness placeholder.

### Tab 2: From Grocery List
- Unchecked grocery items grouped by store (reuse GroceryItem from #298)
- Tappable StorageBadge per item (cycles fridge/freezer/pantry/counter)
- "Select all" per store
- Summary: "X of Y checked" + progress bar
- "Done — add X items to pantry" → bulk-purchase endpoint with `create_inventory_item=true`

### Tab 3: Manual Add
- Inventory item form (name, qty, unit, category, storage, store, expiration)
- "Add another" clears form, stays on screen
- "Done" returns to Home

## Acceptance Criteria

- [ ] Three tabs switch correctly
- [ ] "From grocery list" shows real unchecked items from API
- [ ] StorageBadge cycles on tap (fridge → freezer → pantry → counter)
- [ ] Bulk purchase creates inventory items + marks grocery items purchased
- [ ] Manual add creates inventory via API
- [ ] Scan receipt shows "coming soon" placeholder
- [ ] "Try manual entry" navigates to Tab 3

## DO NOT Scope

- Actual receipt scanning (Phase 4)
- Barcode scanning

---
_Draft PR created automatically by rite for tracking purposes._

---

## Follow-up Issues

**From assessment on 2026-03-25T08:17:57Z:**
- Created: #336 
- Updated: none