### PR TITLE
[1-FE] Profile screen

### DIFF
--- a/frontend/src/components/auth/UserSwitcher.test.tsx
+++ b/frontend/src/components/auth/UserSwitcher.test.tsx
@@ -1,0 +1,293 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import UserSwitcher from './UserSwitcher'
+import { useAuth } from '../../contexts/AuthContext'
+import { useUsers } from '../../api/hooks/useUsers'
+import { UserRole } from '../../api/types'
+import type { UserResponse, UserListResponse } from '../../api/types'
+
+// Mock the hooks
+vi.mock('../../contexts/AuthContext')
+vi.mock('../../api/hooks/useUsers')
+
+describe('UserSwitcher', () => {
+  let queryClient: QueryClient
+
+  const mockCoordinator: UserResponse = {
+    id: '1',
+    name: 'Coordinator User',
+    email: 'coord@example.com',
+    role: UserRole.COORDINATOR,
+    dietary_profile: ['vegetarian'],
+    allergies: [],
+    disliked_ingredients: [],
+    favorite_ingredients: [],
+    failed_login_attempts: 0,
+    lockout_until: null,
+    lockout_count: 0,
+  }
+
+  const mockMember: UserResponse = {
+    id: '2',
+    name: 'Member User',
+    email: 'member@example.com',
+    role: UserRole.MEMBER,
+    dietary_profile: [],
+    allergies: [],
+    disliked_ingredients: [],
+    favorite_ingredients: [],
+    failed_login_attempts: 0,
+    lockout_until: null,
+    lockout_count: 0,
+  }
+
+  const mockHouseholdMembers: UserListResponse[] = [
+    {
+      id: '1',
+      name: 'Coordinator User',
+      role: UserRole.COORDINATOR,
+      dietary_profile: ['vegetarian'],
+      allergies: [],
+      disliked_ingredients: [],
+      favorite_ingredients: [],
+    },
+    {
+      id: '2',
+      name: 'Member User',
+      role: UserRole.MEMBER,
+      dietary_profile: ['vegan'],
+      allergies: [],
+      disliked_ingredients: [],
+      favorite_ingredients: [],
+    },
+    {
+      id: '3',
+      name: 'Another Member',
+      role: UserRole.MEMBER,
+      dietary_profile: [],
+      allergies: [],
+      disliked_ingredients: [],
+      favorite_ingredients: [],
+    },
+  ]
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+  })
+
+  const renderWithProviders = (component: React.ReactElement) => {
+    return render(<QueryClientProvider client={queryClient}>{component}</QueryClientProvider>)
+  }
+
+  it('does not render for non-coordinator users', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      currentUser: mockMember,
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+      switchUser: vi.fn(),
+    })
+
+    const { container } = renderWithProviders(<UserSwitcher />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders for coordinator users', () => {
+    const mockSwitchUser = vi.fn()
+    vi.mocked(useAuth).mockReturnValue({
+      currentUser: mockCoordinator,
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+      switchUser: mockSwitchUser,
+    })
+
+    vi.mocked(useUsers).mockReturnValue({
+      data: mockHouseholdMembers,
+      isLoading: false,
+      error: null,
+    } as any)
+
+    renderWithProviders(<UserSwitcher />)
+    expect(screen.getByText('Who are you?')).toBeInTheDocument()
+  })
+
+  it('displays loading state while fetching users', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      currentUser: mockCoordinator,
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+      switchUser: vi.fn(),
+    })
+
+    vi.mocked(useUsers).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as any)
+
+    renderWithProviders(<UserSwitcher />)
+    expect(screen.getByText('Loading household members...')).toBeInTheDocument()
+  })
+
+  it('renders all household members', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      currentUser: mockCoordinator,
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+      switchUser: vi.fn(),
+    })
+
+    vi.mocked(useUsers).mockReturnValue({
+      data: mockHouseholdMembers,
+      isLoading: false,
+      error: null,
+    } as any)
+
+    renderWithProviders(<UserSwitcher />)
+    expect(screen.getByText('Coordinator User (current)')).toBeInTheDocument()
+    expect(screen.getByText('Member User')).toBeInTheDocument()
+    expect(screen.getByText('Another Member')).toBeInTheDocument()
+  })
+
+  it('highlights current user', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      currentUser: mockCoordinator,
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+      switchUser: vi.fn(),
+    })
+
+    vi.mocked(useUsers).mockReturnValue({
+      data: mockHouseholdMembers,
+      isLoading: false,
+      error: null,
+    } as any)
+
+    renderWithProviders(<UserSwitcher />)
+    const currentUserButton = screen.getByText('Coordinator User (current)').closest('button')
+    expect(currentUserButton?.className).toContain('bg-olive/20')
+    expect(currentUserButton).toBeDisabled()
+  })
+
+  it('calls switchUser when clicking another user', async () => {
+    const mockSwitchUser = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(useAuth).mockReturnValue({
+      currentUser: mockCoordinator,
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+      switchUser: mockSwitchUser,
+    })
+
+    vi.mocked(useUsers).mockReturnValue({
+      data: mockHouseholdMembers,
+      isLoading: false,
+      error: null,
+    } as any)
+
+    renderWithProviders(<UserSwitcher />)
+
+    const memberButton = screen.getByText('Member User').closest('button')
+    fireEvent.click(memberButton!)
+
+    await waitFor(() => {
+      expect(mockSwitchUser).toHaveBeenCalledWith({ user_id: '2' })
+    })
+  })
+
+  it('does not call switchUser when clicking current user', () => {
+    const mockSwitchUser = vi.fn()
+    vi.mocked(useAuth).mockReturnValue({
+      currentUser: mockCoordinator,
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+      switchUser: mockSwitchUser,
+    })
+
+    vi.mocked(useUsers).mockReturnValue({
+      data: mockHouseholdMembers,
+      isLoading: false,
+      error: null,
+    } as any)
+
+    renderWithProviders(<UserSwitcher />)
+
+    const currentUserButton = screen.getByText('Coordinator User (current)').closest('button')
+    fireEvent.click(currentUserButton!)
+
+    expect(mockSwitchUser).not.toHaveBeenCalled()
+  })
+
+  it('displays dietary profiles for users', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      currentUser: mockCoordinator,
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+      switchUser: vi.fn(),
+    })
+
+    vi.mocked(useUsers).mockReturnValue({
+      data: mockHouseholdMembers,
+      isLoading: false,
+      error: null,
+    } as any)
+
+    renderWithProviders(<UserSwitcher />)
+    expect(screen.getByText('vegetarian')).toBeInTheDocument()
+    expect(screen.getByText('vegan')).toBeInTheDocument()
+  })
+
+  it('does not render when no users are available', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      currentUser: mockCoordinator,
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+      switchUser: vi.fn(),
+    })
+
+    vi.mocked(useUsers).mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    } as any)
+
+    const { container } = renderWithProviders(<UserSwitcher />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('does not render when currentUser is null', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      currentUser: undefined,
+      isAuthenticated: false,
+      isLoading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+      switchUser: vi.fn(),
+    })
+
+    const { container } = renderWithProviders(<UserSwitcher />)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/frontend/src/components/auth/UserSwitcher.test.tsx
+++ b/frontend/src/components/auth/UserSwitcher.test.tsx
@@ -290,4 +290,60 @@ describe('UserSwitcher', () => {
     const { container } = renderWithProviders(<UserSwitcher />)
     expect(container.firstChild).toBeNull()
   })
