### PR TITLE
Add URL count limit to batch import endpoint

### DIFF
--- a/src/routers/scraper.py
+++ b/src/routers/scraper.py
@@ -191,12 +191,13 @@ def import_batch_urls(
     Import recipes from multiple URLs (batch operation).
 
     Coordinator-only endpoint. Processes URLs sequentially with rate limiting
-    (1 second delay between requests by default).
+    (1 second delay between requests by default). Limited to 100 URLs per batch
+    to prevent HTTP timeout issues (~100 seconds total processing time).
 
     Rate limited to 5 requests per minute per IP address to prevent abuse.
 
     Args:
-        payload: Request body containing list of URLs to import
+        payload: Request body containing list of URLs to import (max 100)
         request: FastAPI request object (required by slowapi for rate limiting)
         current_user: Authenticated user (must be coordinator)
         db: Database session
@@ -207,6 +208,7 @@ def import_batch_urls(
     Raises:
         HTTPException(401): If Authorization header is missing or token is invalid
         HTTPException(403): If user is not a coordinator
+        HTTPException(422): If URL count exceeds 100
         HTTPException(429): If rate limit is exceeded
     """
     require_coordinator(current_user)

--- a/src/schemas/scraper.py
+++ b/src/schemas/scraper.py
@@ -81,7 +81,7 @@ class ImportUrlRequest(BaseModel):
 
 class ImportBatchRequest(BaseModel):
     """Request schema for batch URL import."""
-    urls: list[str] = Field(..., description="List of recipe URLs to import (each URL max 2048 chars)", min_length=1, max_length=500)
+    urls: list[str] = Field(..., description="List of recipe URLs to import (each URL max 2048 chars)", min_length=1, max_length=100)
 
     @field_validator('urls')
     @classmethod

--- a/tests/routers/test_scraper.py
+++ b/tests/routers/test_scraper.py
@@ -407,6 +407,47 @@ class TestImportBatch:
 
         assert response.status_code == 200
 
+    def test_import_batch_rejects_too_many_urls(self, client, coordinator_headers):
+        """Batch import rejects more than 100 URLs."""
+        # Generate 101 valid URLs to exceed the limit
+        urls = [f"https://www.hellofresh.com/recipes/recipe-{i}" for i in range(101)]
+
+        response = client.post(
+            "/scraper/import-batch",
+            json={"urls": urls},
+            headers=coordinator_headers
+        )
+
+        assert response.status_code == 422
+        data = response.json()
+        assert "detail" in data
+        # Pydantic validation error for list max_length constraint
+        assert any("100" in str(err) for err in data["detail"])
+
+    @patch("src.routers.scraper.import_batch")
+    def test_import_batch_accepts_max_url_count(self, mock_batch, client, coordinator_headers):
+        """Batch import accepts exactly 100 URLs (boundary test)."""
+        mock_batch.return_value = BatchImportResult(
+            total=100,
+            imported=100,
+            duplicates=0,
+            errors=0,
+            results=[]
+        )
+
+        # Generate exactly 100 valid URLs (boundary case)
+        urls = [f"https://www.hellofresh.com/recipes/recipe-{i}" for i in range(100)]
+
+        response = client.post(
+            "/scraper/import-batch",
+            json={"urls": urls},
+            headers=coordinator_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 100
+
 
 class TestDiscover:
     """Test POST /scraper/discover/{source} endpoint."""


### PR DESCRIPTION
## Work in Progress

Closes #343

Add URL count limit to batch import endpoint

<!-- sharkrite-source-issue:308 -->## From PR #339 Assessment

**Severity:** MEDIUM
**Category:** Performance

## Issue
500 URLs × 1 second delay = ~8+ minutes. This exceeds typical HTTP timeouts, but requires architectural changes (job queue, async processing) to properly address. The current limit works for reasonable batch sizes.

## Context
This is a valid concern but requires infrastructure changes beyond the scope of this PR. The current max_length of 500 is documented behavior.

## Defer Reason
Architectural refactor needed - requires job queue infrastructure

---
_Created by Sharkrite assessment on 2026-03-26T08:14:43Z_
_Parent PR: #339_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**9** files, **2** commits (+0 added, ~7 modified, -2 deleted)
- `M` .env.example
- `D` .github/workflows/integration-tests.yml
- `M` docker-compose.yml
- `D` pytest.ini
- `M` requirements.txt
- `M` src/config.py
- `M` src/routers/scraper.py
- `M` src/schemas/scraper.py
- `M` tests/routers/test_scraper.py

### Commits
- b77848e feat: Add URL count limit to batch import endpoint
- 4c5a0f6 chore: initialize work on #343 Add URL count limit to batch import endpoint
<!-- /sharkrite-changes-summary -->