### PR TITLE
[2C] Scraper API endpoints & CLI

### DIFF
--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -1,0 +1,5 @@
+"""
+CLI tools for FreshUp.
+
+Provides command-line utilities for administrative tasks like bulk recipe imports.
+"""

--- a/src/cli/import_recipes.py
+++ b/src/cli/import_recipes.py
@@ -1,0 +1,190 @@
+"""
+Recipe import CLI for FreshUp.
+
+Command-line tool for bulk recipe imports from external sources.
+Supports both URL discovery (via crawlers) and single URL imports.
+
+Usage:
+    # Discover and import from HelloFresh (max 50 recipes)
+    python -m src.cli.import_recipes --source hellofresh --max 50
+
+    # Discover and import from Kitchen Sanctuary (max 50 recipes)
+    python -m src.cli.import_recipes --source kitchen_sanctuary --max 50
+
+    # Import a single URL
+    python -m src.cli.import_recipes --url "https://www.hellofresh.com/recipes/..."
+"""
+
+import argparse
+import sys
+import logging
+from typing import Optional
+
+from src.db.database import init_engine, get_session_factory
+from src.services.import_service import import_recipe_from_url, import_batch
+from src.services.crawlers.hellofresh_crawler import HelloFreshCrawler
+from src.services.crawlers.kitchen_sanctuary_crawler import KitchenSanctuaryCrawler
+from src.config import get_settings
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+def import_from_source(source: str, max_recipes: int) -> None:
+    """
+    Discover and import recipes from a source.
+
+    Args:
+        source: Source name (hellofresh or kitchen_sanctuary)
+        max_recipes: Maximum number of recipes to import
+    """
+    logger.info(f"Starting discovery and import from {source} (max: {max_recipes})")
+
+    # Initialize database
+    settings = get_settings()
+    init_engine(settings.database_url)
+    SessionFactory = get_session_factory()
+
+    try:
+        # Discover URLs using crawler
+        if source == "hellofresh":
+            crawler = HelloFreshCrawler()
+            urls = crawler.discover_recipe_urls()
+        elif source == "kitchen_sanctuary":
+            crawler = KitchenSanctuaryCrawler()
+            urls = crawler.discover_recipe_urls()
+        else:
+            logger.error(f"Invalid source: {source}")
+            sys.exit(1)
+
+        logger.info(f"Discovered {len(urls)} URLs from {source}")
+
+        # Limit to max_recipes
+        urls_to_import = urls[:max_recipes]
+        logger.info(f"Importing {len(urls_to_import)} recipes (limited by max_recipes={max_recipes})")
+
+        # Import recipes in batch
+        with SessionFactory() as db:
+            result = import_batch(urls_to_import, db, delay_seconds=1.0)
+
+            logger.info("=" * 60)
+            logger.info("IMPORT SUMMARY")
+            logger.info("=" * 60)
+            logger.info(f"Total URLs processed: {result.total}")
+            logger.info(f"Successfully imported: {result.imported}")
+            logger.info(f"Duplicates skipped: {result.duplicates}")
+            logger.info(f"Errors: {result.errors}")
+            logger.info("=" * 60)
+
+            if result.errors > 0:
+                logger.warning("Some imports failed. Review logs for details.")
+                # Log first 5 errors for quick debugging
+                error_results = [r for r in result.results if r.status == "error"][:5]
+                for i, err_result in enumerate(error_results, 1):
+                    logger.warning(f"Error {i}: {err_result.source_url} - {err_result.error_message}")
+
+    except Exception as e:
+        logger.error(f"Import failed: {e}", exc_info=True)
+        sys.exit(1)
+
+
+def import_from_url(url: str) -> None:
+    """
+    Import a recipe from a single URL.
+
+    Args:
+        url: Recipe URL to import
+    """
+    logger.info(f"Importing recipe from URL: {url}")
+
+    # Initialize database
+    settings = get_settings()
+    init_engine(settings.database_url)
+    SessionFactory = get_session_factory()
+
+    try:
+        with SessionFactory() as db:
+            result = import_recipe_from_url(url, db)
+
+            logger.info("=" * 60)
+            logger.info("IMPORT RESULT")
+            logger.info("=" * 60)
+            logger.info(f"Status: {result.status}")
+            logger.info(f"URL: {result.source_url}")
+
+            if result.status == "success":
+                logger.info(f"Recipe ID: {result.recipe_id}")
+                if result.warnings:
+                    logger.warning("Warnings:")
+                    for warning in result.warnings:
+                        logger.warning(f"  - {warning}")
+            elif result.status == "duplicate":
+                logger.info(f"Recipe already exists (ID: {result.recipe_id})")
+            elif result.status == "error":
+                logger.error(f"Error: {result.error_message}")
+                sys.exit(1)
+
+            logger.info("=" * 60)
+
+    except Exception as e:
+        logger.error(f"Import failed: {e}", exc_info=True)
+        sys.exit(1)
+
+
+def main() -> None:
+    """Main CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Import recipes from external sources into FreshUp",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Bulk import from HelloFresh (max 50 recipes)
+  python -m src.cli.import_recipes --source hellofresh --max 50
+
+  # Bulk import from Kitchen Sanctuary (max 100 recipes)
+  python -m src.cli.import_recipes --source kitchen_sanctuary --max 100
+
+  # Import a single recipe URL
+  python -m src.cli.import_recipes --url "https://www.hellofresh.com/recipes/chicken-tikka"
+        """
+    )
+
+    # Mutually exclusive group: either --source or --url
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--source",
+        type=str,
+        choices=["hellofresh", "kitchen_sanctuary"],
+        help="Source to import from (discovers URLs via crawler)"
+    )
+    group.add_argument(
+        "--url",
+        type=str,
+        help="Single recipe URL to import"
+    )
+
+    # Optional arguments
+    parser.add_argument(
+        "--max",
+        type=int,
+        default=50,
+        help="Maximum number of recipes to import from source (default: 50, only used with --source)"
+    )
+
+    args = parser.parse_args()
+
+    # Execute appropriate import mode
+    if args.source:
+        import_from_source(args.source, args.max)
+    elif args.url:
+        if args.max != 50:
+            logger.warning("--max argument is ignored when using --url (single import mode)")
+        import_from_url(args.url)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/main.py
+++ b/src/main.py
@@ -11,7 +11,7 @@ from slowapi.errors import RateLimitExceeded
 
 from src.config import get_settings
 from src.db.database import Base, init_engine, get_engine, get_session_factory