+
+  it('shows loading state during user switch', async () => {
+    const mockSwitchUser = vi.fn(() => new Promise((resolve) => setTimeout(resolve, 100)))
+    vi.mocked(useAuth).mockReturnValue({
+      currentUser: mockCoordinator,
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+      switchUser: mockSwitchUser,
+    })
+
+    vi.mocked(useUsers).mockReturnValue({
+      data: mockHouseholdMembers,
+      isLoading: false,
+      error: null,
+    } as any)
+
+    renderWithProviders(<UserSwitcher />)
+
+    const memberButton = screen.getByText('Member User').closest('button')
+    fireEvent.click(memberButton!)
+
+    // Button should be disabled and have cursor-wait while switching
+    await waitFor(() => {
+      expect(memberButton).toBeDisabled()
+      expect(memberButton?.className).toContain('cursor-wait')
+    })
+  })
+
+  it('displays error message when switchUser fails', async () => {
+    const mockSwitchUser = vi.fn().mockRejectedValue(new Error('Network error'))
+    vi.mocked(useAuth).mockReturnValue({
+      currentUser: mockCoordinator,
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+      switchUser: mockSwitchUser,
+    })
+
+    vi.mocked(useUsers).mockReturnValue({
+      data: mockHouseholdMembers,
+      isLoading: false,
+      error: null,
+    } as any)
+
+    renderWithProviders(<UserSwitcher />)
+
+    const memberButton = screen.getByText('Member User').closest('button')
+    fireEvent.click(memberButton!)
+
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/src/components/profile/ProfileHeader.test.tsx
+++ b/frontend/src/components/profile/ProfileHeader.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import ProfileHeader from './ProfileHeader'
+import type { UserResponse } from '../../api/types'
+
+describe('ProfileHeader', () => {
+  const mockCoordinator: UserResponse = {
+    id: '1',
+    name: 'John Doe',
+    email: 'john@example.com',
+    role: 'coordinator',
+    dietary_profile: ['vegetarian'],
+    allergies: [],
+    disliked_ingredients: [],
+    favorite_ingredients: [],
+    failed_login_attempts: 0,
+    lockout_until: null,
+    lockout_count: 0,
+  }
+
+  const mockMember: UserResponse = {
+    ...mockCoordinator,
+    id: '2',
+    name: 'Jane Doe',
+    email: 'jane@example.com',
+    role: 'member',
+  }
+
+  it('renders user name and email', () => {
+    const mockLogout = vi.fn()
+    render(<ProfileHeader user={mockCoordinator} onLogout={mockLogout} />)
+
+    expect(screen.getByText('John Doe')).toBeInTheDocument()
+    expect(screen.getByText('john@example.com')).toBeInTheDocument()
+  })
+
+  it('displays coordinator badge with correct styling', () => {
+    const mockLogout = vi.fn()
+    render(<ProfileHeader user={mockCoordinator} onLogout={mockLogout} />)
+
+    const badge = screen.getByText('Coordinator')
+    expect(badge).toBeInTheDocument()
+    expect(badge.className).toContain('bg-olive')
+    expect(badge.className).toContain('text-cream')
+  })
+
+  it('displays member badge with correct styling', () => {
+    const mockLogout = vi.fn()
+    render(<ProfileHeader user={mockMember} onLogout={mockLogout} />)
+
+    const badge = screen.getByText('Member')
+    expect(badge).toBeInTheDocument()
+    expect(badge.className).toContain('bg-cream-dark')
+    expect(badge.className).toContain('text-text-primary')
+  })
+
+  it('renders logout button', () => {
+    const mockLogout = vi.fn()
+    render(<ProfileHeader user={mockCoordinator} onLogout={mockLogout} />)
+
+    expect(screen.getByRole('button', { name: /log out/i })).toBeInTheDocument()
+  })
+
+  it('calls onLogout when logout button is clicked', async () => {
+    const mockLogout = vi.fn().mockResolvedValue(undefined)
+    render(<ProfileHeader user={mockCoordinator} onLogout={mockLogout} />)
+
+    const logoutButton = screen.getByRole('button', { name: /log out/i })
+    fireEvent.click(logoutButton)
+
+    await waitFor(() => {
+      expect(mockLogout).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('shows loading state during logout', async () => {
+    const mockLogout = vi.fn(() => new Promise((resolve) => setTimeout(resolve, 100)))
+    render(<ProfileHeader user={mockCoordinator} onLogout={mockLogout} />)
+
+    const logoutButton = screen.getByRole('button', { name: /log out/i })
+    fireEvent.click(logoutButton)
+
+    expect(screen.getByText('Logging out...')).toBeInTheDocument()
+    expect(logoutButton).toBeDisabled()
+  })
+
+  it('displays error message when logout fails', async () => {
+    const mockLogout = vi.fn().mockRejectedValue(new Error('Network error'))
+    render(<ProfileHeader user={mockCoordinator} onLogout={mockLogout} />)
+
+    const logoutButton = screen.getByRole('button', { name: /log out/i })
+    fireEvent.click(logoutButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeInTheDocument()
+    })
+  })
+
+  it('displays generic error message for non-Error failures', async () => {
+    const mockLogout = vi.fn().mockRejectedValue('Unknown error')
+    render(<ProfileHeader user={mockCoordinator} onLogout={mockLogout} />)
+
+    const logoutButton = screen.getByRole('button', { name: /log out/i })
+    fireEvent.click(logoutButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to log out. Please try again.')).toBeInTheDocument()
+    })
+  })
+
+  it('clears error message on subsequent logout attempt', async () => {
+    const mockLogout = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Network error'))
+      .mockResolvedValueOnce(undefined)
+    render(<ProfileHeader user={mockCoordinator} onLogout={mockLogout} />)
+
+    const logoutButton = screen.getByRole('button', { name: /log out/i })
+
+    // First attempt - should fail
+    fireEvent.click(logoutButton)
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeInTheDocument()
+    })
+
+    // Second attempt - should clear error
+    fireEvent.click(logoutButton)
+    await waitFor(() => {
+      expect(screen.queryByText('Network error')).not.toBeInTheDocument()
+    })
+  })
+
+  it('applies design system styles', () => {
+    const mockLogout = vi.fn()
+    const { container } = render(<ProfileHeader user={mockCoordinator} onLogout={mockLogout} />)
+
+    const card = container.querySelector('.bg-white')
+    expect(card).toBeInTheDocument()
+    expect(card?.className).toContain('rounded-card')
+    expect(card?.className).toContain('border-warm-border')
+  })
+})

--- a/frontend/src/pages/Profile.test.tsx
+++ b/frontend/src/pages/Profile.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import Profile from './Profile'
+import { useAuth } from '../contexts/AuthContext'
+import type { UserResponse } from '../api/types'
+
+// Mock all the child components
+vi.mock('../components/layout/PageContainer', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+vi.mock('../components/auth/UserSwitcher', () => ({
+  default: () => <div data-testid="user-switcher">UserSwitcher</div>,
+}))
+vi.mock('../components/profile/ProfileHeader', () => ({
+  default: () => <div data-testid="profile-header">ProfileHeader</div>,
+}))
+vi.mock('../components/profile/DietarySection', () => ({
+  default: () => <div data-testid="dietary-section">DietarySection</div>,
+}))
+vi.mock('../components/profile/AllergiesSection', () => ({
+  default: () => <div data-testid="allergies-section">AllergiesSection</div>,
+}))
+vi.mock('../components/profile/DislikedIngredientsSection', () => ({
+  default: () => <div data-testid="disliked-section">DislikedIngredientsSection</div>,
+}))
+vi.mock('../components/profile/SubstitutionsSection', () => ({
+  default: () => <div data-testid="substitutions-section">SubstitutionsSection</div>,
+}))
+
+// Mock the auth context
+vi.mock('../contexts/AuthContext')
+
+describe('Profile Page', () => {
+  let queryClient: QueryClient
+
+  const mockUser: UserResponse = {
+    id: '1',
+    name: 'Test User',
+    email: 'test@example.com',
+    role: 'coordinator',
+    dietary_profile: ['vegetarian', 'vegan'],
+    allergies: ['peanuts', 'shellfish'],
+    disliked_ingredients: ['cilantro'],
+    favorite_ingredients: [],
+    failed_login_attempts: 0,
+    lockout_until: null,
+    lockout_count: 0,
+  }
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+  })
+
+  const renderWithProviders = (component: React.ReactElement) => {
+    return render(<QueryClientProvider client={queryClient}>{component}</QueryClientProvider>)
+  }
+
+  it('renders page title and description', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      currentUser: mockUser,
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+      switchUser: vi.fn(),
+    })
+
+    renderWithProviders(<Profile />)
+    expect(screen.getByText('Profile')).toBeInTheDocument()
+    expect(screen.getByText('Manage your preferences and settings')).toBeInTheDocument()
+  })
+
+  it('renders all profile sections when user is loaded', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      currentUser: mockUser,
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+      switchUser: vi.fn(),
+    })
+
+    renderWithProviders(<Profile />)
+
+    expect(screen.getByTestId('profile-header')).toBeInTheDocument()
+    expect(screen.getByTestId('dietary-section')).toBeInTheDocument()
+    expect(screen.getByTestId('allergies-section')).toBeInTheDocument()
+    expect(screen.getByTestId('disliked-section')).toBeInTheDocument()
+    expect(screen.getByTestId('substitutions-section')).toBeInTheDocument()
+    expect(screen.getByTestId('user-switcher')).toBeInTheDocument()
+  })
+
+  it('displays loading state when currentUser is null', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      currentUser: undefined,
+      isAuthenticated: false,
+      isLoading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+      switchUser: vi.fn(),
+    })
+
+    renderWithProviders(<Profile />)
+    expect(screen.getByText('Loading profile...')).toBeInTheDocument()
+  })
+
+  it('does not render profile sections when loading', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      currentUser: undefined,
+      isAuthenticated: false,
+      isLoading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+      switchUser: vi.fn(),
+    })
+
+    renderWithProviders(<Profile />)
+
+    expect(screen.queryByTestId('profile-header')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('dietary-section')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('allergies-section')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('disliked-section')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('substitutions-section')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('user-switcher')).not.toBeInTheDocument()
+  })
+
+  it('renders sections in correct order', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      currentUser: mockUser,
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+      switchUser: vi.fn(),
+    })
+
+    const { container } = renderWithProviders(<Profile />)
+    const sections = container.querySelectorAll('[data-testid]')
+
+    expect(sections[0]).toHaveAttribute('data-testid', 'profile-header')
+    expect(sections[1]).toHaveAttribute('data-testid', 'dietary-section')
+    expect(sections[2]).toHaveAttribute('data-testid', 'allergies-section')
+    expect(sections[3]).toHaveAttribute('data-testid', 'disliked-section')
+    expect(sections[4]).toHaveAttribute('data-testid', 'substitutions-section')
+    expect(sections[5]).toHaveAttribute('data-testid', 'user-switcher')
+  })
+})


