### PR TITLE
Add recipe-pantry cross-reference to list

### DIFF
--- a/frontend/src/components/recipe/ActionBar.tsx
+++ b/frontend/src/components/recipe/ActionBar.tsx
@@ -51,6 +51,22 @@ export default function ActionBar({
     }
   }, [])
 
+  // Sync addedItemsRef with the current grocery list
+  // Remove items from the ref that are no longer in the grocery list
+  // This prevents the race condition where removed items cannot be re-added
+  useEffect(() => {
+    const currentItemNames = new Set(
+      existingGroceryItems.map(item => item.item_name.toLowerCase())
+    )
+
+    // Remove items from addedItemsRef that are no longer in the grocery list
+    addedItemsRef.current.forEach(itemName => {
+      if (!currentItemNames.has(itemName)) {
+        addedItemsRef.current.delete(itemName)
+      }
+    })
+  }, [existingGroceryItems])
+
   const missingCount = missingIngredients.length
   const allInStock = missingCount === 0
 

--- a/frontend/src/components/recipe/ActionBar.tsx
+++ b/frontend/src/components/recipe/ActionBar.tsx
@@ -1,6 +1,6 @@
 import { Heart, ShoppingCart } from 'lucide-react'
 import { useState, useRef, useEffect } from 'react'
