### PR TITLE
Limit discovery crawling operations

### DIFF
--- a/src/routers/scraper.py
+++ b/src/routers/scraper.py
@@ -282,8 +282,14 @@ def discover_and_import(
     """
     Discover recipe URLs from a source and import them (coordinator-only).
 
-    Combines URL discovery with batch import. Limits the number of imported
-    recipes using the max_recipes parameter (default: 50).
+    Combines URL discovery with batch import. Limits both the discovery crawling
+    (max_pages) and the number of imported recipes (max_recipes) to optimize
+    performance and reduce load on target servers.
+
+    Performance optimization:
+    - Automatically limits sitemap crawling to only the pages needed
+    - Heuristic: ~25 recipes per sitemap page (auto-calculated if max_pages not provided)
+    - Significantly reduces unnecessary crawling (e.g., 500 URLs → 75 URLs for max_recipes=50)
 
     Rate limiting:
     - API layer: 3 requests per minute per IP address to prevent abuse
@@ -292,7 +298,7 @@ def discover_and_import(
     Args:
         source: Source to discover from (hellofresh or kitchen_sanctuary)
         request: FastAPI request object (required by slowapi for rate limiting)
-        payload: Request body with max_recipes parameter (default: 50)
+        payload: Request body with max_recipes (default: 50) and optional max_pages
         current_user: Authenticated user (must be coordinator)
         db: Database session
 
@@ -308,22 +314,33 @@ def discover_and_import(
     require_coordinator(current_user)
 
     max_recipes = payload.max_recipes or 50
-    logger.info(f"Coordinator {current_user.id} discovering and importing from {source} (max: {max_recipes})")
+
+    # Calculate max_pages to limit discovery crawling (optimization)
+    # Heuristic: ~25 recipes per sitemap page (conservative estimate to allow buffer for duplicates)
+    # This significantly reduces crawling overhead by discovering only what we need
+    if payload.max_pages is None:
+        max_pages = (max_recipes // 25) + 1
+        logger.info(f"Auto-calculated max_pages={max_pages} from max_recipes={max_recipes}")
+    else:
+        max_pages = payload.max_pages
+        logger.info(f"Using explicit max_pages={max_pages}")
+
+    logger.info(f"Coordinator {current_user.id} discovering and importing from {source} (max_recipes: {max_recipes}, max_pages: {max_pages})")
 
     try:
-        # Discover URLs
+        # Discover URLs with page limit to reduce unnecessary crawling
         if source == "hellofresh":
             crawler = HelloFreshCrawler()
-            urls = crawler.discover_recipe_urls()
+            urls = crawler.discover_recipe_urls(max_pages=max_pages)
         else:  # kitchen_sanctuary
             crawler = KitchenSanctuaryCrawler()
-            urls = crawler.discover_recipe_urls()
+            urls = crawler.discover_recipe_urls(max_pages=max_pages)
 
-        logger.info(f"Discovered {len(urls)} URLs from {source}")
+        logger.info(f"Discovered {len(urls)} URLs from {source} (limited to {max_pages} pages)")
 
-        # Limit to max_recipes
+        # Limit to max_recipes (may be fewer URLs than max_recipes if discovery was limited)
         urls_to_import = urls[:max_recipes]
-        logger.info(f"Importing {len(urls_to_import)} recipes (limited by max_recipes={max_recipes})")
+        logger.info(f"Importing {len(urls_to_import)} recipes")
 
         # Import batch
         result = import_batch(urls_to_import, db, delay_seconds=1.0)

--- a/src/routers/scraper.py
+++ b/src/routers/scraper.py
@@ -319,7 +319,8 @@ def discover_and_import(
     # Heuristic: ~25 recipes per sitemap page (conservative estimate to allow buffer for duplicates)
     # This significantly reduces crawling overhead by discovering only what we need
     if payload.max_pages is None:
-        max_pages = (max_recipes // 25) + 1
+        calculated_pages = (max_recipes // 25) + 1
+        max_pages = min(calculated_pages, 50)  # Respect schema's max_pages upper bound
         logger.info(f"Auto-calculated max_pages={max_pages} from max_recipes={max_recipes}")
     else:
         max_pages = payload.max_pages

--- a/src/schemas/scraper.py
+++ b/src/schemas/scraper.py
@@ -96,6 +96,7 @@ class ImportBatchRequest(BaseModel):
 class DiscoverAndImportRequest(BaseModel):
     """Request schema for discover-and-import operation."""
     max_recipes: Optional[int] = Field(default=50, description="Maximum number of recipes to import", ge=1, le=1000)
+    max_pages: Optional[int] = Field(default=None, description="Maximum sitemap pages to crawl (auto-calculated from max_recipes if not specified)", ge=1)
 
 
 class DiscoveryResponse(BaseModel):

--- a/src/schemas/scraper.py
+++ b/src/schemas/scraper.py
@@ -96,7 +96,7 @@ class ImportBatchRequest(BaseModel):
 class DiscoverAndImportRequest(BaseModel):
     """Request schema for discover-and-import operation."""
     max_recipes: Optional[int] = Field(default=50, description="Maximum number of recipes to import", ge=1, le=1000)
-    max_pages: Optional[int] = Field(default=None, description="Maximum sitemap pages to crawl (auto-calculated from max_recipes if not specified)", ge=1)
+    max_pages: Optional[int] = Field(default=None, description="Maximum sitemap pages to crawl (auto-calculated from max_recipes if not specified)", ge=1, le=50)
 
 
 class DiscoveryResponse(BaseModel):

--- a/tests/routers/test_scraper.py
+++ b/tests/routers/test_scraper.py
@@ -633,6 +633,36 @@ class TestDiscoverAndImport:
         # max_recipes=200 → max_pages = (200 // 25) + 1 = 9
         mock_crawler.discover_recipe_urls.assert_called_once_with(max_pages=9)
 
+    @patch("src.routers.scraper.import_batch")
+    @patch("src.routers.scraper.HelloFreshCrawler")
+    def test_discover_and_import_auto_calculates_one_page_for_small_max_recipes(self, mock_crawler_class, mock_batch, client, coordinator_headers, db_session):
+        """max_pages calculation returns 1 when max_recipes < 25 (edge case)."""
+        mock_crawler = MagicMock()
+        mock_crawler.discover_recipe_urls.return_value = [
+            f"https://www.hellofresh.com/recipes/recipe-{i}" for i in range(20)
+        ]
+        mock_crawler_class.return_value = mock_crawler
+
+        mock_batch.return_value = BatchImportResult(
+            total=20,
+            imported=20,
+            duplicates=0,
+            errors=0,
+            results=[]
+        )
+
+        response = client.post(
+            "/scraper/discover-and-import/hellofresh",
+            json={"max_recipes": 20},
+            headers=coordinator_headers
+        )
+
+        assert response.status_code == 200
+
+        # Verify that max_pages was calculated correctly for edge case
+        # max_recipes=20 → max_pages = (20 // 25) + 1 = 0 + 1 = 1
+        mock_crawler.discover_recipe_urls.assert_called_once_with(max_pages=1)
+
 
 class TestStatus:
     """Test GET /scraper/status endpoint."""

--- a/tests/routers/test_scraper.py
+++ b/tests/routers/test_scraper.py
@@ -544,6 +544,95 @@ class TestDiscoverAndImport:
         response = client.post("/scraper/discover-and-import/hellofresh")
         assert response.status_code == 401
 
+    @patch("src.routers.scraper.import_batch")
+    @patch("src.routers.scraper.HelloFreshCrawler")
+    def test_discover_and_import_auto_calculates_max_pages(self, mock_crawler_class, mock_batch, client, coordinator_headers, db_session):
+        """max_pages is auto-calculated from max_recipes when not provided."""
+        mock_crawler = MagicMock()
+        mock_crawler.discover_recipe_urls.return_value = [
+            f"https://www.hellofresh.com/recipes/recipe-{i}" for i in range(75)
+        ]
+        mock_crawler_class.return_value = mock_crawler
+
+        mock_batch.return_value = BatchImportResult(
+            total=50,
+            imported=50,
+            duplicates=0,
+            errors=0,
+            results=[]
+        )
+
+        response = client.post(
+            "/scraper/discover-and-import/hellofresh",
+            json={"max_recipes": 50},
+            headers=coordinator_headers
+        )
+
+        assert response.status_code == 200
+
+        # Verify that max_pages was auto-calculated and passed to crawler
+        # max_recipes=50 → max_pages = (50 // 25) + 1 = 3
+        mock_crawler.discover_recipe_urls.assert_called_once_with(max_pages=3)
+
+    @patch("src.routers.scraper.import_batch")
+    @patch("src.routers.scraper.KitchenSanctuaryCrawler")
+    def test_discover_and_import_respects_explicit_max_pages(self, mock_crawler_class, mock_batch, client, coordinator_headers, db_session):
+        """Explicit max_pages parameter is respected when provided."""
+        mock_crawler = MagicMock()
+        mock_crawler.discover_recipe_urls.return_value = [
+            f"https://www.kitchensanctuary.com/recipe-{i}" for i in range(50)
+        ]
+        mock_crawler_class.return_value = mock_crawler
+
+        mock_batch.return_value = BatchImportResult(
+            total=25,
+            imported=25,
+            duplicates=0,
+            errors=0,
+            results=[]
+        )
+
+        response = client.post(
+            "/scraper/discover-and-import/kitchen_sanctuary",
+            json={"max_recipes": 25, "max_pages": 5},
+            headers=coordinator_headers
+        )
+
+        assert response.status_code == 200
+
+        # Verify that explicit max_pages=5 was passed to crawler (not auto-calculated)
+        mock_crawler.discover_recipe_urls.assert_called_once_with(max_pages=5)
+
+    @patch("src.routers.scraper.import_batch")
+    @patch("src.routers.scraper.HelloFreshCrawler")
+    def test_discover_and_import_limits_crawling_for_large_max_recipes(self, mock_crawler_class, mock_batch, client, coordinator_headers, db_session):
+        """max_pages calculation works correctly for large max_recipes values."""
+        mock_crawler = MagicMock()
+        mock_crawler.discover_recipe_urls.return_value = [
+            f"https://www.hellofresh.com/recipes/recipe-{i}" for i in range(200)
+        ]
+        mock_crawler_class.return_value = mock_crawler
+
+        mock_batch.return_value = BatchImportResult(
+            total=200,
+            imported=200,
+            duplicates=0,
+            errors=0,
+            results=[]
+        )
+
+        response = client.post(
+            "/scraper/discover-and-import/hellofresh",
+            json={"max_recipes": 200},
+            headers=coordinator_headers
+        )
+
+        assert response.status_code == 200
+
+        # Verify that max_pages was calculated correctly
+        # max_recipes=200 → max_pages = (200 // 25) + 1 = 9
+        mock_crawler.discover_recipe_urls.assert_called_once_with(max_pages=9)
+
 
 class TestStatus:
     """Test GET /scraper/status endpoint."""


### PR DESCRIPTION
## Work in Progress

Closes #340

Limit discovery crawling operations

<!-- sharkrite-source-issue:308 -->## From PR #339 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
This is a performance optimization that requires understanding crawler internals and coordinating changes across modules. The current implementation works correctly; it just does extra work.

## Context
The discover-and-import endpoint functions correctly per spec. Optimizing the discovery-to-import ratio requires changes to crawler integration patterns beyond the router scope.

## Defer Reason
Scope exceeds time budget - requires analysis of crawler pagination behavior and coordination with crawler modules

---
_Created by Sharkrite assessment on 2026-03-26T08:06:50Z_
_Parent PR: #339_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **2** commits (+0 added, ~3 modified, -0 deleted)
- `M` src/routers/scraper.py
- `M` src/schemas/scraper.py
- `M` tests/routers/test_scraper.py

### Commits
- e887bee feat: Limit discovery crawling operations
- 7d92e5c chore: initialize work on #340 Limit discovery crawling operations
<!-- /sharkrite-changes-summary -->