### PR DESCRIPTION
## Work in Progress

Closes #300

[1-FE] Profile screen

## Summary

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **2** commits (+3 added, ~0 modified, -0 deleted)
- `A` frontend/src/components/auth/UserSwitcher.test.tsx
- `A` frontend/src/components/profile/ProfileHeader.test.tsx
- `A` frontend/src/pages/Profile.test.tsx

### Commits
- 9db792f feat: [1-FE] Profile screen
- 0719c23 chore: initialize work on #300 [1-FE] Profile screen
<!-- /sharkrite-changes-summary -->

User profile management screen with user info display, household member switching (coordinator-only, enables iPad shared terminal flow), dietary profile editing, substitution preference CRUD, and logout.

**Priority:** P2 | **Estimate:** 1–1.5 hours | **Depends on:** #293 (Infrastructure/CORS)

## Design References

- Design System Section 6 (Profile)

## Implementation

### 1. User Info Card
Name, email, role badge (coordinator/member), member since date.

### 2. User Switcher (coordinator only)
All household members via `useUsers`. Tap to switch JWT context. Enables iPad shared terminal flow where multiple family members use the same device. Switching updates auth context and refreshes all cached data.

### 3. Dietary Profile
Display dietary type, allergies, disliked/favorite ingredients as pill/tag display. "Edit" for inline editing via profile update API.

### 4. Substitution Preferences
List of existing substitutions, "Add substitution" form, delete existing. Full CRUD via substitution API.

### 5. Logout
Clears JWT, returns to `/login`.

## Acceptance Criteria

- [ ] User info renders from auth context
- [ ] Switcher shows all household members (coordinator only)
- [ ] Switching users updates auth context + refreshes all data
- [ ] Dietary profile edit works via profile update API
- [ ] Substitution CRUD works (create, read, delete)
- [ ] Logout clears state + navigates to `/login`
- [ ] Design system compliant: bg-white cards on bg-cream, font-medium headings, olive period

## DO NOT Scope

- User registration (that's the login flow)
- Role assignment changes

---
_Draft PR created automatically by rite for tracking purposes._

---

## Follow-up Issues

**From assessment on 2026-03-25T08:31:47Z:**
- Created: none
- Updated: #323 