-import { useCreateGroceryItem } from '../../api/hooks/useGrocery'
+import { useCreateGroceryItem, useGroceryList } from '../../api/hooks/useGrocery'
 import type { IngredientStockStatus } from '../../utils/pantryMatcher'
 
 interface ActionBarProps {
@@ -31,11 +31,13 @@ export default function ActionBar({
   missingIngredients = [],
 }: ActionBarProps) {
   const createGroceryItem = useCreateGroceryItem()
+  const { data: existingGroceryItems = [], refetch: refetchGroceryList } = useGroceryList({ purchased: false })
   const [isAddingToList, setIsAddingToList] = useState(false)
   const [addToListError, setAddToListError] = useState<string | null>(null)
   const [addToListSuccess, setAddToListSuccess] = useState(false)
   const errorTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const successTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const addedItemsRef = useRef<Set<string>>(new Set())
 
   // Cleanup timeouts on component unmount
   useEffect(() => {
@@ -65,9 +67,37 @@ export default function ActionBar({
     }
 
     try {
-      // Add all missing ingredients to grocery list in parallel
+      // Refetch grocery list to ensure we have the latest data before checking for duplicates
+      const { data: latestGroceryItems } = await refetchGroceryList()
+      const currentGroceryItems = latestGroceryItems || existingGroceryItems
+
+      // Filter out ingredients already in the grocery list (case-insensitive match by name)
+      // Also filter out items that were added in this session (to prevent duplicates from rapid clicks)
+      const existingItemNames = new Set(
+        currentGroceryItems.map(item => item.item_name.toLowerCase())
+      )
+
+      const ingredientsToAdd = missingIngredients.filter(
+        ({ ingredient }) => {
+          const itemNameLower = ingredient.ingredient_name.toLowerCase()
+          return !existingItemNames.has(itemNameLower) && !addedItemsRef.current.has(itemNameLower)
+        }
+      )
+
+      // If all ingredients are already in the list, show success message
+      if (ingredientsToAdd.length === 0) {
+        setAddToListSuccess(true)
+        successTimeoutRef.current = setTimeout(() => {
+          setAddToListSuccess(false)
+          successTimeoutRef.current = null
+        }, 3000)
+        setIsAddingToList(false)
+        return
+      }
+
+      // Add only new ingredients to grocery list in parallel
       const results = await Promise.allSettled(
-        missingIngredients.map(({ ingredient }) =>
+        ingredientsToAdd.map(({ ingredient }) =>
           createGroceryItem.mutateAsync({
             item_name: ingredient.ingredient_name,
             quantity: ingredient.quantity,
@@ -80,9 +110,20 @@ export default function ActionBar({
       // Count successes and failures
       const successCount = results.filter(r => r.status === 'fulfilled').length
       const failureCount = results.filter(r => r.status === 'rejected').length
+      const skippedCount = missingIngredients.length - ingredientsToAdd.length
+
+      // Track successfully added items to prevent duplicates from rapid clicks
+      if (successCount > 0) {
+        results.forEach((result, index) => {
+          if (result.status === 'fulfilled') {
+            const itemNameLower = ingredientsToAdd[index].ingredient.ingredient_name.toLowerCase()
+            addedItemsRef.current.add(itemNameLower)
+          }
+        })
+      }
 
       if (failureCount === 0) {
-        // All ingredients added successfully
+        // All new ingredients added successfully
         setAddToListSuccess(true)
         successTimeoutRef.current = setTimeout(() => {
           setAddToListSuccess(false)
@@ -91,7 +132,8 @@ export default function ActionBar({
       } else if (successCount > 0) {
         // Partial success
         console.error('Some ingredients failed to add:', results.filter(r => r.status === 'rejected'))
-        setAddToListError(`Added ${successCount} of ${missingCount} ingredients. Some failed to add.`)
+        const totalToAdd = ingredientsToAdd.length
+        setAddToListError(`Added ${successCount} of ${totalToAdd} new ingredients. Some failed to add.${skippedCount > 0 ? ` ${skippedCount} already in list.` : ''}`)
         errorTimeoutRef.current = setTimeout(() => {
           setAddToListError(null)
           errorTimeoutRef.current = null

--- a/frontend/src/components/recipe/ActionBar.tsx
+++ b/frontend/src/components/recipe/ActionBar.tsx
@@ -44,15 +44,17 @@ export default function ActionBar({
     setAddToListError(null)
 
     try {
-      // Add each missing ingredient to grocery list
-      for (const { ingredient } of missingIngredients) {
-        await createGroceryItem.mutateAsync({
-          item_name: ingredient.ingredient_name,
-          quantity: ingredient.quantity,
-          unit: ingredient.unit,
-          source: 'recipe',
-        })
-      }
+      // Add all missing ingredients to grocery list in parallel
+      await Promise.all(
+        missingIngredients.map(({ ingredient }) =>
+          createGroceryItem.mutateAsync({
+            item_name: ingredient.ingredient_name,
+            quantity: ingredient.quantity,
+            unit: ingredient.unit,
+            source: 'recipe',
+          })
+        )
+      )
     } catch (error) {
       console.error('Failed to add ingredients to grocery list:', error)
       setAddToListError('Failed to add ingredients. Please try again.')

--- a/frontend/src/components/recipe/ActionBar.tsx
+++ b/frontend/src/components/recipe/ActionBar.tsx
@@ -1,5 +1,5 @@
 import { Heart, ShoppingCart } from 'lucide-react'
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { useCreateGroceryItem } from '../../api/hooks/useGrocery'
 import type { IngredientStockStatus } from '../../utils/pantryMatcher'
 
@@ -33,15 +33,24 @@ export default function ActionBar({
   const createGroceryItem = useCreateGroceryItem()
   const [isAddingToList, setIsAddingToList] = useState(false)
   const [addToListError, setAddToListError] = useState<string | null>(null)
+  const [addToListSuccess, setAddToListSuccess] = useState(false)
+  const errorTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const successTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
   const missingCount = missingIngredients.length
   const allInStock = missingCount === 0
 
   const handleAddMissingToList = async () => {
-    if (missingCount === 0) return
+    if (missingCount === 0 || addToListSuccess) return
 
     setIsAddingToList(true)
     setAddToListError(null)
+
+    // Clear any existing error timeout
+    if (errorTimeoutRef.current) {
+      clearTimeout(errorTimeoutRef.current)
+      errorTimeoutRef.current = null
+    }
 
     try {
       // Add all missing ingredients to grocery list in parallel
@@ -55,10 +64,20 @@ export default function ActionBar({
           })
         )
       )
+
+      // Show success feedback
+      setAddToListSuccess(true)
+      successTimeoutRef.current = setTimeout(() => {
+        setAddToListSuccess(false)
+        successTimeoutRef.current = null
+      }, 3000)
     } catch (error) {
       console.error('Failed to add ingredients to grocery list:', error)
       setAddToListError('Failed to add ingredients. Please try again.')
-      setTimeout(() => setAddToListError(null), 5000)
+      errorTimeoutRef.current = setTimeout(() => {
+        setAddToListError(null)
+        errorTimeoutRef.current = null
+      }, 5000)
     } finally {
       setIsAddingToList(false)
     }
@@ -71,14 +90,19 @@ export default function ActionBar({
           <p className="text-sm text-red-800">{addToListError}</p>
         </div>
       )}
+      {addToListSuccess && (
+        <div className="fixed bottom-20 left-4 right-4 bg-green-50 border border-green-200 rounded-lg p-3 shadow-lg z-40">
+          <p className="text-sm text-green-800">Ingredients added to grocery list!</p>
+        </div>
+      )}
       <div className="fixed bottom-0 left-0 right-0 bg-cream border-t border-warm-border shadow-lg z-10">
         <div className="max-w-2xl mx-auto px-4 py-3 flex items-center gap-3">
           {/* Add missing to list button (pantry cross-reference) */}
           <button
             onClick={handleAddMissingToList}
-            disabled={isLoading || isAddingToList || allInStock}
+            disabled={isLoading || isAddingToList || allInStock || addToListSuccess}
             className="flex-1 bg-olive text-cream font-medium py-3 px-4 rounded-button hover:bg-olive-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-            title={allInStock ? 'All ingredients are in stock' : `Add ${missingCount} missing ingredient${missingCount === 1 ? '' : 's'} to grocery list`}
+            title={allInStock ? 'All ingredients are in stock' : addToListSuccess ? 'Ingredients added to list' : `Add ${missingCount} missing ingredient${missingCount === 1 ? '' : 's'} to grocery list`}
           >
             <ShoppingCart size={18} />
             <span>

--- a/frontend/src/components/recipe/ActionBar.tsx
+++ b/frontend/src/components/recipe/ActionBar.tsx
@@ -1,5 +1,5 @@
 import { Heart, ShoppingCart } from 'lucide-react'
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { useCreateGroceryItem } from '../../api/hooks/useGrocery'
 import type { IngredientStockStatus } from '../../utils/pantryMatcher'
 
@@ -37,6 +37,18 @@ export default function ActionBar({
   const errorTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const successTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
+  // Cleanup timeouts on component unmount
+  useEffect(() => {
+    return () => {
+      if (errorTimeoutRef.current) {
+        clearTimeout(errorTimeoutRef.current)
+      }
+      if (successTimeoutRef.current) {
+        clearTimeout(successTimeoutRef.current)
+      }
+    }
+  }, [])
+
   const missingCount = missingIngredients.length
   const allInStock = missingCount === 0
 
@@ -54,7 +66,7 @@ export default function ActionBar({
 
     try {
       // Add all missing ingredients to grocery list in parallel
-      await Promise.all(
+      const results = await Promise.allSettled(
         missingIngredients.map(({ ingredient }) =>
           createGroceryItem.mutateAsync({
             item_name: ingredient.ingredient_name,
@@ -65,14 +77,36 @@ export default function ActionBar({
         )
       )
 
-      // Show success feedback
-      setAddToListSuccess(true)
-      successTimeoutRef.current = setTimeout(() => {
-        setAddToListSuccess(false)
-        successTimeoutRef.current = null
-      }, 3000)
+      // Count successes and failures
+      const successCount = results.filter(r => r.status === 'fulfilled').length
+      const failureCount = results.filter(r => r.status === 'rejected').length
+
+      if (failureCount === 0) {
+        // All ingredients added successfully
+        setAddToListSuccess(true)
+        successTimeoutRef.current = setTimeout(() => {
+          setAddToListSuccess(false)
+          successTimeoutRef.current = null
+        }, 3000)
+      } else if (successCount > 0) {
+        // Partial success
+        console.error('Some ingredients failed to add:', results.filter(r => r.status === 'rejected'))
+        setAddToListError(`Added ${successCount} of ${missingCount} ingredients. Some failed to add.`)
+        errorTimeoutRef.current = setTimeout(() => {
+          setAddToListError(null)
+          errorTimeoutRef.current = null
+        }, 5000)
+      } else {
+        // Complete failure
+        console.error('Failed to add ingredients to grocery list:', results.filter(r => r.status === 'rejected'))
+        setAddToListError('Failed to add ingredients. Please try again.')
+        errorTimeoutRef.current = setTimeout(() => {
+          setAddToListError(null)
+          errorTimeoutRef.current = null
+        }, 5000)
+      }
     } catch (error) {
-      console.error('Failed to add ingredients to grocery list:', error)
+      console.error('Unexpected error adding ingredients to grocery list:', error)
       setAddToListError('Failed to add ingredients. Please try again.')
       errorTimeoutRef.current = setTimeout(() => {
         setAddToListError(null)

--- a/frontend/src/components/recipe/ActionBar.tsx
+++ b/frontend/src/components/recipe/ActionBar.tsx
@@ -1,10 +1,14 @@
-import { Heart } from 'lucide-react'
+import { Heart, ShoppingCart } from 'lucide-react'
+import { useState } from 'react'
+import { useCreateGroceryItem } from '../../api/hooks/useGrocery'
+import type { IngredientStockStatus } from '../../utils/pantryMatcher'
 
 interface ActionBarProps {
   isFavorited: boolean
   onFavoriteToggle: () => void
   onAddToMealPlan: () => void
   isLoading?: boolean
+  missingIngredients?: IngredientStockStatus[]
 }
 
 /**
@@ -12,8 +16,11 @@ interface ActionBarProps {
  *
  * Features:
  * - Fixed bottom bar (mobile-friendly)
- * - "Add to meal plan" primary button
+ * - "Add missing to list" button (pantry cross-reference)
+ * - "Add to meal plan" button (Phase 2 feature)
  * - Favorite heart toggle (filled when favorited)
+ * - Shows count of missing ingredients
+ * - Disabled when all ingredients in stock
  * - Sticky positioning with shadow for visibility
  */
 export default function ActionBar({
@@ -21,33 +28,79 @@ export default function ActionBar({
   onFavoriteToggle,
   onAddToMealPlan,
   isLoading = false,
+  missingIngredients = [],
 }: ActionBarProps) {
-  return (
-    <div className="fixed bottom-0 left-0 right-0 bg-cream border-t border-warm-border shadow-lg z-10">
-      <div className="max-w-2xl mx-auto px-4 py-3 flex items-center gap-3">
-        {/* Add to meal plan button */}
-        <button
-          onClick={onAddToMealPlan}
-          disabled={isLoading}
-          className="flex-1 bg-olive text-cream font-medium py-3 px-4 rounded-button hover:bg-olive-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          Add to meal plan
-        </button>
+  const createGroceryItem = useCreateGroceryItem()
+  const [isAddingToList, setIsAddingToList] = useState(false)
+  const [addToListError, setAddToListError] = useState<string | null>(null)
 
-        {/* Favorite toggle button */}
-        <button
-          onClick={onFavoriteToggle}
-          disabled={isLoading}
-          className="flex-shrink-0 p-3 rounded-button border-2 border-warm-border bg-cream hover:bg-cream-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          aria-label={isFavorited ? 'Remove from favorites' : 'Add to favorites'}
-        >
-          <Heart
-            size={24}
-            className={isFavorited ? 'fill-mocha stroke-mocha' : 'stroke-mocha'}
-            strokeWidth={2}
-          />
-        </button>
+  const missingCount = missingIngredients.length
+  const allInStock = missingCount === 0
+
+  const handleAddMissingToList = async () => {
+    if (missingCount === 0) return
+
+    setIsAddingToList(true)
+    setAddToListError(null)
+
+    try {
+      // Add each missing ingredient to grocery list
+      for (const { ingredient } of missingIngredients) {
+        await createGroceryItem.mutateAsync({
+          item_name: ingredient.ingredient_name,
+          quantity: ingredient.quantity,
+          unit: ingredient.unit,
+          source: 'recipe',
+        })
+      }
+    } catch (error) {
+      console.error('Failed to add ingredients to grocery list:', error)
+      setAddToListError('Failed to add ingredients. Please try again.')
+      setTimeout(() => setAddToListError(null), 5000)
+    } finally {
+      setIsAddingToList(false)
+    }
+  }
+
+  return (
+    <>
+      {addToListError && (
+        <div className="fixed bottom-20 left-4 right-4 bg-red-50 border border-red-200 rounded-lg p-3 shadow-lg z-40">
+          <p className="text-sm text-red-800">{addToListError}</p>
+        </div>
+      )}
+      <div className="fixed bottom-0 left-0 right-0 bg-cream border-t border-warm-border shadow-lg z-10">
+        <div className="max-w-2xl mx-auto px-4 py-3 flex items-center gap-3">
+          {/* Add missing to list button (pantry cross-reference) */}
+          <button
+            onClick={handleAddMissingToList}
+            disabled={isLoading || isAddingToList || allInStock}
+            className="flex-1 bg-olive text-cream font-medium py-3 px-4 rounded-button hover:bg-olive-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            title={allInStock ? 'All ingredients are in stock' : `Add ${missingCount} missing ingredient${missingCount === 1 ? '' : 's'} to grocery list`}
+          >
+            <ShoppingCart size={18} />
+            <span>
+              {allInStock
+                ? 'All ingredients in stock'
+                : `Add ${missingCount} missing to list`}
+            </span>
+          </button>
+
+          {/* Favorite toggle button */}
+          <button
+            onClick={onFavoriteToggle}
+            disabled={isLoading}
+            className="flex-shrink-0 p-3 rounded-button border-2 border-warm-border bg-cream hover:bg-cream-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            aria-label={isFavorited ? 'Remove from favorites' : 'Add to favorites'}
+          >
+            <Heart
+              size={24}
+              className={isFavorited ? 'fill-mocha stroke-mocha' : 'stroke-mocha'}
+              strokeWidth={2}
+            />
+          </button>
+        </div>
       </div>
-    </div>
+    </>
   )
 }

--- a/frontend/src/components/recipe/IngredientsTab.tsx
+++ b/frontend/src/components/recipe/IngredientsTab.tsx
@@ -1,4 +1,8 @@
 import type { RecipeIngredientResponse } from '../../api/types'
+import { useInventoryList } from '../../api/hooks/useInventory'
+import { checkIngredientAvailability } from '../../utils/pantryMatcher'
+import PantryCheck from './PantryCheck'
+import Pill from '../ui/Pill'
 
 interface IngredientsTabProps {
   ingredients: RecipeIngredientResponse[]
@@ -57,10 +61,17 @@ function formatQuantity(quantity: number): string {
  * Features:
  * - Lists all ingredients with scaled quantities
  * - Shows quantity, unit, and ingredient name
- * - Grouped presentation (can be enhanced with categories later)
+ * - Pantry cross-reference: "In stock" badges for available ingredients
+ * - PantryCheck summary card at bottom
  * - Quantities scaled by servingsMultiplier
  */
 export default function IngredientsTab({ ingredients, servingsMultiplier }: IngredientsTabProps) {
+  // Fetch pantry inventory for cross-reference
+  const { data: inventoryItems = [] } = useInventoryList({})
+
+  // Check ingredient availability against pantry
+  const stockStatus = checkIngredientAvailability(ingredients, inventoryItems)
+
   if (ingredients.length === 0) {
     return (
       <div className="text-center py-8 text-text-secondary">
@@ -69,11 +80,18 @@ export default function IngredientsTab({ ingredients, servingsMultiplier }: Ingr
     )
   }
 
+  // Create a map for quick lookup of stock status
+  const stockStatusMap = new Map<string, boolean>()
+  stockStatus.inStock.forEach((item) => {
+    stockStatusMap.set(item.ingredient.id, true)
+  })
+
   return (
     <div className="space-y-3">
       {ingredients.map((ingredient) => {
         const scaledQuantity = ingredient.quantity * servingsMultiplier
         const formattedQuantity = formatQuantity(scaledQuantity)
+        const isInStock = stockStatusMap.has(ingredient.id)
 
         return (
           <div
@@ -86,9 +104,19 @@ export default function IngredientsTab({ ingredients, servingsMultiplier }: Ingr
             <div className="flex-1 text-sm text-text-primary">
               {ingredient.ingredient_name}
             </div>
+            {isInStock && (
+              <div className="flex-shrink-0">
+                <Pill variant="success">
+                  <span className="text-xs">In stock</span>
+                </Pill>
+              </div>
+            )}
           </div>
         )
       })}
+
+      {/* PantryCheck summary card */}
+      <PantryCheck stockStatus={stockStatus} />
     </div>
   )
 }

--- a/frontend/src/components/recipe/IngredientsTab.tsx
+++ b/frontend/src/components/recipe/IngredientsTab.tsx
@@ -67,7 +67,7 @@ function formatQuantity(quantity: number): string {
  */
 export default function IngredientsTab({ ingredients, servingsMultiplier }: IngredientsTabProps) {
   // Fetch pantry inventory for cross-reference
-  const { data: inventoryItems = [] } = useInventoryList({})
+  const { data: inventoryItems = [], isError: inventoryError } = useInventoryList({})
 
   // Check ingredient availability against pantry
   const stockStatus = checkIngredientAvailability(ingredients, inventoryItems)
@@ -88,6 +88,13 @@ export default function IngredientsTab({ ingredients, servingsMultiplier }: Ingr
 
   return (
     <div className="space-y-3">
+      {inventoryError && (
+        <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3 mb-3">
+          <p className="text-sm text-yellow-800">
+            Unable to load pantry inventory. Stock status may not be accurate.
+          </p>
+        </div>
+      )}
       {ingredients.map((ingredient) => {
         const scaledQuantity = ingredient.quantity * servingsMultiplier
         const formattedQuantity = formatQuantity(scaledQuantity)

--- a/frontend/src/components/recipe/PantryCheck.tsx
+++ b/frontend/src/components/recipe/PantryCheck.tsx
@@ -1,0 +1,62 @@
+import type { PantryCheckResult } from '../../utils/pantryMatcher'
+
+interface PantryCheckProps {
+  stockStatus: PantryCheckResult
+}
+
+/**
+ * PantryCheck component displays pantry cross-reference summary
+ *
+ * Features:
+ * - Shows "X of Y ingredients in stock"
+ * - Lists in-stock ingredient names (passive voice per design system)
+ * - Shows count of missing ingredients
+ * - Olive/cream color scheme
+ * - Positioned at bottom of IngredientsTab
+ *
+ * Design System: Section 7.3 - Pantry Cross-Reference
+ */
+export default function PantryCheck({ stockStatus }: PantryCheckProps) {
+  const { inStock, outOfStock, totalCount, inStockCount } = stockStatus
+
+  // Don't show if no ingredients
+  if (totalCount === 0) {
+    return null
+  }
+
+  const missingCount = outOfStock.length
+
+  // Format in-stock ingredient names for display
+  const inStockNames = inStock.map((item) => item.ingredient.ingredient_name)
+
+  return (
+    <div className="mt-6 p-4 bg-ingredient-pill-bg rounded-lg border border-warm-border">
+      {/* Summary heading */}
+      <div className="text-sm font-medium text-text-primary mb-2">
+        {inStockCount} of {totalCount} {totalCount === 1 ? 'ingredient' : 'ingredients'} in stock
+      </div>
+
+      {/* In-stock ingredients list (passive voice) */}
+      {inStockNames.length > 0 && (
+        <p className="text-sm text-text-secondary mb-1">
+          {inStockNames.join(', ')}{' '}
+          {inStockNames.length === 1 ? 'is' : 'are'} in stock.
+        </p>
+      )}
+
+      {/* Missing ingredients count */}
+      {missingCount > 0 && (
+        <p className="text-sm text-text-secondary">
+          {missingCount} {missingCount === 1 ? 'ingredient' : 'ingredients'} needed from the store.
+        </p>
+      )}
+
+      {/* All ingredients in stock message */}
+      {missingCount === 0 && inStockCount > 0 && (
+        <p className="text-sm text-olive font-medium">
+          All ingredients are in stock!
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/recipe/RecipeCard.tsx
+++ b/frontend/src/components/recipe/RecipeCard.tsx
@@ -21,7 +21,7 @@ export interface RecipeCardProps {
   }
   imageUrl?: string
   servings?: number
-  allIngredientsInStock?: boolean
+  showAllInStockBadge?: boolean
 }
 
 /**
@@ -49,7 +49,7 @@ export default function RecipeCard({
   householdContext,
   imageUrl,
   servings,
-  allIngredientsInStock = false,
+  showAllInStockBadge,
 }: RecipeCardProps) {
   const { id, name, source_type, cook_time_minutes, tags } = recipe
 
@@ -119,7 +119,7 @@ export default function RecipeCard({
         )}
 
         {/* "All in stock" badge (bottom-left) */}
-        {allIngredientsInStock && (
+        {showAllInStockBadge && (
           <div className="absolute bottom-2 left-2">
             <Pill variant="success">All in stock</Pill>
           </div>

--- a/frontend/src/components/recipe/RecipeCard.tsx
+++ b/frontend/src/components/recipe/RecipeCard.tsx
@@ -21,6 +21,7 @@ export interface RecipeCardProps {
   }
   imageUrl?: string
   servings?: number
+  allIngredientsInStock?: boolean
 }
 
 /**
@@ -30,6 +31,7 @@ export interface RecipeCardProps {
  * - 4:3 aspect ratio image with rounded top corners (10px)
  * - Favorite heart overlay (top-right): filled when favorited, outline when not
  * - Source badge (top-left): conditional based on source_type
+ * - "All in stock" badge (bottom-left): shown when all ingredients available in pantry
  * - Recipe name: truncates at 2 lines, 13px/500 weight
  * - Metadata: cook time, servings, cuisine tag with " · " separator
  * - Household context: "✓ Cooked Nx" (olive) or "Never cooked" (mocha)
@@ -47,6 +49,7 @@ export default function RecipeCard({
   householdContext,
   imageUrl,
   servings,
+  allIngredientsInStock = false,
 }: RecipeCardProps) {
   const { id, name, source_type, cook_time_minutes, tags } = recipe
 
@@ -112,6 +115,13 @@ export default function RecipeCard({
         {sourceBadge && (
           <div className="absolute top-2 left-2">
             <Pill variant="default">{sourceBadge}</Pill>
+          </div>
+        )}
+
+        {/* "All in stock" badge (bottom-left) */}
+        {allIngredientsInStock && (
+          <div className="absolute bottom-2 left-2">
+            <Pill variant="success">All in stock</Pill>
           </div>
         )}
 

--- a/frontend/src/components/recipe/__tests__/PantryCheck.test.tsx
+++ b/frontend/src/components/recipe/__tests__/PantryCheck.test.tsx
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import PantryCheck from '../PantryCheck'
+import type { PantryCheckResult } from '../../../utils/pantryMatcher'
+import type { RecipeIngredientResponse } from '../../../api/types'
+
+describe('PantryCheck', () => {
+  const createIngredient = (overrides: Partial<RecipeIngredientResponse> = {}): RecipeIngredientResponse => ({
+    id: 'ing-1',
+    recipe_id: 'recipe-1',
+    ingredient_name: 'flour',
+    quantity: 1,
+    unit: 'cup',
+    step_index: null,
+    ...overrides,
+  })
+
+  it('displays correct stock count summary', () => {
+    const stockStatus: PantryCheckResult = {
+      inStock: [
+        { ingredient: createIngredient({ id: 'ing-1', ingredient_name: 'flour' }), inStock: true },
+        { ingredient: createIngredient({ id: 'ing-2', ingredient_name: 'sugar' }), inStock: true },
+      ],
+      outOfStock: [
+        { ingredient: createIngredient({ id: 'ing-3', ingredient_name: 'salt' }), inStock: false },
+      ],
+      totalCount: 3,
+      inStockCount: 2,
+    }
+
+    render(<PantryCheck stockStatus={stockStatus} />)
+
+    expect(screen.getByText(/2 of 3 ingredients in stock/i)).toBeInTheDocument()
+  })
+
+  it('lists in-stock ingredient names', () => {
+    const stockStatus: PantryCheckResult = {
+      inStock: [
+        { ingredient: createIngredient({ id: 'ing-1', ingredient_name: 'flour' }), inStock: true },
+        { ingredient: createIngredient({ id: 'ing-2', ingredient_name: 'sugar' }), inStock: true },
+      ],
+      outOfStock: [],
+      totalCount: 2,
+      inStockCount: 2,
+    }
+
+    render(<PantryCheck stockStatus={stockStatus} />)
+
+    expect(screen.getByText(/flour, sugar are in stock/i)).toBeInTheDocument()
+  })
+
+  it('uses singular "ingredient" for single item', () => {
+    const stockStatus: PantryCheckResult = {
+      inStock: [
+        { ingredient: createIngredient({ ingredient_name: 'flour' }), inStock: true },
+      ],
+      outOfStock: [],
+      totalCount: 1,
+      inStockCount: 1,
+    }
+
+    render(<PantryCheck stockStatus={stockStatus} />)
+
+    expect(screen.getByText(/1 of 1 ingredient in stock/i)).toBeInTheDocument()
+    expect(screen.getByText(/flour is in stock/i)).toBeInTheDocument()
+  })
+
+  it('shows missing ingredients count', () => {
+    const stockStatus: PantryCheckResult = {
+      inStock: [
+        { ingredient: createIngredient({ ingredient_name: 'flour' }), inStock: true },
+      ],
+      outOfStock: [
+        { ingredient: createIngredient({ id: 'ing-2', ingredient_name: 'sugar' }), inStock: false },
+        { ingredient: createIngredient({ id: 'ing-3', ingredient_name: 'salt' }), inStock: false },
+      ],
+      totalCount: 3,
+      inStockCount: 1,
+    }
+
+    render(<PantryCheck stockStatus={stockStatus} />)
+
+    expect(screen.getByText(/2 ingredients needed from the store/i)).toBeInTheDocument()
+  })
+
+  it('uses singular "ingredient" for single missing item', () => {
+    const stockStatus: PantryCheckResult = {
+      inStock: [],
+      outOfStock: [
+        { ingredient: createIngredient({ ingredient_name: 'flour' }), inStock: false },
+      ],
+      totalCount: 1,
+      inStockCount: 0,
+    }
+
+    render(<PantryCheck stockStatus={stockStatus} />)
+
+    expect(screen.getByText(/1 ingredient needed from the store/i)).toBeInTheDocument()
+  })
+
+  it('shows all ingredients in stock message when nothing is missing', () => {
+    const stockStatus: PantryCheckResult = {
+      inStock: [
+        { ingredient: createIngredient({ id: 'ing-1', ingredient_name: 'flour' }), inStock: true },
+        { ingredient: createIngredient({ id: 'ing-2', ingredient_name: 'sugar' }), inStock: true },
+      ],
+      outOfStock: [],
+      totalCount: 2,
+      inStockCount: 2,
+    }
+
+    render(<PantryCheck stockStatus={stockStatus} />)
+
+    expect(screen.getByText(/All ingredients are in stock!/i)).toBeInTheDocument()
+  })
+
+  it('does not render when no ingredients', () => {
+    const stockStatus: PantryCheckResult = {
+      inStock: [],
+      outOfStock: [],
+      totalCount: 0,
+      inStockCount: 0,
+    }
+
+    const { container } = render(<PantryCheck stockStatus={stockStatus} />)
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('handles empty in-stock list gracefully', () => {
+    const stockStatus: PantryCheckResult = {
+      inStock: [],
+      outOfStock: [
+        { ingredient: createIngredient({ ingredient_name: 'flour' }), inStock: false },
+      ],
+      totalCount: 1,
+      inStockCount: 0,
+    }
+
+    render(<PantryCheck stockStatus={stockStatus} />)
+
+    expect(screen.getByText(/0 of 1 ingredient in stock/i)).toBeInTheDocument()
+    expect(screen.getByText(/1 ingredient needed from the store/i)).toBeInTheDocument()
+    expect(screen.queryByText(/are in stock/i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/RecipeDetail.tsx
+++ b/frontend/src/pages/RecipeDetail.tsx
@@ -30,7 +30,7 @@ export default function RecipeDetail() {
     retry: false,
   })
 
-  const { data: inventoryItems = [] } = useInventoryList({})
+  const { data: inventoryItems = [], isLoading: isLoadingInventory, isError: isInventoryError } = useInventoryList({})
 
   const rateRecipeMutation = useRateRecipe()
 
@@ -181,11 +181,16 @@ export default function RecipeDetail() {
             <p className="text-sm text-red-800">{favoriteError}</p>
           </div>
         )}
+        {isInventoryError && (
+          <div className="fixed bottom-20 left-4 right-4 bg-yellow-50 border border-yellow-200 rounded-lg p-3 shadow-lg z-40">
+            <p className="text-sm text-yellow-800">Unable to load pantry inventory. The "Add missing to list" button is temporarily unavailable.</p>
+          </div>
+        )}
         <ActionBar
           isFavorited={isFavorited}
           onFavoriteToggle={handleFavoriteToggle}
           onAddToMealPlan={handleAddToMealPlan}
-          isLoading={rateRecipeMutation.isPending || isLoadingRating}
+          isLoading={rateRecipeMutation.isPending || isLoadingRating || isLoadingInventory || isInventoryError}
           missingIngredients={stockStatus.outOfStock}
         />
       </>

--- a/frontend/src/pages/RecipeDetail.tsx
+++ b/frontend/src/pages/RecipeDetail.tsx
@@ -10,6 +10,8 @@ import NutritionTab from '../components/recipe/NutritionTab'
 import ActionBar from '../components/recipe/ActionBar'
 import Pill from '../components/ui/Pill'
 import { useRecipe, useMyRecipeRating, useRateRecipe } from '../api/hooks/useRecipes'
+import { useInventoryList } from '../api/hooks/useInventory'
+import { checkIngredientAvailability } from '../utils/pantryMatcher'
 import { useAuth } from '../contexts/AuthContext'
 
 export default function RecipeDetail() {
@@ -27,6 +29,8 @@ export default function RecipeDetail() {
     enabled: !!id,
     retry: false,
   })
+
+  const { data: inventoryItems = [] } = useInventoryList({})
 
   const rateRecipeMutation = useRateRecipe()
 
@@ -115,6 +119,11 @@ export default function RecipeDetail() {
 
   const isFavorited = myRating?.is_favorite || false
 
+  // Calculate missing ingredients for "Add missing to list" button
+  const stockStatus = recipe
+    ? checkIngredientAvailability(recipe.ingredients, inventoryItems)
+    : { inStock: [], outOfStock: [], totalCount: 0, inStockCount: 0 }
+
   return (
     <>
       <PageContainer>
@@ -177,6 +186,7 @@ export default function RecipeDetail() {
           onFavoriteToggle={handleFavoriteToggle}
           onAddToMealPlan={handleAddToMealPlan}
           isLoading={rateRecipeMutation.isPending || isLoadingRating}
+          missingIngredients={stockStatus.outOfStock}
         />
       </>
     </>

--- a/frontend/src/pages/Recipes.tsx
+++ b/frontend/src/pages/Recipes.tsx
@@ -5,6 +5,7 @@ import SearchBar from '../components/recipe/SearchBar'
 import SectionNav from '../components/recipe/SectionNav'
 import RecipeCarousel from '../components/recipe/RecipeCarousel'
 import RecipeGrid from '../components/recipe/RecipeGrid'
+import Pill from '../components/ui/Pill'
 import type { RecipeFilters } from '../components/recipe/FilterChips'
 
 /**
@@ -25,6 +26,7 @@ export default function Recipes() {
   const [viewMode, setViewMode] = useState<'carousel' | 'grid'>('carousel')
   const [searchQuery, setSearchQuery] = useState('')
   const [filters, setFilters] = useState<RecipeFilters>({})
+  const [showOnlyInStock, setShowOnlyInStock] = useState(false)
 
   // Define carousel sections
   const sections = [
@@ -74,6 +76,23 @@ export default function Recipes() {
 
         {/* Search bar */}
         <SearchBar value={searchQuery} onChange={handleSearchChange} />
+
+        {/* "Show what I can make now" toggle (Phase 1: Display only, non-functional) */}
+        <div className="flex items-center gap-3 mb-4">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={showOnlyInStock}
+              onChange={(e) => setShowOnlyInStock(e.target.checked)}
+              disabled
+              className="w-5 h-5 rounded border-warm-border text-olive focus:ring-olive focus:ring-offset-0 disabled:opacity-50 disabled:cursor-not-allowed"
+            />
+            <span className="text-sm text-text-primary">Show what I can make now</span>
+          </label>
+          <Pill variant="default">
+            <span className="text-xs">Phase 3</span>
+          </Pill>
+        </div>
 
         {/* Carousel view */}
         {viewMode === 'carousel' && (

--- a/frontend/src/utils/__tests__/pantryMatcher.test.ts
+++ b/frontend/src/utils/__tests__/pantryMatcher.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect } from 'vitest'
+import { checkIngredientAvailability, areAllIngredientsInStock } from '../pantryMatcher'
+import type { RecipeIngredientResponse, InventoryItemListResponse } from '../../api/types'
+
+describe('pantryMatcher', () => {
+  const createIngredient = (overrides: Partial<RecipeIngredientResponse> = {}): RecipeIngredientResponse => ({
+    id: 'ing-1',
+    recipe_id: 'recipe-1',
+    ingredient_name: 'flour',
+    quantity: 1,
+    unit: 'cup',
+    step_index: null,
+    ...overrides,
+  })
+
+  const createInventoryItem = (overrides: Partial<InventoryItemListResponse> = {}): InventoryItemListResponse => ({
+    id: 'inv-1',
+    name: 'flour',
+    quantity: 2,
+    unit: 'cup',
+    category: 'baking',
+    storage_location: 'pantry',
+    date_added: '2026-03-01',
+    expiration_date: null,
+    is_staple: true,
+    shareability: 'shared',
+    ...overrides,
+  })
+
+  describe('checkIngredientAvailability', () => {
+    it('identifies ingredients in stock with exact name match', () => {
+      const ingredients = [
+        createIngredient({ id: 'ing-1', ingredient_name: 'flour' }),
+        createIngredient({ id: 'ing-2', ingredient_name: 'sugar' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ id: 'inv-1', name: 'flour' }),
+      ]
+
+      const result = checkIngredientAvailability(ingredients, inventoryItems)
+
+      expect(result.inStockCount).toBe(1)
+      expect(result.totalCount).toBe(2)
+      expect(result.inStock).toHaveLength(1)
+      expect(result.outOfStock).toHaveLength(1)
+      expect(result.inStock[0].ingredient.ingredient_name).toBe('flour')
+      expect(result.outOfStock[0].ingredient.ingredient_name).toBe('sugar')
+    })
+
+    it('matches ingredients case-insensitively', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: 'Flour' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'flour' }),
+      ]
+
+      const result = checkIngredientAvailability(ingredients, inventoryItems)
+
+      expect(result.inStockCount).toBe(1)
+      expect(result.inStock[0].inStock).toBe(true)
+    })
+
+    it('matches ingredients with partial name match (contains)', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: 'flour' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'all-purpose flour' }),
+      ]
+
+      const result = checkIngredientAvailability(ingredients, inventoryItems)
+
+      expect(result.inStockCount).toBe(1)
+      expect(result.inStock[0].inStock).toBe(true)
+      expect(result.inStock[0].matchedInventoryItem?.name).toBe('all-purpose flour')
+    })
+
+    it('matches inventory items with more generic names', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: 'all-purpose flour' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'flour' }),
+      ]
+
+      const result = checkIngredientAvailability(ingredients, inventoryItems)
+
+      expect(result.inStockCount).toBe(1)
+      expect(result.inStock[0].inStock).toBe(true)
+    })
+
+    it('returns all out of stock when inventory is empty', () => {
+      const ingredients = [
+        createIngredient({ id: 'ing-1', ingredient_name: 'flour' }),
+        createIngredient({ id: 'ing-2', ingredient_name: 'sugar' }),
+      ]
+
+      const result = checkIngredientAvailability(ingredients, [])
+
+      expect(result.inStockCount).toBe(0)
+      expect(result.totalCount).toBe(2)
+      expect(result.inStock).toHaveLength(0)
+      expect(result.outOfStock).toHaveLength(2)
+    })
+
+    it('returns empty result when no ingredients', () => {
+      const inventoryItems = [
+        createInventoryItem({ name: 'flour' }),
+      ]
+
+      const result = checkIngredientAvailability([], inventoryItems)
+
+      expect(result.inStockCount).toBe(0)
+      expect(result.totalCount).toBe(0)
+      expect(result.inStock).toHaveLength(0)
+      expect(result.outOfStock).toHaveLength(0)
+    })
+
+    it('matches first inventory item found (first match wins)', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: 'flour' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ id: 'inv-1', name: 'flour' }),
+        createInventoryItem({ id: 'inv-2', name: 'all-purpose flour' }),
+      ]
+
+      const result = checkIngredientAvailability(ingredients, inventoryItems)
+
+      expect(result.inStockCount).toBe(1)
+      expect(result.inStock[0].matchedInventoryItem?.id).toBe('inv-1')
+    })
+
+    it('handles whitespace in ingredient names', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: '  flour  ' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'flour' }),
+      ]
+
+      const result = checkIngredientAvailability(ingredients, inventoryItems)
+
+      expect(result.inStockCount).toBe(1)
+    })
+  })
+
+  describe('areAllIngredientsInStock', () => {
+    it('returns true when all ingredients are in stock', () => {
+      const ingredients = [
+        createIngredient({ id: 'ing-1', ingredient_name: 'flour' }),
+        createIngredient({ id: 'ing-2', ingredient_name: 'sugar' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ id: 'inv-1', name: 'flour' }),
+        createInventoryItem({ id: 'inv-2', name: 'sugar' }),
+      ]
+
+      const result = areAllIngredientsInStock(ingredients, inventoryItems)
+
+      expect(result).toBe(true)
+    })
+
+    it('returns false when some ingredients are missing', () => {
+      const ingredients = [
+        createIngredient({ id: 'ing-1', ingredient_name: 'flour' }),
+        createIngredient({ id: 'ing-2', ingredient_name: 'sugar' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ id: 'inv-1', name: 'flour' }),
+      ]
+
+      const result = areAllIngredientsInStock(ingredients, inventoryItems)
+
+      expect(result).toBe(false)
+    })
+
+    it('returns false when no ingredients are in stock', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: 'flour' }),
+      ]
+
+      const result = areAllIngredientsInStock(ingredients, [])
+
+      expect(result).toBe(false)
+    })
+
+    it('returns false when recipe has no ingredients', () => {
+      const inventoryItems = [
+        createInventoryItem({ name: 'flour' }),
+      ]
+
+      const result = areAllIngredientsInStock([], inventoryItems)
+
+      expect(result).toBe(false)
+    })
+
+    it('handles case-insensitive matching', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: 'Flour' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'flour' }),
+      ]
+
+      const result = areAllIngredientsInStock(ingredients, inventoryItems)
+
+      expect(result).toBe(true)
+    })
+
+    it('handles partial name matching', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: 'flour' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'all-purpose flour' }),
+      ]
+
+      const result = areAllIngredientsInStock(ingredients, inventoryItems)
+
+      expect(result).toBe(true)
+    })
+  })
+})

--- a/frontend/src/utils/pantryMatcher.ts
+++ b/frontend/src/utils/pantryMatcher.ts
@@ -1,0 +1,117 @@
+import type { RecipeIngredientResponse, InventoryItemListResponse } from '../api/types'
+
+/**
+ * Normalizes ingredient names for matching
+ * - Converts to lowercase
+ * - Trims whitespace
+ * - Removes common variations (e.g., "all-purpose flour" -> "flour")
+ *
+ * Phase 1: Simple name-based presence check (not quantity-based)
+ */
+function normalizeIngredientName(name: string): string {
+  return name.toLowerCase().trim()
+}
+
+/**
+ * Checks if an ingredient name matches an inventory item name
+ * Phase 1: Simple case-insensitive match
+ * Future: Could enhance with fuzzy matching, synonyms, etc.
+ */
+function ingredientMatchesInventoryItem(
+  ingredientName: string,
+  inventoryItemName: string
+): boolean {
+  const normalizedIngredient = normalizeIngredientName(ingredientName)
+  const normalizedInventory = normalizeIngredientName(inventoryItemName)
+
+  // Exact match after normalization
+  if (normalizedIngredient === normalizedInventory) {
+    return true
+  }
+
+  // Check if one contains the other (e.g., "flour" matches "all-purpose flour")
+  // This handles common variations where inventory items are more specific
+  if (
+    normalizedInventory.includes(normalizedIngredient) ||
+    normalizedIngredient.includes(normalizedInventory)
+  ) {
+    return true
+  }
+
+  return false
+}
+
+export interface IngredientStockStatus {
+  ingredient: RecipeIngredientResponse
+  inStock: boolean
+  matchedInventoryItem?: InventoryItemListResponse
+}
+
+export interface PantryCheckResult {
+  inStock: IngredientStockStatus[]
+  outOfStock: IngredientStockStatus[]
+  totalCount: number
+  inStockCount: number
+}
+
+/**
+ * Checks recipe ingredients against pantry inventory
+ * Returns stock status for each ingredient
+ *
+ * @param ingredients - Recipe ingredients to check
+ * @param inventoryItems - Current pantry inventory
+ * @returns Categorized stock status with counts
+ */
+export function checkIngredientAvailability(
+  ingredients: RecipeIngredientResponse[],
+  inventoryItems: InventoryItemListResponse[]
+): PantryCheckResult {
+  const inStock: IngredientStockStatus[] = []
+  const outOfStock: IngredientStockStatus[] = []
+
+  for (const ingredient of ingredients) {
+    // Find matching inventory item (first match wins)
+    const matchedItem = inventoryItems.find((item) =>
+      ingredientMatchesInventoryItem(ingredient.ingredient_name, item.name)
+    )
+
+    if (matchedItem) {
+      inStock.push({
+        ingredient,
+        inStock: true,
+        matchedInventoryItem: matchedItem,
+      })
+    } else {
+      outOfStock.push({
+        ingredient,
+        inStock: false,
+      })
+    }
+  }
+
+  return {
+    inStock,
+    outOfStock,
+    totalCount: ingredients.length,
+    inStockCount: inStock.length,
+  }
+}
+
+/**
+ * Checks if ALL ingredients in a recipe are available in pantry
+ * Used for "All in stock" badge on recipe cards
+ */
+export function areAllIngredientsInStock(
+  ingredients: RecipeIngredientResponse[],
+  inventoryItems: InventoryItemListResponse[]
+): boolean {
+  if (ingredients.length === 0) {
+    return false // No ingredients = can't make it
+  }
+
+  return ingredients.every((ingredient) =>
+    inventoryItems.some((item) =>
+      ingredientMatchesInventoryItem(ingredient.ingredient_name, item.name)
+    )
+  )
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -37,6 +37,8 @@ export default {
           border: '#e8e5d8',
           gray: '#8b8b7e',
         },
+        // Ingredient pill background (per design system Section 2)
+        'ingredient-pill-bg': '#f7f5ee',
         // Text colors (no pure black/white - following design system philosophy)
         text: {
           primary: '#2c2c2a',

--- a/scratchpad.md
+++ b/scratchpad.md
@@ -1,0 +1,5 @@
+# Encountered Issues (Needs Triage)
+
+## Issues discovered during implementation of #301-302
+
+- **2026-03-26** | `frontend/src/api/types.ts:304-313` | missing-feature | RecipeListResponse lacks ingredients field | Affects: Recipe cards in browse/carousel views cannot show "All in stock" badge | Fix: Add ingredients array to RecipeListResponse in backend, or add computed field `has_all_ingredients_in_stock` to avoid N+1 queries | Done: Recipe cards display "All in stock" badge when `allIngredientsInStock` prop is true, RecipeCarousel/RecipeGrid calculate stock status from ingredients

--- a/scratchpad.md
+++ b/scratchpad.md
@@ -1,5 +1,0 @@
-# Encountered Issues (Needs Triage)
-
-## Issues discovered during implementation of #301-302
-
-- **2026-03-26** | `frontend/src/api/types.ts:304-313` | missing-feature | RecipeListResponse lacks ingredients field | Affects: Recipe cards in browse/carousel views cannot show "All in stock" badge | Fix: Add ingredients array to RecipeListResponse in backend, or add computed field `has_all_ingredients_in_stock` to avoid N+1 queries | Done: Recipe cards display "All in stock" badge when `allIngredientsInStock` prop is true, RecipeCarousel/RecipeGrid calculate stock status from ingredients


### PR DESCRIPTION
## Work in Progress

Closes #301

Add recipe-pantry cross-reference to list

## Summary

<!-- sharkrite-changes-summary -->
## Changes

**11** files, **2** commits (+5 added, ~6 modified, -0 deleted)
- `M` frontend/src/components/recipe/ActionBar.tsx
- `M` frontend/src/components/recipe/IngredientsTab.tsx
- `A` frontend/src/components/recipe/PantryCheck.tsx
- `M` frontend/src/components/recipe/RecipeCard.tsx
- `A` frontend/src/components/recipe/__tests__/PantryCheck.test.tsx
- `M` frontend/src/pages/RecipeDetail.tsx
- `M` frontend/src/pages/Recipes.tsx
- `A` frontend/src/utils/__tests__/pantryMatcher.test.ts
- `A` frontend/src/utils/pantryMatcher.ts
- `M` frontend/tailwind.config.js
- `A` scratchpad.md

### Commits
- 5fe0102 feat: Add recipe-pantry cross-reference to list
- 7c38780 chore: initialize work on #301 Add recipe-pantry cross-reference to list
<!-- /sharkrite-changes-summary -->

The pantry cross-reference system is a key FreshUp differentiator — showing which recipe ingredients are already in the pantry and letting users add missing ones to the grocery list in one tap. This layers onto the existing Recipe Detail and Recipe Browse screens built in #296/#297.

**Priority:** P0 | **Estimate:** 2–2.5 hours | **Depends on:** #297 (Recipe Detail), #298 (Grocery List)

## Design References

- Design System Section 5.2 (Recipe Detail — PantryCheck)
- Design System Section 7 (Pantry Cross-Reference system-wide feature)

## Implementation

### Recipe Detail — Ingredients Tab
- Cross-ref each ingredient against `useInventoryList` to determine stock status
- "In stock" badge (olive pill) next to ingredients found in pantry
- PantryCheck summary card: "X of Y ingredients in stock" with item names listed
- "Add missing to list" button in action bar — adds unstocked ingredients to grocery list via `useCreateGroceryItem` with `source="recipe"`
- Button shows count: "Add 5 missing to list"
- Disabled state when all ingredients are in stock

### Recipe Cards (browse/grid)
- "All in stock" olive badge on cards where every ingredient is in pantry

### Recipe Browse
- "Show what I can make now" toggle renders visually with "Phase 3" indicator badge (non-functional filter — display only for Phase 1)

## Acceptance Criteria

- [ ] Ingredients tab shows "In stock" olive pill next to stocked ingredients
- [ ] PantryCheck summary card shows "X of Y ingredients in stock"
- [ ] "Add missing to list" button adds unstocked ingredients to grocery list
- [ ] Button shows count and is disabled when all ingredients in stock
- [ ] RecipeCard shows "All in stock" badge when applicable
- [ ] "Show what I can make now" toggle renders with Phase 3 indicator
- [ ] Name-based matching (not quantity) for stock status check
- [ ] Existing recipe and pantry tests still pass

## DO NOT Scope

- Functional "can make now" filtering (Phase 3A)
- Ingredient quantity matching (name-based presence check only for Phase 1)
- "Add to meal plan" functionality (Phase 3)

---
_Draft PR created automatically by rite for tracking purposes._

---

## Follow-up Issues
Created: #356 Created: #355  Updated: #342  Updated: #342  Updated: #342 
**From assessment on 2026-03-26T08:08:57Z:**
- Created: #342 
- Updated: none