-from src.routers import auth_router, users_router, substitutions_router, inventory_router, recipes_router, grocery_router, prepared_foods_router
+from src.routers import auth_router, users_router, substitutions_router, inventory_router, recipes_router, grocery_router, prepared_foods_router, scraper_router
 from src.middleware.rate_limit import limiter
 
 logger = logging.getLogger(__name__)
@@ -103,6 +103,7 @@ app.include_router(inventory_router)
 app.include_router(recipes_router)
 app.include_router(grocery_router)
 app.include_router(prepared_foods_router)
+app.include_router(scraper_router)
 
 
 @app.get("/health")

--- a/src/routers/__init__.py
+++ b/src/routers/__init__.py
@@ -5,6 +5,7 @@
 # - recipes.py (1E)
 # - grocery.py (1F)
 # - prepared_foods.py (1G)
+# - scraper.py (2C - scraper/import endpoints)
 
 from src.routers.auth import router as auth_router
 from src.routers.users import router as users_router
@@ -13,5 +14,6 @@ from src.routers.inventory import router as inventory_router
 from src.routers.recipes import router as recipes_router
 from src.routers.grocery import router as grocery_router
 from src.routers.prepared_foods import router as prepared_foods_router
+from src.routers.scraper import router as scraper_router
 
-__all__ = ["auth_router", "users_router", "substitutions_router", "inventory_router", "recipes_router", "grocery_router", "prepared_foods_router"]
+__all__ = ["auth_router", "users_router", "substitutions_router", "inventory_router", "recipes_router", "grocery_router", "prepared_foods_router", "scraper_router"]

--- a/src/routers/scraper.py
+++ b/src/routers/scraper.py
@@ -56,6 +56,11 @@ def validate_domain(url: str, allowed_domains: list[str]) -> bool:
     """
     try:
         parsed = urlparse(url)
+
+        # Validate URL scheme (only allow http and https)
+        if parsed.scheme not in ('http', 'https'):
+            return False
+
         hostname = parsed.hostname
         if not hostname:
             return False

--- a/src/routers/scraper.py
+++ b/src/routers/scraper.py
@@ -83,6 +83,16 @@ def import_single_url(
     """
     logger.info(f"User {current_user.id} importing recipe from URL")
 
+    # Validate URL is from a supported domain
+    allowed_domains = ["hellofresh.com", "kitchensanctuary.com"]
+    url_lower = request.url.lower()
+    if not any(domain in url_lower for domain in allowed_domains):
+        logger.warning(f"User {current_user.id} attempted to import from unsupported domain: {request.url}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"URL must be from a supported domain: {', '.join(allowed_domains)}"
+        )
+
     try:
         result = import_recipe_from_url(request.url, db)
         return result

--- a/src/routers/scraper.py
+++ b/src/routers/scraper.py
@@ -13,6 +13,7 @@ Authorization:
 
 import logging
 from typing import Literal
+from urllib.parse import urlparse
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 from sqlalchemy import func
@@ -37,6 +38,37 @@ from src.schemas.import_service import ImportResult, BatchImportResult
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/scraper", tags=["scraper"])
+
+
+def validate_domain(url: str, allowed_domains: list[str]) -> bool:
+    """
+    Validate that a URL's hostname is from an allowed domain.
+
+    Uses proper domain suffix matching to prevent SSRF attacks via
+    subdomain tricks like "evil.com/hellofresh.com" or "hellofresh.com.evil.com".
+
+    Args:
+        url: URL to validate
+        allowed_domains: List of allowed domain suffixes (e.g., ["hellofresh.com"])
+
+    Returns:
+        True if the URL's hostname matches an allowed domain, False otherwise
+    """
+    try:
+        parsed = urlparse(url)
+        hostname = parsed.hostname
+        if not hostname:
+            return False
+        hostname_lower = hostname.lower()
+
+        # Check if hostname exactly matches or is a subdomain of an allowed domain
+        for domain in allowed_domains:
+            domain_lower = domain.lower()
+            if hostname_lower == domain_lower or hostname_lower.endswith(f".{domain_lower}"):
+                return True
+        return False
+    except Exception:
+        return False
 
 
 def require_coordinator(user: User) -> None:
