### PR TITLE
No Rate Limiting or Abuse Prevention

### DIFF
--- a/src/routers/scraper.py
+++ b/src/routers/scraper.py
@@ -108,8 +108,8 @@ def require_coordinator(user: User) -> None:
 @router.post("/import-url", response_model=ImportResult, status_code=status.HTTP_200_OK)
 @limiter.limit("20/minute")
 def import_single_url(
-    request: ImportUrlRequest,
-    fastapi_request: Request,
+    payload: ImportUrlRequest,
+    request: Request,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -122,8 +122,8 @@ def import_single_url(
     Rate limited to 20 requests per minute per IP address to prevent abuse.
 
     Args:
-        request: Request containing the URL to import
-        fastapi_request: FastAPI request object (for rate limiting)
+        payload: Request body containing the URL to import
+        request: FastAPI request object (required by slowapi for rate limiting)
         current_user: Authenticated user (injected by get_current_user)
         db: Database session
 
@@ -139,15 +139,15 @@ def import_single_url(
 
     # Validate URL is from a supported domain
     allowed_domains = ["hellofresh.com", "kitchensanctuary.com"]
-    if not validate_domain(request.url, allowed_domains):
-        logger.warning(f"User {current_user.id} attempted to import from unsupported domain: {request.url}")
+    if not validate_domain(payload.url, allowed_domains):
+        logger.warning(f"User {current_user.id} attempted to import from unsupported domain: {payload.url}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"URL must be from a supported domain: {', '.join(allowed_domains)}"
         )
 
     try:
-        result = import_recipe_from_url(request.url, db)
+        result = import_recipe_from_url(payload.url, db)
         return result
     except Exception as e:
         logger.error(f"Unexpected error during import for user {current_user.id}: {e}")
@@ -160,8 +160,8 @@ def import_single_url(
 @router.post("/import-batch", response_model=BatchImportResult, status_code=status.HTTP_200_OK)
 @limiter.limit("5/minute")
 def import_batch_urls(
-    request: ImportBatchRequest,
-    fastapi_request: Request,
+    payload: ImportBatchRequest,
+    request: Request,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -174,8 +174,8 @@ def import_batch_urls(
     Rate limited to 5 requests per minute per IP address to prevent abuse.
 
     Args:
-        request: Request containing list of URLs to import
-        fastapi_request: FastAPI request object (for rate limiting)
+        payload: Request body containing list of URLs to import
+        request: FastAPI request object (required by slowapi for rate limiting)
         current_user: Authenticated user (must be coordinator)
         db: Database session
 
@@ -189,11 +189,11 @@ def import_batch_urls(
     """
     require_coordinator(current_user)
 
-    logger.info(f"Coordinator {current_user.id} importing batch of {len(request.urls)} URLs")
+    logger.info(f"Coordinator {current_user.id} importing batch of {len(payload.urls)} URLs")
 
     # Validate all URLs are from supported domains
     allowed_domains = ["hellofresh.com", "kitchensanctuary.com"]
-    invalid_urls = [url for url in request.urls if not validate_domain(url, allowed_domains)]
+    invalid_urls = [url for url in payload.urls if not validate_domain(url, allowed_domains)]
     if invalid_urls:
         logger.warning(f"Coordinator {current_user.id} attempted batch import with {len(invalid_urls)} invalid URLs")
         raise HTTPException(
@@ -202,7 +202,7 @@ def import_batch_urls(
         )
 
     try:
-        result = import_batch(request.urls, db, delay_seconds=1.0)
+        result = import_batch(payload.urls, db, delay_seconds=1.0)
         logger.info(
             f"Batch import complete: {result.imported} imported, "
             f"{result.duplicates} duplicates, {result.errors} errors"
@@ -220,7 +220,7 @@ def import_batch_urls(
 @limiter.limit("5/minute")
 def discover_urls(
     source: Literal["hellofresh", "kitchen_sanctuary"],
-    fastapi_request: Request,
+    request: Request,
     max_pages: int | None = Query(default=None, description="Maximum number of pages to crawl (for testing)", ge=1),
     current_user: User = Depends(get_current_user),
 ):
@@ -234,7 +234,7 @@ def discover_urls(
 
     Args:
         source: Source to discover from (hellofresh or kitchen_sanctuary)
-        fastapi_request: FastAPI request object (for rate limiting)
+        request: FastAPI request object (required by slowapi for rate limiting)
         max_pages: Optional maximum number of pages to crawl (for testing/limiting scope)
         current_user: Authenticated user (must be coordinator)
 
@@ -274,8 +274,8 @@ def discover_urls(
 @limiter.limit("3/minute")
 def discover_and_import(
     source: Literal["hellofresh", "kitchen_sanctuary"],
-    fastapi_request: Request,
-    request: DiscoverAndImportRequest = DiscoverAndImportRequest(),
+    request: Request,
+    payload: DiscoverAndImportRequest = DiscoverAndImportRequest(),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -291,8 +291,8 @@ def discover_and_import(
 
     Args:
         source: Source to discover from (hellofresh or kitchen_sanctuary)
-        fastapi_request: FastAPI request object (for rate limiting)
-        request: Request with max_recipes parameter (default: 50)
+        request: FastAPI request object (required by slowapi for rate limiting)
+        payload: Request body with max_recipes parameter (default: 50)
         current_user: Authenticated user (must be coordinator)
         db: Database session
 
@@ -307,7 +307,7 @@ def discover_and_import(
     """
     require_coordinator(current_user)
 
-    max_recipes = request.max_recipes or 50
+    max_recipes = payload.max_recipes or 50
     logger.info(f"Coordinator {current_user.id} discovering and importing from {source} (max: {max_recipes})")
 
     try:

--- a/src/routers/scraper.py
+++ b/src/routers/scraper.py
@@ -9,12 +9,22 @@ Authorization:
 - Batch operations: Coordinator only
 - Discovery operations: Coordinator only
 - Status: Any authenticated user
+
+Rate Limiting (API layer - abuse prevention):
+- /import-url: 20 requests/minute per IP
+- /import-batch: 5 requests/minute per IP
+- /discover/{source}: 5 requests/minute per IP
+- /discover-and-import/{source}: 3 requests/minute per IP
+- /status: No rate limiting (read-only, cheap query)
+
+Note: Service layer has separate polite delays (1 second between external requests)
+for crawler etiquette, not abuse prevention.
 """
 
 import logging
 from typing import Literal
 from urllib.parse import urlparse
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from sqlalchemy.orm import Session
 from sqlalchemy import func
 
@@ -22,6 +32,7 @@ from src.db.database import get_db
 from src.db.models.user import User, UserRole
 from src.db.models.recipe import Recipe
 from src.middleware.auth import get_current_user
+from src.middleware.rate_limit import limiter
 from src.services.import_service import import_recipe_from_url, import_batch
 from src.services.crawlers.hellofresh_crawler import HelloFreshCrawler
 from src.services.crawlers.kitchen_sanctuary_crawler import KitchenSanctuaryCrawler
@@ -95,8 +106,10 @@ def require_coordinator(user: User) -> None:
 
 
 @router.post("/import-url", response_model=ImportResult, status_code=status.HTTP_200_OK)
+@limiter.limit("20/minute")
 def import_single_url(
     request: ImportUrlRequest,
+    fastapi_request: Request,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -106,8 +119,11 @@ def import_single_url(
     Any authenticated user can import recipes. The recipe becomes globally
     readable (system-imported, created_by=None).
 
+    Rate limited to 20 requests per minute per IP address to prevent abuse.
+
     Args:
         request: Request containing the URL to import
+        fastapi_request: FastAPI request object (for rate limiting)
         current_user: Authenticated user (injected by get_current_user)
         db: Database session
 
@@ -117,6 +133,7 @@ def import_single_url(
     Raises:
         HTTPException(401): If Authorization header is missing or token is invalid
         HTTPException(400): If URL is invalid or import fails
+        HTTPException(429): If rate limit is exceeded
     """
     logger.info(f"User {current_user.id} importing recipe from URL")
 
@@ -141,8 +158,10 @@ def import_single_url(
 
 
 @router.post("/import-batch", response_model=BatchImportResult, status_code=status.HTTP_200_OK)
+@limiter.limit("5/minute")
 def import_batch_urls(
     request: ImportBatchRequest,
+    fastapi_request: Request,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -152,8 +171,11 @@ def import_batch_urls(
     Coordinator-only endpoint. Processes URLs sequentially with rate limiting
     (1 second delay between requests by default).
 
+    Rate limited to 5 requests per minute per IP address to prevent abuse.
+
     Args:
         request: Request containing list of URLs to import
+        fastapi_request: FastAPI request object (for rate limiting)
         current_user: Authenticated user (must be coordinator)
         db: Database session
 
@@ -163,6 +185,7 @@ def import_batch_urls(
     Raises:
         HTTPException(401): If Authorization header is missing or token is invalid
         HTTPException(403): If user is not a coordinator
+        HTTPException(429): If rate limit is exceeded
     """
     require_coordinator(current_user)
 
@@ -194,8 +217,10 @@ def import_batch_urls(
 
 
 @router.post("/discover/{source}", response_model=DiscoveryResponse, status_code=status.HTTP_200_OK)
+@limiter.limit("5/minute")
 def discover_urls(
     source: Literal["hellofresh", "kitchen_sanctuary"],
+    fastapi_request: Request,
     max_pages: int | None = Query(default=None, description="Maximum number of pages to crawl (for testing)", ge=1),
     current_user: User = Depends(get_current_user),
 ):
@@ -205,8 +230,11 @@ def discover_urls(
     Coordinator-only endpoint. Uses crawlers to discover URLs from sitemap.xml
     or paginated category pages. URLs are returned but NOT imported.
 
+    Rate limited to 5 requests per minute per IP address to prevent abuse.
+
     Args:
         source: Source to discover from (hellofresh or kitchen_sanctuary)
+        fastapi_request: FastAPI request object (for rate limiting)
         max_pages: Optional maximum number of pages to crawl (for testing/limiting scope)
         current_user: Authenticated user (must be coordinator)
 
@@ -217,6 +245,7 @@ def discover_urls(
         HTTPException(401): If Authorization header is missing or token is invalid
         HTTPException(403): If user is not a coordinator
         HTTPException(400): If discovery fails
+        HTTPException(429): If rate limit is exceeded
     """
     require_coordinator(current_user)
 
@@ -242,8 +271,10 @@ def discover_urls(
 
 
 @router.post("/discover-and-import/{source}", response_model=BatchImportResult, status_code=status.HTTP_200_OK)
+@limiter.limit("3/minute")
 def discover_and_import(
     source: Literal["hellofresh", "kitchen_sanctuary"],
+    fastapi_request: Request,
     request: DiscoverAndImportRequest = DiscoverAndImportRequest(),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
@@ -254,10 +285,13 @@ def discover_and_import(
     Combines URL discovery with batch import. Limits the number of imported
     recipes using the max_recipes parameter (default: 50).
 
-    Rate limiting: 1 second delay between imports.
+    Rate limiting:
+    - API layer: 3 requests per minute per IP address to prevent abuse
+    - Service layer: 1 second delay between imports (polite crawling)
 
     Args:
         source: Source to discover from (hellofresh or kitchen_sanctuary)
+        fastapi_request: FastAPI request object (for rate limiting)
         request: Request with max_recipes parameter (default: 50)
         current_user: Authenticated user (must be coordinator)
         db: Database session
@@ -269,6 +303,7 @@ def discover_and_import(
         HTTPException(401): If Authorization header is missing or token is invalid
         HTTPException(403): If user is not a coordinator
         HTTPException(400): If discovery or import fails
+        HTTPException(429): If rate limit is exceeded
     """
     require_coordinator(current_user)
 

--- a/tests/routers/test_scraper.py
+++ b/tests/routers/test_scraper.py
@@ -9,6 +9,9 @@ Tests cover:
 - GET /scraper/status: import statistics (any authenticated user)
 - Authorization checks (coordinator vs member)
 - Error handling and validation
+- Rate limiting (API layer abuse prevention)
+
+Note: Rate limiter is reset before each test to prevent cross-test interference.
 """
 
 import pytest
@@ -35,6 +38,14 @@ app = FastAPI(
     version="0.1.0",
 )
 
+# Register rate limiting for the test app
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from src.middleware.rate_limit import limiter
+
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
 # Register the scraper router
 app.include_router(scraper_router.router)
 
@@ -44,7 +55,7 @@ TEST_DATABASE_URL = "sqlite:///:memory:"
 
 @pytest.fixture(autouse=True)
 def setup_test_env(monkeypatch):
-    """Set up test environment variables."""
+    """Set up test environment variables and reset rate limiter."""
     from src.config import get_settings
     get_settings.cache_clear()
 
@@ -55,6 +66,9 @@ def setup_test_env(monkeypatch):
     monkeypatch.setenv("ACCESS_TOKEN_EXPIRE_MINUTES", "43200")
 
     get_settings.cache_clear()
+
+    # Reset rate limiter state before each test to prevent cross-test interference
+    limiter.reset()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Work in Progress

Closes #318

No Rate Limiting or Abuse Prevention

<!-- sharkrite-source-issue:303 -->## From PR #310 Assessment

**Severity:** MEDIUM
**Category:** ScopeCreep

## Issue
Rate limiting is a real concern for any service handling external requests, but the original issue explicitly states "This is a parsing wrapper only" and excludes API endpoints. Rate limiting belongs at the API layer, not the service layer.

## Context
The issue scope is a thin wrapper for parsing. Rate limiting is an API/infrastructure concern that should be implemented when this service is exposed through endpoints (a separate issue).

## Defer Reason
Needs separate focused PR

---
_Created by Sharkrite assessment on 2026-03-25T07:10:30Z_
_Parent PR: #310_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**17** files, **2** commits (+0 added, ~17 modified, -0 deleted)
- `M` frontend/src/App.test.tsx
- `M` frontend/src/components/recipe/IngredientsTab.tsx
- `M` frontend/src/components/recipe/__tests__/IngredientsTab.test.tsx
- `M` requirements.txt
- `M` src/routers/scraper.py
- `M` src/services/crawlers/base_crawler.py
- `M` src/services/crawlers/hellofresh_crawler.py
- `M` src/services/crawlers/kitchen_sanctuary_crawler.py
- `M` src/services/import_service.py
- `M` src/services/ingredient_parser.py
- `M` src/services/scraper_service.py
- `M` tests/routers/test_scraper.py
- `M` tests/services/crawlers/test_hellofresh_crawler.py
- `M` tests/services/crawlers/test_kitchen_sanctuary_crawler.py
- `M` tests/services/test_import_service.py
- `M` tests/services/test_ingredient_parser.py
- `M` tests/services/test_scraper_service.py

### Commits
- d4966fc wip: auto-commit relevant changes for issue #318 (2026-03-26)
- 2e23de4 chore: initialize work on #318 No Rate Limiting or Abuse Prevention
<!-- /sharkrite-changes-summary -->