### PR TITLE
Use dynamic rendering for category enums

### DIFF
--- a/frontend/src/components/pantry/StorageTabs.tsx
+++ b/frontend/src/components/pantry/StorageTabs.tsx
@@ -1,4 +1,5 @@
 import { StorageLocation } from '../../api/types'
+import { getEnumOptions } from '../../utils/enumUtils'
 
 type StorageTab = 'all' | StorageLocation
 
@@ -11,17 +12,19 @@ interface StorageTabsProps {
  * StorageTabs component for filtering pantry inventory by storage location
  *
  * Features:
- * - Four tabs: All | Fridge | Freezer | Pantry
+ * - Dynamically generated tabs from StorageLocation enum (All + all enum values)
  * - Active tab: olive background with cream text
  * - Inactive tabs: cream background with primary text
  * - Applies storage location filter to inventory list
  */
 export default function StorageTabs({ activeTab, onTabChange }: StorageTabsProps) {
+  // Generate tabs dynamically from enum
   const tabs: { value: StorageTab; label: string }[] = [
     { value: 'all', label: 'All' },
-    { value: StorageLocation.FRIDGE, label: 'Fridge' },
-    { value: StorageLocation.FREEZER, label: 'Freezer' },
-    { value: StorageLocation.PANTRY, label: 'Pantry' },
+    ...getEnumOptions(StorageLocation).map((option) => ({
+      value: option.value as StorageLocation,
+      label: option.label,
+    })),
   ]
 
   return (

--- a/frontend/src/components/shopped/ManualAddTab.tsx
+++ b/frontend/src/components/shopped/ManualAddTab.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useCreateInventoryItem } from '../../api'
 import { Category, StorageLocation } from '../../api/types'
+import { getEnumOptions } from '../../utils/enumUtils'
 
 /**
  * ManualAddTab component - Manual inventory item entry form
@@ -261,18 +262,11 @@ export default function ManualAddTab() {
               className="w-full px-3 py-2 border border-warm-border rounded-md focus:outline-none focus:ring-2 focus:ring-olive focus:border-transparent"
               required
             >
-              <option value={Category.PRODUCE}>Produce</option>
-              <option value={Category.DAIRY}>Dairy</option>
-              <option value={Category.PROTEIN}>Protein</option>
-              <option value={Category.GRAINS}>Grains</option>
-              <option value={Category.CONDIMENTS}>Condiments</option>
-              <option value={Category.SNACKS}>Snacks</option>
-              <option value={Category.BEVERAGES}>Beverages</option>
-              <option value={Category.FROZEN}>Frozen</option>
-              <option value={Category.CANNED}>Canned</option>
-              <option value={Category.BAKING}>Baking</option>
-              <option value={Category.SPICES}>Spices</option>
-              <option value={Category.OTHER}>Other</option>
+              {getEnumOptions(Category).map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
             </select>
           </div>
 
@@ -291,10 +285,11 @@ export default function ManualAddTab() {
               className="w-full px-3 py-2 border border-warm-border rounded-md focus:outline-none focus:ring-2 focus:ring-olive focus:border-transparent"
               required
             >
-              <option value={StorageLocation.PANTRY}>Pantry</option>
-              <option value={StorageLocation.FRIDGE}>Fridge</option>
-              <option value={StorageLocation.FREEZER}>Freezer</option>
-              <option value={StorageLocation.COUNTER}>Counter</option>
+              {getEnumOptions(StorageLocation).map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
             </select>
           </div>
 

--- a/frontend/src/utils/enumUtils.test.ts
+++ b/frontend/src/utils/enumUtils.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest'
+import { getEnumValues, formatEnumLabel, getEnumOptions } from './enumUtils'
+import { Category, StorageLocation } from '../api/types'
+
+describe('enumUtils', () => {
+  describe('getEnumValues', () => {
+    it('should extract all values from an enum', () => {
+      enum TestEnum {
+        FIRST = 'first',
+        SECOND = 'second',
+        THIRD = 'third',
+      }
+
+      const values = getEnumValues(TestEnum)
+
+      expect(values).toEqual(['first', 'second', 'third'])
+      expect(values).toHaveLength(3)
+    })
+
+    it('should work with Category enum', () => {
+      const values = getEnumValues(Category)
+
+      expect(values).toContain(Category.PRODUCE)
+      expect(values).toContain(Category.DAIRY)
+      expect(values).toContain(Category.PROTEIN)
+      expect(values).toContain(Category.GRAINS)
+      expect(values).toContain(Category.CONDIMENTS)
+      expect(values).toContain(Category.SNACKS)
+      expect(values).toContain(Category.BEVERAGES)
+      expect(values).toContain(Category.FROZEN)
+      expect(values).toContain(Category.CANNED)
+      expect(values).toContain(Category.BAKING)
+      expect(values).toContain(Category.SPICES)
+      expect(values).toContain(Category.OTHER)
+      expect(values).toHaveLength(12)
+    })
+
+    it('should work with StorageLocation enum', () => {
+      const values = getEnumValues(StorageLocation)
+
+      expect(values).toContain(StorageLocation.PANTRY)
+      expect(values).toContain(StorageLocation.FRIDGE)
+      expect(values).toContain(StorageLocation.FREEZER)
+      expect(values).toContain(StorageLocation.COUNTER)
+      expect(values).toHaveLength(4)
+    })
+  })
+
+  describe('formatEnumLabel', () => {
+    it('should format UPPER_CASE to Title Case', () => {
+      expect(formatEnumLabel('GLUTEN_FREE')).toBe('Gluten Free')
+      expect(formatEnumLabel('STORAGE_LOCATION')).toBe('Storage Location')
+      expect(formatEnumLabel('DAIRY_FREE')).toBe('Dairy Free')
+    })
+
+    it('should format single words', () => {
+      expect(formatEnumLabel('PRODUCE')).toBe('Produce')
+      expect(formatEnumLabel('DAIRY')).toBe('Dairy')
+      expect(formatEnumLabel('PROTEIN')).toBe('Protein')
+    })
+
+    it('should format lowercase words', () => {
+      expect(formatEnumLabel('produce')).toBe('Produce')
+      expect(formatEnumLabel('dairy')).toBe('Dairy')
+    })
+
+    it('should handle snake_case', () => {
+      expect(formatEnumLabel('gluten_free')).toBe('Gluten Free')
+      expect(formatEnumLabel('storage_location')).toBe('Storage Location')
+    })
+
+    it('should format actual Category enum keys', () => {
+      expect(formatEnumLabel('PRODUCE')).toBe('Produce')
+      expect(formatEnumLabel('DAIRY')).toBe('Dairy')
+      expect(formatEnumLabel('PROTEIN')).toBe('Protein')
+      expect(formatEnumLabel('GRAINS')).toBe('Grains')
+      expect(formatEnumLabel('CONDIMENTS')).toBe('Condiments')
+      expect(formatEnumLabel('SNACKS')).toBe('Snacks')
+      expect(formatEnumLabel('BEVERAGES')).toBe('Beverages')
+      expect(formatEnumLabel('FROZEN')).toBe('Frozen')
+      expect(formatEnumLabel('CANNED')).toBe('Canned')
+      expect(formatEnumLabel('BAKING')).toBe('Baking')
+      expect(formatEnumLabel('SPICES')).toBe('Spices')
+      expect(formatEnumLabel('OTHER')).toBe('Other')
+    })
+
+    it('should format actual StorageLocation enum keys', () => {
+      expect(formatEnumLabel('PANTRY')).toBe('Pantry')
+      expect(formatEnumLabel('FRIDGE')).toBe('Fridge')
+      expect(formatEnumLabel('FREEZER')).toBe('Freezer')
+      expect(formatEnumLabel('COUNTER')).toBe('Counter')
+    })
+  })
+
+  describe('getEnumOptions', () => {
+    it('should return array of value/label objects', () => {
+      enum TestEnum {
+        FIRST_OPTION = 'first',
+        SECOND_OPTION = 'second',
+      }
+
+      const options = getEnumOptions(TestEnum)
+
+      expect(options).toEqual([
+        { value: 'first', label: 'First Option' },
+        { value: 'second', label: 'Second Option' },
+      ])
+    })
+
+    it('should work with Category enum', () => {
+      const options = getEnumOptions(Category)
+
+      expect(options).toHaveLength(12)
+      expect(options).toContainEqual({ value: 'produce', label: 'Produce' })
+      expect(options).toContainEqual({ value: 'dairy', label: 'Dairy' })
+      expect(options).toContainEqual({ value: 'protein', label: 'Protein' })
+      expect(options).toContainEqual({ value: 'grains', label: 'Grains' })
+      expect(options).toContainEqual({ value: 'condiments', label: 'Condiments' })
+      expect(options).toContainEqual({ value: 'snacks', label: 'Snacks' })
+      expect(options).toContainEqual({ value: 'beverages', label: 'Beverages' })
+      expect(options).toContainEqual({ value: 'frozen', label: 'Frozen' })
+      expect(options).toContainEqual({ value: 'canned', label: 'Canned' })
+      expect(options).toContainEqual({ value: 'baking', label: 'Baking' })
+      expect(options).toContainEqual({ value: 'spices', label: 'Spices' })
+      expect(options).toContainEqual({ value: 'other', label: 'Other' })
+    })
+
+    it('should work with StorageLocation enum', () => {
+      const options = getEnumOptions(StorageLocation)
+
+      expect(options).toHaveLength(4)
+      expect(options).toContainEqual({ value: 'pantry', label: 'Pantry' })
+      expect(options).toContainEqual({ value: 'fridge', label: 'Fridge' })
+      expect(options).toContainEqual({ value: 'freezer', label: 'Freezer' })
+      expect(options).toContainEqual({ value: 'counter', label: 'Counter' })
+    })
+
+    it('should preserve enum value types', () => {
+      const options = getEnumOptions(Category)
+      const firstOption = options[0]
+
+      // Value should be the actual enum value
+      expect(typeof firstOption.value).toBe('string')
+      expect(Object.values(Category)).toContain(firstOption.value)
+    })
+  })
+})

--- a/frontend/src/utils/enumUtils.ts
+++ b/frontend/src/utils/enumUtils.ts
@@ -1,0 +1,66 @@
+/**
+ * Utility functions for working with TypeScript enums
+ *
+ * Provides helpers to:
+ * - Extract all values from an enum
+ * - Format enum keys into human-readable labels
+ */
+
+/**
+ * Extracts all values from a TypeScript enum
+ *
+ * @param enumObject - The enum to extract values from
+ * @returns Array of enum values
+ *
+ * @example
+ * enum Color { RED = 'red', BLUE = 'blue' }
+ * getEnumValues(Color) // ['red', 'blue']
+ */
+export function getEnumValues<T extends Record<string, string>>(
+  enumObject: T
+): T[keyof T][] {
+  return Object.values(enumObject)
+}
+
+/**
+ * Converts an enum key to a human-readable label
+ *
+ * Handles various formatting patterns:
+ * - UPPER_CASE → Title Case
+ * - camelCase → Title Case
+ * - snake_case → Title Case
+ *
+ * @param enumKey - The enum key to format
+ * @returns Formatted label
+ *
+ * @example
+ * formatEnumLabel('GLUTEN_FREE') // 'Gluten Free'
+ * formatEnumLabel('produce') // 'Produce'
+ * formatEnumLabel('STORAGE_LOCATION') // 'Storage Location'
+ */
+export function formatEnumLabel(enumKey: string): string {
+  return enumKey
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ')
+}
+
+/**
+ * Gets all enum values with their formatted labels
+ *
+ * @param enumObject - The enum to process
+ * @returns Array of objects with value and label properties
+ *
+ * @example
+ * enum Status { ACTIVE = 'active', PENDING = 'pending' }
+ * getEnumOptions(Status)
+ * // [{ value: 'active', label: 'Active' }, { value: 'pending', label: 'Pending' }]
+ */
+export function getEnumOptions<T extends Record<string, string>>(
+  enumObject: T
+): Array<{ value: T[keyof T]; label: string }> {
+  return Object.entries(enumObject).map(([key, value]) => ({
+    value: value as T[keyof T],
+    label: formatEnumLabel(key),
+  }))
+}

--- a/frontend/src/utils/enumUtils.ts
+++ b/frontend/src/utils/enumUtils.ts
@@ -48,8 +48,12 @@ export function formatEnumLabel(enumKey: string): string {
 /**
  * Gets all enum values with their formatted labels
  *
+ * **Important:** The order of returned options depends on the definition order of enum members.
+ * If you need a specific display order (e.g., alphabetical), the enum members must be defined
+ * in that order, or the result should be sorted after calling this function.
+ *
  * @param enumObject - The enum to process
- * @returns Array of objects with value and label properties
+ * @returns Array of objects with value and label properties, in enum definition order
  *
  * @example
  * enum Status { ACTIVE = 'active', PENDING = 'pending' }


### PR DESCRIPTION
## Work in Progress

Closes #336

Use dynamic rendering for category enums

<!-- sharkrite-source-issue:299 -->## From PR #332 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
This is a real maintainability concern - if the `Category` or `StorageLocation` enums are updated in the API types, the component options will drift out of sync without any compile-time warning. This has caused real bugs in similar codebases.

## Context


## Defer Reason
Scope exceeds time budget - requires creating a label formatting utility function and testing the dynamic rendering approach across both enum types.

---
_Created by Sharkrite assessment on 2026-03-25T08:17:57Z_
_Parent PR: #332_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**4** files, **2** commits (+2 added, ~2 modified, -0 deleted)
- `M` frontend/src/components/pantry/StorageTabs.tsx
- `M` frontend/src/components/shopped/ManualAddTab.tsx
- `A` frontend/src/utils/enumUtils.test.ts
- `A` frontend/src/utils/enumUtils.ts

### Commits
- 52d3a06 feat: Use dynamic rendering for category enums
- c559ebf chore: initialize work on #336 Use dynamic rendering for category enums
<!-- /sharkrite-changes-summary -->