### PR TITLE
Silent Failure When robots.txt Cannot Be Fetched

### DIFF
--- a/src/services/crawlers/base_crawler.py
+++ b/src/services/crawlers/base_crawler.py
@@ -163,9 +163,12 @@ class RobotsTxtParser:
             parser.read()
             logger.info(f"Successfully fetched robots.txt from {robots_url}")
         except Exception as e:
-            # If robots.txt fetch fails, assume crawling is allowed
+            # If robots.txt fetch fails, initialize parser with empty rules
+            # to allow all crawling (consistent with "fail-open" policy)
             logger.warning(f"Failed to fetch robots.txt from {robots_url}: {e}")
             logger.info(f"Assuming crawling is allowed for {domain}")
+            # Parse empty robots.txt (allows all URLs, no crawl delay)
+            parser.parse([])
 
         self._parsers[domain] = parser
 

--- a/src/services/crawlers/base_crawler.py
+++ b/src/services/crawlers/base_crawler.py
@@ -165,7 +165,7 @@ class RobotsTxtParser:
         except Exception as e:
             # If robots.txt fetch fails, initialize parser with empty rules
             # to allow all crawling (consistent with "fail-open" policy)
-            logger.warning(f"Failed to fetch robots.txt from {robots_url}: {e}")
+            logger.warning(f"Failed to fetch robots.txt from {robots_url}: {type(e).__name__}: {e}")
             logger.info(f"Assuming crawling is allowed for {domain}")
             # Parse empty robots.txt (allows all URLs, no crawl delay)
             parser.parse([])

--- a/tests/services/crawlers/test_hellofresh_crawler.py
+++ b/tests/services/crawlers/test_hellofresh_crawler.py
@@ -279,3 +279,79 @@ class TestBaseCrawlerUtilities:
             # Second call to same domain should use cache
             parser.can_fetch("https://example.com/page2")
             assert mock_fetch.call_count == 1  # Still 1, not 2
+
+    def test_robots_txt_fetch_failure_allows_crawling(self):
+        """Test that fetch failure results in a parser that allows all crawling."""
+        from src.services.crawlers.base_crawler import RobotsTxtParser
+        from urllib.robotparser import RobotFileParser
+
+        parser = RobotsTxtParser()
+
+        # Mock RobotFileParser.read() to raise an exception (simulating fetch failure)
+        with patch.object(RobotFileParser, 'read', side_effect=Exception("Network error")):
+            # This should not raise an exception
+            can_fetch_result = parser.can_fetch("https://example.com/page")
+
+            # Should allow crawling (fail-open policy)
+            assert can_fetch_result is True
+
+            # Verify parser was cached
+            assert "example.com" in parser._parsers
+
+    def test_robots_txt_fetch_failure_returns_no_crawl_delay(self):
+        """Test that fetch failure results in no crawl delay."""
+        from src.services.crawlers.base_crawler import RobotsTxtParser
+        from urllib.robotparser import RobotFileParser
+
+        parser = RobotsTxtParser()
+
+        # Mock RobotFileParser.read() to raise an exception
+        with patch.object(RobotFileParser, 'read', side_effect=Exception("Network error")):
+            crawl_delay = parser.get_crawl_delay("https://example.com/page")
+
+            # Should return None (no crawl delay)
+            assert crawl_delay is None
+
+    def test_robots_txt_fetch_failure_caches_parser(self):
+        """Test that failed fetch still caches the parser to avoid repeated failures."""
+        from src.services.crawlers.base_crawler import RobotsTxtParser
+        from urllib.robotparser import RobotFileParser
+
+        parser = RobotsTxtParser()
+
+        # Mock RobotFileParser.read() to raise an exception
+        with patch.object(RobotFileParser, 'read', side_effect=Exception("Network error")) as mock_read:
+            # First call - should attempt fetch
+            parser.can_fetch("https://example.com/page1")
+            assert mock_read.call_count == 1
+
+            # Second call - should use cached parser (no additional fetch)
+            parser.can_fetch("https://example.com/page2")
+            assert mock_read.call_count == 1  # Still 1, not 2
+
+            # Verify consistent behavior on both calls
+            assert parser.can_fetch("https://example.com/page3") is True
+
+    def test_robots_txt_fetch_failure_consistent_behavior(self):
+        """Test that parser behavior is consistent after fetch failure."""
+        from src.services.crawlers.base_crawler import RobotsTxtParser
+        from urllib.robotparser import RobotFileParser
+
+        parser = RobotsTxtParser()
+
+        # Mock RobotFileParser.read() to raise an exception
+        with patch.object(RobotFileParser, 'read', side_effect=Exception("Timeout")):
+            # Multiple calls should return consistent results
+            url1 = "https://example.com/page1"
+            url2 = "https://example.com/admin"
+            url3 = "https://example.com/api/private"
+
+            # All should be allowed (fail-open policy)
+            assert parser.can_fetch(url1) is True
+            assert parser.can_fetch(url2) is True
+            assert parser.can_fetch(url3) is True
+
+            # All crawl delays should be None
+            assert parser.get_crawl_delay(url1) is None
+            assert parser.get_crawl_delay(url2) is None
+            assert parser.get_crawl_delay(url3) is None


### PR DESCRIPTION
## Work in Progress

Closes #326

Silent Failure When robots.txt Cannot Be Fetched

<!-- sharkrite-source-issue:305 -->## From PR #322 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
This is a real, verifiable bug risk — caching an uninitialized `RobotFileParser` after a fetch failure could cause inconsistent behavior in `can_fetch()` and `crawl_delay()` calls. However, this is an edge case affecting error handling robustness, not blocking the core feature.

## Context


## Defer Reason
Edge case in error handling path; core functionality works correctly when robots.txt is accessible

---
_Created by Sharkrite assessment on 2026-03-25T07:47:08Z_
_Parent PR: #322_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+0 added, ~2 modified, -0 deleted)
- `M` src/services/crawlers/base_crawler.py
- `M` tests/services/crawlers/test_hellofresh_crawler.py

### Commits
- 625c48d feat: Silent Failure When robots.txt Cannot Be Fetched
- 2b506aa chore: initialize work on #326 Silent Failure When robots.txt Cannot Be Fetched
<!-- /sharkrite-changes-summary -->