@@ -85,8 +117,7 @@ def import_single_url(
 
     # Validate URL is from a supported domain
     allowed_domains = ["hellofresh.com", "kitchensanctuary.com"]
-    url_lower = request.url.lower()
-    if not any(domain in url_lower for domain in allowed_domains):
+    if not validate_domain(request.url, allowed_domains):
         logger.warning(f"User {current_user.id} attempted to import from unsupported domain: {request.url}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -131,6 +162,16 @@ def import_batch_urls(
     require_coordinator(current_user)
 
     logger.info(f"Coordinator {current_user.id} importing batch of {len(request.urls)} URLs")
+
+    # Validate all URLs are from supported domains
+    allowed_domains = ["hellofresh.com", "kitchensanctuary.com"]
+    invalid_urls = [url for url in request.urls if not validate_domain(url, allowed_domains)]
+    if invalid_urls:
+        logger.warning(f"Coordinator {current_user.id} attempted batch import with {len(invalid_urls)} invalid URLs")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"All URLs must be from supported domains: {', '.join(allowed_domains)}. Found {len(invalid_urls)} invalid URL(s)."
+        )
 
     try:
         result = import_batch(request.urls, db, delay_seconds=1.0)

--- a/src/routers/scraper.py
+++ b/src/routers/scraper.py
@@ -1,0 +1,302 @@
+"""
+Scraper API endpoints for FreshUp.
+
+Provides endpoints for importing recipes from external URLs, discovering recipes
+from supported sources (HelloFresh, Kitchen Sanctuary), and viewing import statistics.
+
+Authorization:
+- Single URL import: Any authenticated user
+- Batch operations: Coordinator only
+- Discovery operations: Coordinator only
+- Status: Any authenticated user
+"""
+
+import logging
+from typing import Literal
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+
+from src.db.database import get_db
+from src.db.models.user import User, UserRole
+from src.db.models.recipe import Recipe
+from src.middleware.auth import get_current_user
+from src.services.import_service import import_recipe_from_url, import_batch
+from src.services.crawlers.hellofresh_crawler import HelloFreshCrawler
+from src.services.crawlers.kitchen_sanctuary_crawler import KitchenSanctuaryCrawler
+from src.schemas.scraper import (
+    ImportUrlRequest,
+    ImportBatchRequest,
+    DiscoverAndImportRequest,
+    DiscoveryResponse,
+    StatusResponse,
+    SourceStats,
+)
+from src.schemas.import_service import ImportResult, BatchImportResult
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/scraper", tags=["scraper"])
+
+
+def require_coordinator(user: User) -> None:
+    """
+    Verify that the user has coordinator role.
+
+    Args:
+        user: Authenticated user
+
+    Raises:
+        HTTPException(403): If user is not a coordinator
+    """
+    if user.role != UserRole.coordinator.value:
+        logger.warning(f"Access denied: User {user.id} attempted coordinator-only operation")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Coordinator role required for this operation"
+        )
+
+
+@router.post("/import-url", response_model=ImportResult, status_code=status.HTTP_200_OK)
+def import_single_url(
+    request: ImportUrlRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Import a recipe from a single URL.
+
+    Any authenticated user can import recipes. The recipe becomes globally
+    readable (system-imported, created_by=None).
+
+    Args:
+        request: Request containing the URL to import
+        current_user: Authenticated user (injected by get_current_user)
+        db: Database session
+
+    Returns:
+        ImportResult: Result of the import operation (success/duplicate/error)
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(400): If URL is invalid or import fails
+    """
+    logger.info(f"User {current_user.id} importing recipe from URL")
+
+    try:
+        result = import_recipe_from_url(request.url, db)
+        return result
+    except Exception as e:
+        logger.error(f"Unexpected error during import for user {current_user.id}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Import failed: {str(e)}"
+        )
+
+
+@router.post("/import-batch", response_model=BatchImportResult, status_code=status.HTTP_200_OK)
+def import_batch_urls(
+    request: ImportBatchRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Import recipes from multiple URLs (batch operation).
+
+    Coordinator-only endpoint. Processes URLs sequentially with rate limiting
+    (1 second delay between requests by default).
+
+    Args:
+        request: Request containing list of URLs to import
+        current_user: Authenticated user (must be coordinator)
+        db: Database session
+
+    Returns:
+        BatchImportResult: Aggregate statistics and individual results
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(403): If user is not a coordinator
+    """
+    require_coordinator(current_user)
+
+    logger.info(f"Coordinator {current_user.id} importing batch of {len(request.urls)} URLs")
+
+    try:
+        result = import_batch(request.urls, db, delay_seconds=1.0)
+        logger.info(
+            f"Batch import complete: {result.imported} imported, "
+            f"{result.duplicates} duplicates, {result.errors} errors"
+        )
+        return result
+    except Exception as e:
+        logger.error(f"Unexpected error during batch import: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Batch import failed: {str(e)}"
+        )
+
+
+@router.post("/discover/{source}", response_model=DiscoveryResponse, status_code=status.HTTP_200_OK)
+def discover_urls(
+    source: Literal["hellofresh", "kitchen_sanctuary"],
+    max_pages: int | None = Query(default=None, description="Maximum number of pages to crawl (for testing)", ge=1),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Discover recipe URLs from a supported source without importing.
+
+    Coordinator-only endpoint. Uses crawlers to discover URLs from sitemap.xml
+    or paginated category pages. URLs are returned but NOT imported.
+
+    Args:
+        source: Source to discover from (hellofresh or kitchen_sanctuary)
+        max_pages: Optional maximum number of pages to crawl (for testing/limiting scope)
+        current_user: Authenticated user (must be coordinator)
+
+    Returns:
+        DiscoveryResponse: Source name, discovered URLs, and count
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(403): If user is not a coordinator
+        HTTPException(400): If discovery fails
+    """
+    require_coordinator(current_user)
+
+    logger.info(f"Coordinator {current_user.id} discovering URLs from {source}")
+
+    try:
+        if source == "hellofresh":
+            crawler = HelloFreshCrawler()
+            urls = crawler.discover_recipe_urls(max_pages=max_pages)
+        else:  # kitchen_sanctuary
+            crawler = KitchenSanctuaryCrawler()
+            urls = crawler.discover_recipe_urls(max_pages=max_pages)
+
+        logger.info(f"Discovered {len(urls)} URLs from {source}")
+        return DiscoveryResponse(source=source, urls=urls, count=len(urls))
+
+    except Exception as e:
+        logger.error(f"Discovery failed for {source}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"URL discovery failed: {str(e)}"
+        )
+
+
+@router.post("/discover-and-import/{source}", response_model=BatchImportResult, status_code=status.HTTP_200_OK)
+def discover_and_import(
+    source: Literal["hellofresh", "kitchen_sanctuary"],
+    request: DiscoverAndImportRequest = DiscoverAndImportRequest(),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Discover recipe URLs from a source and import them (coordinator-only).
+
+    Combines URL discovery with batch import. Limits the number of imported
+    recipes using the max_recipes parameter (default: 50).
+
+    Rate limiting: 1 second delay between imports.
+
+    Args:
+        source: Source to discover from (hellofresh or kitchen_sanctuary)
+        request: Request with max_recipes parameter (default: 50)
+        current_user: Authenticated user (must be coordinator)
+        db: Database session
+
+    Returns:
+        BatchImportResult: Aggregate statistics and individual results
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(403): If user is not a coordinator
+        HTTPException(400): If discovery or import fails
+    """
+    require_coordinator(current_user)
+
+    max_recipes = request.max_recipes or 50
+    logger.info(f"Coordinator {current_user.id} discovering and importing from {source} (max: {max_recipes})")
+
+    try:
+        # Discover URLs
+        if source == "hellofresh":
+            crawler = HelloFreshCrawler()
+            urls = crawler.discover_recipe_urls()
+        else:  # kitchen_sanctuary
+            crawler = KitchenSanctuaryCrawler()
+            urls = crawler.discover_recipe_urls()
+
+        logger.info(f"Discovered {len(urls)} URLs from {source}")
+
+        # Limit to max_recipes
+        urls_to_import = urls[:max_recipes]
+        logger.info(f"Importing {len(urls_to_import)} recipes (limited by max_recipes={max_recipes})")
+
+        # Import batch
+        result = import_batch(urls_to_import, db, delay_seconds=1.0)
+
+        logger.info(
+            f"Discover-and-import complete for {source}: {result.imported} imported, "
+            f"{result.duplicates} duplicates, {result.errors} errors"
+        )
+        return result
+
+    except Exception as e:
+        logger.error(f"Discover-and-import failed for {source}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Discover-and-import failed: {str(e)}"
+        )
+
+
+@router.get("/status", response_model=StatusResponse, status_code=status.HTTP_200_OK)
+def get_import_status(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Get recipe import statistics by source type.
+
+    Returns the count of recipes grouped by source_type (e.g., hellofresh_web,
+    kitchen_sanctuary, url_import, manual).
+
+    Any authenticated user can view statistics.
+
+    Args:
+        current_user: Authenticated user (injected by get_current_user)
+        db: Database session
+
+    Returns:
+        StatusResponse: Recipe counts by source type
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+    """
+    logger.debug(f"User {current_user.id} requesting import status")
+
+    try:
+        # Query recipe counts grouped by source_type
+        stats_query = (
+            db.query(
+                Recipe.source_type,
+                func.count(Recipe.id).label('count')
+            )
+            .group_by(Recipe.source_type)
+            .all()
+        )
+
+        stats = [
+            SourceStats(source_type=source_type, count=count)
+            for source_type, count in stats_query
+        ]
+
+        return StatusResponse(stats=stats)
+
+    except Exception as e:
+        logger.error(f"Error retrieving import status: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to retrieve import status"
+        )

--- a/src/schemas/scraper.py
+++ b/src/schemas/scraper.py
@@ -76,12 +76,21 @@ class ScrapedRecipeData(BaseModel):
 
 class ImportUrlRequest(BaseModel):
     """Request schema for single URL import."""
-    url: str = Field(..., description="Recipe URL to import", min_length=1)
+    url: str = Field(..., description="Recipe URL to import", min_length=1, max_length=2048)
 
 
 class ImportBatchRequest(BaseModel):
     """Request schema for batch URL import."""
-    urls: list[str] = Field(..., description="List of recipe URLs to import", min_length=1, max_length=500)
+    urls: list[str] = Field(..., description="List of recipe URLs to import (each URL max 2048 chars)", min_length=1, max_length=500)
+
+    @field_validator('urls')
+    @classmethod
+    def validate_url_lengths(cls, v: list[str]) -> list[str]:
+        """Ensure each URL doesn't exceed maximum length."""
+        for url in v:
+            if len(url) > 2048:
+                raise ValueError("Each URL must not exceed 2048 characters")
+        return v
 
 
 class DiscoverAndImportRequest(BaseModel):

--- a/src/schemas/scraper.py
+++ b/src/schemas/scraper.py
@@ -72,3 +72,36 @@ class ScrapedRecipeData(BaseModel):
             v = v.strip()
             return v if v else None
         return None
+
+
+class ImportUrlRequest(BaseModel):
+    """Request schema for single URL import."""
+    url: str = Field(..., description="Recipe URL to import", min_length=1)
+
+
+class ImportBatchRequest(BaseModel):
+    """Request schema for batch URL import."""
+    urls: list[str] = Field(..., description="List of recipe URLs to import", min_length=1)
+
+
+class DiscoverAndImportRequest(BaseModel):
+    """Request schema for discover-and-import operation."""
+    max_recipes: Optional[int] = Field(default=50, description="Maximum number of recipes to import", ge=1)
+
+
+class DiscoveryResponse(BaseModel):
+    """Response schema for URL discovery."""
+    source: str = Field(..., description="Source name (hellofresh or kitchen_sanctuary)")
+    urls: list[str] = Field(..., description="Discovered recipe URLs")
+    count: int = Field(..., description="Number of URLs discovered")
+
+
+class SourceStats(BaseModel):
+    """Statistics for a single source type."""
+    source_type: str = Field(..., description="Source type identifier")
+    count: int = Field(..., description="Number of recipes from this source")
+
+
+class StatusResponse(BaseModel):
+    """Response schema for scraper status endpoint."""
+    stats: list[SourceStats] = Field(..., description="Recipe counts by source type")

--- a/src/schemas/scraper.py
+++ b/src/schemas/scraper.py
@@ -86,7 +86,7 @@ class ImportBatchRequest(BaseModel):
 
 class DiscoverAndImportRequest(BaseModel):
     """Request schema for discover-and-import operation."""
-    max_recipes: Optional[int] = Field(default=50, description="Maximum number of recipes to import", ge=1)
+    max_recipes: Optional[int] = Field(default=50, description="Maximum number of recipes to import", ge=1, le=1000)
 
 
 class DiscoveryResponse(BaseModel):

--- a/src/schemas/scraper.py
+++ b/src/schemas/scraper.py
@@ -81,7 +81,7 @@ class ImportUrlRequest(BaseModel):
 
 class ImportBatchRequest(BaseModel):
     """Request schema for batch URL import."""
-    urls: list[str] = Field(..., description="List of recipe URLs to import", min_length=1)
+    urls: list[str] = Field(..., description="List of recipe URLs to import", min_length=1, max_length=500)
 
 
 class DiscoverAndImportRequest(BaseModel):

--- a/tests/routers/test_scraper.py
+++ b/tests/routers/test_scraper.py
@@ -155,12 +155,12 @@ class TestImportUrl:
             recipe_id=recipe_id,
             warnings=[],
             error_message=None,
-            source_url="https://example.com/recipe"
+            source_url="https://www.hellofresh.com/recipes/test-recipe"
         )
 
         response = client.post(
             "/scraper/import-url",
-            json={"url": "https://example.com/recipe"},
+            json={"url": "https://www.hellofresh.com/recipes/test-recipe"},
             headers=member_headers
         )
 
@@ -179,12 +179,12 @@ class TestImportUrl:
             recipe_id=recipe_id,
             warnings=[],
             error_message=None,
-            source_url="https://example.com/recipe"
+            source_url="https://www.hellofresh.com/recipes/test-recipe"
         )
 
         response = client.post(
             "/scraper/import-url",
-            json={"url": "https://example.com/recipe"},
+            json={"url": "https://www.hellofresh.com/recipes/test-recipe"},
             headers=member_headers
         )
 
@@ -197,7 +197,7 @@ class TestImportUrl:
         """Import URL requires authentication."""
         response = client.post(
             "/scraper/import-url",
-            json={"url": "https://example.com/recipe"}
+            json={"url": "https://www.hellofresh.com/recipes/test-recipe"}
         )
 
         assert response.status_code == 401
@@ -219,7 +219,7 @@ class TestImportBatch:
 
         response = client.post(
             "/scraper/import-batch",
-            json={"urls": ["https://example.com/1", "https://example.com/2", "https://example.com/3"]},
+            json={"urls": ["https://www.hellofresh.com/recipes/1", "https://www.hellofresh.com/recipes/2", "https://www.hellofresh.com/recipes/3"]},
             headers=coordinator_headers
         )
 
@@ -234,7 +234,7 @@ class TestImportBatch:
         """Member cannot import batch URLs (coordinator only)."""
         response = client.post(
             "/scraper/import-batch",
-            json={"urls": ["https://example.com/1"]},
+            json={"urls": ["https://www.hellofresh.com/recipes/1"]},
             headers=member_headers
         )
 
@@ -245,7 +245,7 @@ class TestImportBatch:
         """Import batch requires authentication."""
         response = client.post(
             "/scraper/import-batch",
-            json={"urls": ["https://example.com/1"]}
+            json={"urls": ["https://www.hellofresh.com/recipes/1"]}
         )
 
         assert response.status_code == 401
@@ -316,6 +316,24 @@ class TestDiscover:
         )
 
         assert response.status_code == 422
