### PR TITLE
Missing User-Agent Header in HTTP Requests

### DIFF
--- a/src/services/scraper_service.py
+++ b/src/services/scraper_service.py
@@ -18,6 +18,7 @@ from recipe_scrapers._exceptions import WebsiteNotImplementedError
 from src.schemas.scraper import ScrapedRecipeData
 from src.db.models.recipe import SourceType
 from src.config import get_settings
+from src.services.crawlers.base_crawler import USER_AGENT
 
 
 # Custom exceptions for scraping errors
@@ -228,12 +229,12 @@ def scrape_recipe(url: str) -> ScrapedRecipeData:
                 if parsed.query:
                     request_url += f"?{parsed.query}"
 
-            # Set Host header to preserve virtual hosting
-            headers = {'Host': original_hostname}
+            # Set Host header to preserve virtual hosting and User-Agent for reliability
+            headers = {'Host': original_hostname, 'User-Agent': USER_AGENT}
         else:
             # Fallback to original URL if no validated IP
             request_url = url
-            headers = {}
+            headers = {'User-Agent': USER_AGENT}
 
         # Fetch the HTML content with timeout and disabled redirects
         # Redirects are disabled to prevent redirect-based SSRF bypasses

--- a/tests/services/test_scraper_service.py
+++ b/tests/services/test_scraper_service.py
@@ -118,11 +118,14 @@ class TestScrapeRecipe:
         assert len(result.instructions) == 3  # Split by newline
 
         # Verify requests.get was called with timeout, headers, and allow_redirects=False
-        # The URL will be an IP address due to SSRF protection, with Host header set
+        # The URL will be an IP address due to SSRF protection, with Host and User-Agent headers set
         mock_requests_get.assert_called_once()
         call_args = mock_requests_get.call_args
         assert call_args[1]['timeout'] == 30.0
-        assert call_args[1]['headers'] == {'Host': 'www.hellofresh.com'}
+        assert 'Host' in call_args[1]['headers']
+        assert call_args[1]['headers']['Host'] == 'www.hellofresh.com'
+        assert 'User-Agent' in call_args[1]['headers']
+        assert 'FreshUp-Crawler' in call_args[1]['headers']['User-Agent']
         assert call_args[1]['allow_redirects'] is False
 
         # Verify scrape_html was called with the fetched HTML
@@ -256,12 +259,47 @@ class TestScrapeRecipe:
             scrape_recipe(url)
 
         # Verify requests.get was called with the configured timeout, headers, and allow_redirects=False
-        # The URL will be an IP address due to SSRF protection, with Host header set
+        # The URL will be an IP address due to SSRF protection, with Host and User-Agent headers set
         mock_requests_get.assert_called_once()
         call_args = mock_requests_get.call_args
         assert call_args[1]['timeout'] == 45.0
-        assert call_args[1]['headers'] == {'Host': 'www.example.com'}
+        assert 'Host' in call_args[1]['headers']
+        assert call_args[1]['headers']['Host'] == 'www.example.com'
+        assert 'User-Agent' in call_args[1]['headers']
+        assert 'FreshUp-Crawler' in call_args[1]['headers']['User-Agent']
         assert call_args[1]['allow_redirects'] is False
+
+    @patch('src.services.scraper_service.recipe_scrapers.scrape_html')
+    @patch('src.services.scraper_service.requests.get')
+    def test_sets_user_agent_header(self, mock_requests_get, mock_scrape_html):
+        """Test that User-Agent header is set for all HTTP requests."""
+        # Mock HTTP response
+        mock_requests_get.return_value = _mock_successful_http_response()
+
+        mock_scraper = Mock()
+        mock_scraper.title.return_value = "Test Recipe"
+        mock_scraper.ingredients.return_value = ["ingredient 1"]
+        mock_scraper.instructions.return_value = "Step 1"
+        mock_scraper.prep_time.side_effect = Exception("Not available")
+        mock_scraper.cook_time.side_effect = Exception("Not available")
+        mock_scraper.total_time.side_effect = Exception("Not available")
+        mock_scraper.yields.side_effect = Exception("Not available")
+        mock_scraper.image.side_effect = Exception("Not available")
+        mock_scraper.nutrients.side_effect = Exception("Not available")
+        mock_scraper.author.side_effect = Exception("Not available")
+        mock_scraper.site_name.side_effect = Exception("Not available")
+
+        mock_scrape_html.return_value = mock_scraper
+
+        url = "https://www.hellofresh.com/recipes/test"
+        result = scrape_recipe(url)
+
+        # Verify User-Agent header is present
+        mock_requests_get.assert_called_once()
+        call_args = mock_requests_get.call_args
+        assert 'User-Agent' in call_args[1]['headers']
+        assert 'FreshUp-Crawler/1.0' in call_args[1]['headers']['User-Agent']
+        assert 'github.com/freshup/freshup' in call_args[1]['headers']['User-Agent']
 
     @patch('src.services.scraper_service.recipe_scrapers.scrape_html')
     @patch('src.services.scraper_service.requests.get')
