### PR TITLE
No Logging

### DIFF
--- a/deploy/checks/containers.sh
+++ b/deploy/checks/containers.sh
@@ -23,10 +23,16 @@ check_containers() {
         if docker ps -a --format '{{.Names}}' | grep -q "^${container}$"; then
             alert "Container $container is stopped — restarting"
             docker start "$container" >> "$LOGFILE" 2>&1
+            if [ $? -ne 0 ]; then
+                alert "Failed to start $container — check $LOGFILE"
+            fi
         else
             # Container doesn't exist at all — bring up the whole stack
             alert "Container $container not found — bringing up stack"
             docker compose -f "$REPO_DIR/docker-compose.yml" up -d >> "$LOGFILE" 2>&1
+            if [ $? -ne 0 ]; then
+                alert "Failed to bring up stack — check $LOGFILE"
+            fi
             return  # up -d handles all containers, no need to continue the loop
         fi
     done

--- a/deploy/checks/freshup.sh
+++ b/deploy/checks/freshup.sh
@@ -19,6 +19,7 @@ check_freshup() {
     git pull origin main >> "$LOGFILE" 2>&1
     if [ $? -ne 0 ]; then
         alert "Git pull failed — check $LOGFILE"
+        return 1
     fi
 
     local CHANGED

--- a/deploy/checks/freshup.sh
+++ b/deploy/checks/freshup.sh
@@ -17,6 +17,9 @@ check_freshup() {
 
     log "FRESHUP UPDATE: ${LOCAL:0:7} -> ${REMOTE:0:7}"
     git pull origin main >> "$LOGFILE" 2>&1
+    if [ $? -ne 0 ]; then
+        alert "Git pull failed — check $LOGFILE"
+    fi
 
     local CHANGED
     CHANGED=$(git diff --name-only "$LOCAL" "$REMOTE")
@@ -32,14 +35,23 @@ check_freshup() {
     if [ "$NEEDS_BUILD" = true ]; then
         log "FRESHUP REBUILD: infrastructure files changed"
         docker compose -f "$REPO_DIR/docker-compose.yml" up -d --build >> "$LOGFILE" 2>&1
+        if [ $? -ne 0 ]; then
+            alert "Docker rebuild failed — check $LOGFILE"
+        fi
     else
         if [ "$NEEDS_RESTART" = true ]; then
             log "FRESHUP RESTART: source files changed"
             docker compose -f "$REPO_DIR/docker-compose.yml" restart api >> "$LOGFILE" 2>&1
+            if [ $? -ne 0 ]; then
+                alert "API restart failed — check $LOGFILE"
+            fi
         fi
         if [ "$NEEDS_FRONTEND_RESTART" = true ]; then
             log "FRESHUP RESTART FRONTEND: frontend files changed"
             docker compose -f "$REPO_DIR/docker-compose.yml" restart frontend >> "$LOGFILE" 2>&1
+            if [ $? -ne 0 ]; then
+                alert "Frontend restart failed — check $LOGFILE"
+            fi
         fi
         if [ "$NEEDS_RESTART" = false ] && [ "$NEEDS_FRONTEND_RESTART" = false ]; then
             log "FRESHUP PULL ONLY: no deploy-relevant files changed"


### PR DESCRIPTION
## Work in Progress

Closes #317

No Logging

<!-- sharkrite-source-issue:293 -->## From PR #312 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
This is a valid operational concern—silent restart failures could lead to debugging headaches on the homelab. However, it's an enhancement to existing deployment script patterns, not core to the LAN access feature being implemented.

## Context
The original issue scope is specifically about adding frontend restart capability, not improving error handling across all existing restart commands. The current pattern (redirect to logfile) matches existing code for the API restart.

## Defer Reason
Scope exceeds time budget — improving error handling across deployment scripts should be a separate focused PR that addresses the pattern holistically rather than just for this one addition.

---
_Created by Sharkrite assessment on 2026-03-25T07:01:38Z_
_Parent PR: #312_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+0 added, ~2 modified, -0 deleted)
- `M` deploy/checks/containers.sh
- `M` deploy/checks/freshup.sh

### Commits
- 4afb171 feat: No Logging
- 600c2d2 chore: initialize work on #317 No Logging
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues
 Updated: #346 
**From assessment on 2026-03-26T09:15:40Z:**
- Created: #346 
- Updated: none