### PR TITLE
XML Parsing Vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ pytest==8.3.4
 httpx==0.28.1
 recipe-scrapers==15.4.0
 requests==2.32.3
+defusedxml==0.7.1

--- a/src/services/crawlers/hellofresh_crawler.py
+++ b/src/services/crawlers/hellofresh_crawler.py
@@ -6,7 +6,7 @@ category crawl fallback. Includes rate limiting and robots.txt compliance.
 """
 
 import logging
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET  # Use defusedxml for defense-in-depth XXE protection
 from typing import Optional
 from urllib.parse import urljoin, urlparse
 

--- a/src/services/crawlers/kitchen_sanctuary_crawler.py
+++ b/src/services/crawlers/kitchen_sanctuary_crawler.py
@@ -6,7 +6,7 @@ Includes rate limiting and robots.txt compliance.
 """
 
 import logging
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET  # Use defusedxml for defense-in-depth XXE protection
 from typing import Optional
 from urllib.parse import urljoin, urlparse
 

--- a/tests/services/crawlers/test_hellofresh_crawler.py
+++ b/tests/services/crawlers/test_hellofresh_crawler.py
@@ -160,7 +160,7 @@ class TestHelloFreshCrawlerUnit:
             assert "?" not in url, "Query params should be stripped"
             assert "#" not in url, "Fragments should be stripped"
 
-    @patch('src.services.crawlers.hellofresh_crawler.ET.fromstring')
+    @patch('defusedxml.ElementTree.fromstring')
     @patch('src.services.crawlers.hellofresh_crawler.HelloFreshCrawler._configure_from_robots_txt')
     def test_discover_from_sitemap_success(self, mock_robots_config, mock_fromstring):
         """Test successful sitemap parsing."""

--- a/tests/services/crawlers/test_kitchen_sanctuary_crawler.py
+++ b/tests/services/crawlers/test_kitchen_sanctuary_crawler.py
@@ -190,7 +190,7 @@ class TestKitchenSanctuaryCrawlerUnit:
         for url in invalid_urls:
             assert not crawler._is_recipe_url(url), f"Should reject non-recipe URL: {url}"
 
-    @patch('src.services.crawlers.kitchen_sanctuary_crawler.ET.fromstring')
+    @patch('defusedxml.ElementTree.fromstring')
     @patch('src.services.crawlers.kitchen_sanctuary_crawler.KitchenSanctuaryCrawler._configure_from_robots_txt')
     def test_extract_recipe_urls_from_sitemap(self, mock_robots_config, mock_fromstring):
         """Test recipe URL extraction from sitemap with filtering."""


### PR DESCRIPTION
## Work in Progress

Closes #331

XML Parsing Vulnerability

<!-- sharkrite-source-issue:306 -->## From PR #327 Assessment

**Severity:** MEDIUM
**Category:** Security

## Issue
While Python's ElementTree has built-in protections against the most dangerous XXE attacks, using `defusedxml` for untrusted external content is a security best practice. However, this requires adding a new dependency and should be applied consistently across all crawlers.

## Context
The original issue scope focuses on functionality (discover URLs, filter to recipes, reuse base_crawler). Adding a security dependency is valid but affects the broader crawler infrastructure and warrants a separate, focused change.

## Defer Reason
Needs separate focused PR to add dependency and apply consistently across all crawlers

---
_Created by Sharkrite assessment on 2026-03-25T08:00:09Z_
_Parent PR: #327_

---

## Additional Assessment (PR #327)

**Severity:** MEDIUM
**Reasoning:** This is the same finding as the prior "XML Parsing Vulnerability - External Entity Expansion" decision, which was already classified as ACTIONABLE_LATER. The file changed since classification, but examining the review shows the code still uses `ET.fromstring()` without `defusedxml`. The prior reasoning remains valid: Python 3.x has built-in protections, but using `defusedxml` is a security best practice that requires adding a new dependency and should be applied consistently across all crawlers.
**Context:** Defense-in-depth security improvement that exceeds the scope of implementing a single crawler. Should be applied uniformly across HelloFresh and Kitchen Sanctuary crawlers.
**Defer Reason:** Requires new dependency and consistent application across multiple crawlers

_Added by Sharkrite on 2026-03-25T08:03:27Z_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**5** files, **2** commits (+0 added, ~5 modified, -0 deleted)
- `M` requirements.txt
- `M` src/services/crawlers/hellofresh_crawler.py
- `M` src/services/crawlers/kitchen_sanctuary_crawler.py
- `M` tests/services/crawlers/test_hellofresh_crawler.py
- `M` tests/services/crawlers/test_kitchen_sanctuary_crawler.py

### Commits
- 4674be0 feat: XML Parsing Vulnerability
- 243fd60 chore: initialize work on #331 XML Parsing Vulnerability
<!-- /sharkrite-changes-summary -->