@@ -430,7 +468,10 @@ class TestScrapeRecipe:
         mock_requests_get.assert_called_once()
         call_args = mock_requests_get.call_args
         assert call_args[1]['timeout'] == 30.0
-        assert call_args[1]['headers'] == {'Host': 'www.hellofresh.com'}
+        assert 'Host' in call_args[1]['headers']
+        assert call_args[1]['headers']['Host'] == 'www.hellofresh.com'
+        assert 'User-Agent' in call_args[1]['headers']
+        assert 'FreshUp-Crawler' in call_args[1]['headers']['User-Agent']
         assert call_args[1]['allow_redirects'] is False
 
         # Verify scrape_html was called with the fetched HTML


### PR DESCRIPTION
## Work in Progress

Closes #334

Missing User-Agent Header in HTTP Requests

<!-- sharkrite-source-issue:315 -->## From PR #330 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
This is a real functional concern (many recipe sites block default User-Agent), but it's a reliability improvement rather than a security or correctness issue. The PR's scope is timeout configuration, not HTTP client hardening.

## Context
While adding a User-Agent improves scraping success rates, the original issue is specifically about timeout configuration. This is a valid enhancement but exceeds the defined scope.

## Defer Reason
Needs separate focused PR

---
_Created by Sharkrite assessment on 2026-03-25T08:07:33Z_
_Parent PR: #330_

---

## Additional Assessment (PR #330)

**Severity:** MEDIUM
**Reasoning:** This was already classified as ACTIONABLE_LATER in prior assessment. The file changed but the core issue (no User-Agent header) persists. This is a reliability improvement, not a security or correctness issue blocking the PR.
**Context:** Valid functional concern for production reliability, but not within the timeout configuration scope. The PR's security and timeout goals are met without this.
**Defer Reason:** Needs separate focused PR

_Added by Sharkrite on 2026-03-25T08:16:42Z_

---

## Additional Assessment (PR #330)

**Severity:** MEDIUM
**Reasoning:** Prior assessment already classified this as ACTIONABLE_LATER. The file changed but the core issue persists. This is a reliability improvement for HTTP client hardening, not a security or correctness issue blocking merge.
**Context:** The PR scope is timeout configuration and SSRF mitigation, not comprehensive HTTP client hardening. User-Agent is a valid follow-up concern.
**Defer Reason:** Needs separate focused PR

_Added by Sharkrite on 2026-03-25T08:20:21Z_

---

## Additional Assessment (PR #330)

**Severity:** HIGH
**Reasoning:** Prior assessment already classified the User-Agent header issue as ACTIONABLE_LATER. The file has changed but the core issue persists. This is a reliability improvement for HTTP client hardening, not a security or correctness issue blocking merge. The PR's scope is timeout configuration, not HTTP client hardening.
**Context:** Many recipe websites block requests without proper User-Agent headers. While this causes degraded functionality, it's outside the original issue scope of timeout configuration. The prior decision explicitly deferred this to a separate PR.
**Defer Reason:** Needs separate focused PR

_Added by Sharkrite on 2026-03-25T08:23:57Z_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+0 added, ~2 modified, -0 deleted)
- `M` src/services/scraper_service.py
- `M` tests/services/test_scraper_service.py

### Commits
- 664bdd4 feat: Missing User-Agent Header in HTTP Requests
- e7d7ca8 chore: initialize work on #334 Missing User-Agent Header in HTTP Requests
<!-- /sharkrite-changes-summary -->