+
+    @patch("src.routers.scraper.HelloFreshCrawler")
+    def test_discover_with_max_pages_parameter(self, mock_crawler_class, client, coordinator_headers):
+        """Max_pages parameter is passed to crawler."""
+        mock_crawler = MagicMock()
+        mock_crawler.discover_recipe_urls.return_value = [
+            "https://www.hellofresh.com/recipes/recipe-1"
+        ]
+        mock_crawler_class.return_value = mock_crawler
+
+        response = client.post(
+            "/scraper/discover/hellofresh?max_pages=5",
+            headers=coordinator_headers
+        )
+
+        assert response.status_code == 200
+        # Verify that max_pages was passed to the crawler
+        mock_crawler.discover_recipe_urls.assert_called_once_with(max_pages=5)
 
 
 class TestDiscoverAndImport:

--- a/tests/routers/test_scraper.py
+++ b/tests/routers/test_scraper.py
@@ -1,0 +1,423 @@
+"""
+Integration tests for scraper endpoints.
+
+Tests cover:
+- POST /scraper/import-url: single URL import (any authenticated user)
+- POST /scraper/import-batch: batch URL import (coordinator only)
+- POST /scraper/discover/{source}: URL discovery (coordinator only)
+- POST /scraper/discover-and-import/{source}: discover + import (coordinator only)
+- GET /scraper/status: import statistics (any authenticated user)
+- Authorization checks (coordinator vs member)
+- Error handling and validation
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from uuid import uuid4
+
+from src.db.database import Base, get_db
+from src.db import models
+from src.db.models.user import User, UserRole
+from src.db.models.recipe import Recipe, SourceType
+from src.services.auth_service import hash_password, create_access_token
+from src.schemas.import_service import ImportResult, ImportStatus, BatchImportResult
+
+from fastapi import FastAPI
+from src.routers import scraper as scraper_router
+
+# Create a test app without lifespan
+app = FastAPI(
+    title="FreshUp",
+    description="Privacy-first kitchen management system",
+    version="0.1.0",
+)
+
+# Register the scraper router
+app.include_router(scraper_router.router)
+
+# Create an in-memory SQLite database for testing
+TEST_DATABASE_URL = "sqlite:///:memory:"
+
+
+@pytest.fixture(autouse=True)
+def setup_test_env(monkeypatch):
+    """Set up test environment variables."""
+    from src.config import get_settings
+    get_settings.cache_clear()
+
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars")
+    monkeypatch.setenv("JWT_ALGORITHM", "HS256")
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    monkeypatch.setenv("ACCESS_TOKEN_EXPIRE_MINUTES", "43200")
+
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def db_session():
+    """Create a fresh database session for each test."""
+    from sqlalchemy.pool import StaticPool
+
+    # Import models to ensure all SQLAlchemy model classes are registered
+    _ = models
+
+    engine = create_engine(
+        TEST_DATABASE_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+@pytest.fixture
+def client(db_session):
+    """Create a test client with database dependency override."""
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def coordinator_user(db_session):
+    """Create a coordinator test user."""
+    user = User(
+        id=uuid4(),
+        email="coordinator@example.com",
+        hashed_password=hash_password("testpassword123"),
+        name="Coordinator User",
+        role=UserRole.coordinator.value,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def member_user(db_session):
+    """Create a member test user."""
+    user = User(
+        id=uuid4(),
+        email="member@example.com",
+        hashed_password=hash_password("testpassword123"),
+        name="Member User",
+        role=UserRole.member.value,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def coordinator_headers(coordinator_user):
+    """Generate authorization headers for coordinator user."""
+    access_token = create_access_token({"sub": str(coordinator_user.id)})
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+@pytest.fixture
+def member_headers(member_user):
+    """Generate authorization headers for member user."""
+    access_token = create_access_token({"sub": str(member_user.id)})
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+class TestImportUrl:
+    """Test POST /scraper/import-url endpoint."""
+
+    @patch("src.routers.scraper.import_recipe_from_url")
+    def test_import_url_success_as_member(self, mock_import, client, member_headers, db_session):
+        """Member can import a single URL successfully."""
+        recipe_id = uuid4()
+        mock_import.return_value = ImportResult(
+            status=ImportStatus.success,
+            recipe_id=recipe_id,
+            warnings=[],
+            error_message=None,
+            source_url="https://example.com/recipe"
+        )
+
+        response = client.post(
+            "/scraper/import-url",
+            json={"url": "https://example.com/recipe"},
+            headers=member_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+        assert data["recipe_id"] == str(recipe_id)
+        mock_import.assert_called_once()
+
+    @patch("src.routers.scraper.import_recipe_from_url")
+    def test_import_url_duplicate(self, mock_import, client, member_headers, db_session):
+        """Import returns duplicate status for existing recipe."""
+        recipe_id = uuid4()
+        mock_import.return_value = ImportResult(
+            status=ImportStatus.duplicate,
+            recipe_id=recipe_id,
+            warnings=[],
+            error_message=None,
+            source_url="https://example.com/recipe"
+        )
+
+        response = client.post(
+            "/scraper/import-url",
+            json={"url": "https://example.com/recipe"},
+            headers=member_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "duplicate"
+        assert data["recipe_id"] == str(recipe_id)
+
+    def test_import_url_requires_auth(self, client):
+        """Import URL requires authentication."""
+        response = client.post(
+            "/scraper/import-url",
+            json={"url": "https://example.com/recipe"}
+        )
+
+        assert response.status_code == 401
+
+
+class TestImportBatch:
+    """Test POST /scraper/import-batch endpoint."""
+
+    @patch("src.routers.scraper.import_batch")
+    def test_import_batch_success_as_coordinator(self, mock_batch, client, coordinator_headers, db_session):
+        """Coordinator can import batch URLs successfully."""
+        mock_batch.return_value = BatchImportResult(
+            total=3,
+            imported=2,
+            duplicates=1,
+            errors=0,
+            results=[]
+        )
+
+        response = client.post(
+            "/scraper/import-batch",
+            json={"urls": ["https://example.com/1", "https://example.com/2", "https://example.com/3"]},
+            headers=coordinator_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 3
+        assert data["imported"] == 2
+        assert data["duplicates"] == 1
+        assert data["errors"] == 0
+
+    def test_import_batch_forbidden_for_member(self, client, member_headers):
+        """Member cannot import batch URLs (coordinator only)."""
+        response = client.post(
+            "/scraper/import-batch",
+            json={"urls": ["https://example.com/1"]},
+            headers=member_headers
+        )
+
+        assert response.status_code == 403
+        assert "Coordinator role required" in response.json()["detail"]
+
+    def test_import_batch_requires_auth(self, client):
+        """Import batch requires authentication."""
+        response = client.post(
+            "/scraper/import-batch",
+            json={"urls": ["https://example.com/1"]}
+        )
+
+        assert response.status_code == 401
+
+
+class TestDiscover:
+    """Test POST /scraper/discover/{source} endpoint."""
+
+    @patch("src.routers.scraper.HelloFreshCrawler")
+    def test_discover_hellofresh_success(self, mock_crawler_class, client, coordinator_headers):
+        """Coordinator can discover HelloFresh URLs."""
+        mock_crawler = MagicMock()
+        mock_crawler.discover_recipe_urls.return_value = [
+            "https://www.hellofresh.com/recipes/recipe-1",
+            "https://www.hellofresh.com/recipes/recipe-2"
+        ]
+        mock_crawler_class.return_value = mock_crawler
+
+        response = client.post(
+            "/scraper/discover/hellofresh",
+            headers=coordinator_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["source"] == "hellofresh"
+        assert data["count"] == 2
+        assert len(data["urls"]) == 2
+
+    @patch("src.routers.scraper.KitchenSanctuaryCrawler")
+    def test_discover_kitchen_sanctuary_success(self, mock_crawler_class, client, coordinator_headers):
+        """Coordinator can discover Kitchen Sanctuary URLs."""
+        mock_crawler = MagicMock()
+        mock_crawler.discover_recipe_urls.return_value = [
+            "https://www.kitchensanctuary.com/recipe-1"
+        ]
+        mock_crawler_class.return_value = mock_crawler
+
+        response = client.post(
+            "/scraper/discover/kitchen_sanctuary",
+            headers=coordinator_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["source"] == "kitchen_sanctuary"
+        assert data["count"] == 1
+
+    def test_discover_forbidden_for_member(self, client, member_headers):
+        """Member cannot discover URLs (coordinator only)."""
+        response = client.post(
+            "/scraper/discover/hellofresh",
+            headers=member_headers
+        )
+
+        assert response.status_code == 403
+
+    def test_discover_requires_auth(self, client):
+        """Discover requires authentication."""
+        response = client.post("/scraper/discover/hellofresh")
+        assert response.status_code == 401
+
+    def test_discover_invalid_source(self, client, coordinator_headers):
+        """Invalid source returns 422."""
+        response = client.post(
+            "/scraper/discover/invalid_source",
+            headers=coordinator_headers
+        )
+
+        assert response.status_code == 422
+
+
+class TestDiscoverAndImport:
+    """Test POST /scraper/discover-and-import/{source} endpoint."""
+
+    @patch("src.routers.scraper.import_batch")
+    @patch("src.routers.scraper.HelloFreshCrawler")
+    def test_discover_and_import_success(self, mock_crawler_class, mock_batch, client, coordinator_headers, db_session):
+        """Coordinator can discover and import recipes."""
+        mock_crawler = MagicMock()
+        mock_crawler.discover_recipe_urls.return_value = [
+            f"https://www.hellofresh.com/recipes/recipe-{i}" for i in range(100)
+        ]
+        mock_crawler_class.return_value = mock_crawler
+
+        mock_batch.return_value = BatchImportResult(
+            total=50,
+            imported=45,
+            duplicates=3,
+            errors=2,
+            results=[]
+        )
+
+        response = client.post(
+            "/scraper/discover-and-import/hellofresh",
+            json={"max_recipes": 50},
+            headers=coordinator_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 50
+        assert data["imported"] == 45
+
+        # Verify that import_batch was called with limited URLs (50, not 100)
+        mock_batch.assert_called_once()
+        urls_arg = mock_batch.call_args[0][0]
+        assert len(urls_arg) == 50
+
+    def test_discover_and_import_forbidden_for_member(self, client, member_headers):
+        """Member cannot discover and import (coordinator only)."""
+        response = client.post(
+            "/scraper/discover-and-import/hellofresh",
+            headers=member_headers
+        )
+
+        assert response.status_code == 403
+
+    def test_discover_and_import_requires_auth(self, client):
+        """Discover-and-import requires authentication."""
+        response = client.post("/scraper/discover-and-import/hellofresh")
+        assert response.status_code == 401
+
+
+class TestStatus:
+    """Test GET /scraper/status endpoint."""
+
+    def test_status_success(self, client, member_headers, db_session):
+        """Any authenticated user can view import statistics."""
+        # Create some test recipes
+        recipe1 = Recipe(
+            id=uuid4(),
+            name="Recipe 1",
+            source_type=SourceType.hellofresh_web.value,
+            created_by=None,
+            base_servings=4
+        )
+        recipe2 = Recipe(
+            id=uuid4(),
+            name="Recipe 2",
+            source_type=SourceType.kitchen_sanctuary.value,
+            created_by=None,
+            base_servings=4
+        )
+        recipe3 = Recipe(
+            id=uuid4(),
+            name="Recipe 3",
+            source_type=SourceType.hellofresh_web.value,
+            created_by=None,
+            base_servings=4
+        )
+        db_session.add_all([recipe1, recipe2, recipe3])
+        db_session.commit()
+
+        response = client.get("/scraper/status", headers=member_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "stats" in data
+        stats = {item["source_type"]: item["count"] for item in data["stats"]}
+        assert stats[SourceType.hellofresh_web.value] == 2
+        assert stats[SourceType.kitchen_sanctuary.value] == 1
+
+    def test_status_empty_database(self, client, member_headers, db_session):
+        """Status returns empty stats when no recipes exist."""
+        response = client.get("/scraper/status", headers=member_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["stats"] == []
+
+    def test_status_requires_auth(self, client):
+        """Status requires authentication."""
+        response = client.get("/scraper/status")
+        assert response.status_code == 401

--- a/tests/routers/test_scraper.py
+++ b/tests/routers/test_scraper.py
@@ -202,6 +202,99 @@ class TestImportUrl:
 
         assert response.status_code == 401
 
+    def test_import_url_rejects_invalid_domain(self, client, member_headers):
+        """Import URL rejects URLs from unsupported domains."""
+        response = client.post(
+            "/scraper/import-url",
+            json={"url": "https://evil.com/recipes/test-recipe"},
+            headers=member_headers
+        )
+
+        assert response.status_code == 400
+        assert "supported domain" in response.json()["detail"].lower()
+
+    def test_import_url_rejects_subdomain_bypass_attempt(self, client, member_headers):
+        """Import URL rejects SSRF attempts via path-based domain spoofing."""
+        response = client.post(
+            "/scraper/import-url",
+            json={"url": "https://evil.com/hellofresh.com/recipes/test"},
+            headers=member_headers
+        )
+
+        assert response.status_code == 400
+        assert "supported domain" in response.json()["detail"].lower()
+
+    def test_import_url_rejects_subdomain_suffix_bypass_attempt(self, client, member_headers):
+        """Import URL rejects SSRF attempts via domain suffix spoofing."""
+        response = client.post(
+            "/scraper/import-url",
+            json={"url": "https://hellofresh.com.evil.com/recipes/test"},
+            headers=member_headers
+        )
+
+        assert response.status_code == 400
+        assert "supported domain" in response.json()["detail"].lower()
+
+    @patch("src.routers.scraper.import_recipe_from_url")
+    def test_import_url_accepts_valid_hellofresh_domain(self, mock_import, client, member_headers):
+        """Import URL accepts valid HelloFresh domain."""
+        recipe_id = uuid4()
+        mock_import.return_value = ImportResult(
+            status=ImportStatus.success,
+            recipe_id=recipe_id,
+            warnings=[],
+            error_message=None,
+            source_url="https://www.hellofresh.com/recipes/test"
+        )
+
+        response = client.post(
+            "/scraper/import-url",
+            json={"url": "https://www.hellofresh.com/recipes/test"},
+            headers=member_headers
+        )
+
+        assert response.status_code == 200
+
+    @patch("src.routers.scraper.import_recipe_from_url")
+    def test_import_url_accepts_valid_kitchen_sanctuary_domain(self, mock_import, client, member_headers):
+        """Import URL accepts valid Kitchen Sanctuary domain."""
+        recipe_id = uuid4()
+        mock_import.return_value = ImportResult(
+            status=ImportStatus.success,
+            recipe_id=recipe_id,
+            warnings=[],
+            error_message=None,
+            source_url="https://www.kitchensanctuary.com/recipe/test"
+        )
+
+        response = client.post(
+            "/scraper/import-url",
+            json={"url": "https://www.kitchensanctuary.com/recipe/test"},
+            headers=member_headers
+        )
+
+        assert response.status_code == 200
+
+    @patch("src.routers.scraper.import_recipe_from_url")
+    def test_import_url_accepts_subdomain(self, mock_import, client, member_headers):
+        """Import URL accepts legitimate subdomains of allowed domains."""
+        recipe_id = uuid4()
+        mock_import.return_value = ImportResult(
+            status=ImportStatus.success,
+            recipe_id=recipe_id,
+            warnings=[],
+            error_message=None,
+            source_url="https://recipes.hellofresh.com/test"
+        )
+
+        response = client.post(
+            "/scraper/import-url",
+            json={"url": "https://recipes.hellofresh.com/test"},
+            headers=member_headers
+        )
+
+        assert response.status_code == 200
+
 
 class TestImportBatch:
     """Test POST /scraper/import-batch endpoint."""
@@ -249,6 +342,56 @@ class TestImportBatch:
         )
 
         assert response.status_code == 401
+
+    def test_import_batch_rejects_invalid_domain(self, client, coordinator_headers):
+        """Batch import rejects URLs from unsupported domains."""
+        response = client.post(
+            "/scraper/import-batch",
+            json={"urls": [
+                "https://www.hellofresh.com/recipes/1",
+                "https://evil.com/recipes/2"
+            ]},
+            headers=coordinator_headers
+        )
+
+        assert response.status_code == 400
+        assert "supported domain" in response.json()["detail"].lower()
+
+    def test_import_batch_rejects_ssrf_bypass_attempts(self, client, coordinator_headers):
+        """Batch import rejects SSRF attempts."""
+        response = client.post(
+            "/scraper/import-batch",
+            json={"urls": [
+                "https://evil.com/hellofresh.com/recipe",
+                "https://hellofresh.com.evil.com/recipe"
+            ]},
+            headers=coordinator_headers
+        )
+
+        assert response.status_code == 400
+        assert "supported domain" in response.json()["detail"].lower()
+
+    @patch("src.routers.scraper.import_batch")
+    def test_import_batch_accepts_valid_domains(self, mock_batch, client, coordinator_headers):
+        """Batch import accepts all valid domains."""
+        mock_batch.return_value = BatchImportResult(
+            total=2,
+            imported=2,
+            duplicates=0,
+            errors=0,
+            results=[]
+        )
+
+        response = client.post(
+            "/scraper/import-batch",
+            json={"urls": [
+                "https://www.hellofresh.com/recipes/1",
+                "https://www.kitchensanctuary.com/recipe/2"
+            ]},
+            headers=coordinator_headers
+        )
+
+        assert response.status_code == 200
 
 
 class TestDiscover:


### PR DESCRIPTION
## Work in Progress

Closes #308

[2C] Scraper API endpoints & CLI

## Summary

<!-- sharkrite-changes-summary -->
## Changes

**7** files, **2** commits (+4 added, ~3 modified, -0 deleted)
- `A` src/cli/__init__.py
- `A` src/cli/import_recipes.py
- `M` src/main.py
- `M` src/routers/__init__.py
- `A` src/routers/scraper.py
- `M` src/schemas/scraper.py
- `A` tests/routers/test_scraper.py

### Commits
- b31b97c feat: [2C] Scraper API endpoints & CLI
- aee6fc4 chore: initialize work on #308 [2C] Scraper API endpoints & CLI
<!-- /sharkrite-changes-summary -->

REST API endpoints in `src/routers/scraper.py` and a CLI script for bulk imports. Single-URL import for any authenticated user, batch/discovery operations coordinator-only.

**Priority:** P1 | **Estimate:** 1.5–2 hours | **Depends on:** #305 (HF Crawler), #306 (KS Crawler), #307 (Import Pipeline)

## Implementation

### API Endpoints (`src/routers/scraper.py`)
- `POST /scraper/import-url` — single URL import. Any authenticated user.
- `POST /scraper/import-batch` — multiple URLs. Coordinator only.
- `POST /scraper/discover/{source}` — discover URLs for hellofresh/kitchen_sanctuary. Coordinator only. Returns URLs without importing.
- `POST /scraper/discover-and-import/{source}` — discover + import. `{max_recipes: 50}`. Coordinator only.
- `GET /scraper/status` — import stats per source (count by source_type). Any authenticated user.

Register router in `main.py`.

### CLI (`src/cli/import_recipes.py`)
```bash
python -m src.cli.import_recipes --source hellofresh --max 50
python -m src.cli.import_recipes --source kitchen_sanctuary --max 50
python -m src.cli.import_recipes --url "https://www.hellofresh.com/recipes/some-recipe"
```

## Acceptance Criteria

- [ ] Single URL import works via API
- [ ] Batch ops require coordinator role
- [ ] Discovery returns URLs without importing
- [ ] discover-and-import respects max_recipes parameter
- [ ] Status endpoint shows counts per source_type
- [ ] CLI works for both bulk (--source) and single (--url) modes
- [ ] Rate limiting applied in batch operations
- [ ] Follows existing router patterns (auth decorators, error handling, response schemas)
- [ ] Router registered in main.py

## DO NOT Scope

- Frontend management UI
- Scheduled/cron scraping
- Image downloading
- Partial re-import/versioning

---
_Draft PR created automatically by rite for tracking purposes._

---

## Follow-up Issues
Created: #343 
**From assessment on 2026-03-26T08:06:50Z:**
- Created: #340 #341 
- Updated: none