### PR TITLE
[Phase 2A] Implement Ollama HTTP client

### DIFF
--- a/src/services/llm/__init__.py
+++ b/src/services/llm/__init__.py
@@ -1,0 +1,43 @@
+"""
+LLM service module for FreshUp.
+
+Provides model-agnostic LLM client abstraction with structured output validation
+and automatic retry logic for malformed responses.
+
+Usage:
+    from src.services.llm import OllamaClient, LLMUnavailableError, LLMResponseError
+
+    # Create client
+    client = OllamaClient()
+
+    # Generate structured completion
+    try:
+        result = await client.complete(
+            prompt="Parse this receipt: ...",
+            system_prompt="You are a receipt parser...",
+            response_schema=ReceiptData,
+        )
+    except LLMUnavailableError:
+        # Handle service unavailable
+        pass
+    except LLMResponseError:
+        # Handle validation failure
+        pass
+    finally:
+        await client.close()
+"""
+
+from src.services.llm.client import LLMClient, OllamaClient
+from src.services.llm.exceptions import (
+    LLMError,
+    LLMUnavailableError,
+    LLMResponseError,
+)
+
+__all__ = [
+    "LLMClient",
+    "OllamaClient",
+    "LLMError",
+    "LLMUnavailableError",
+    "LLMResponseError",
+]

--- a/src/services/llm/client.py
+++ b/src/services/llm/client.py
@@ -189,8 +189,13 @@ class OllamaClient(LLMClient):
                             "model": self.model,
                             "attempt": attempt + 1,
                             "error": error_msg,
-                            "response_preview": response_text[:200],
                         },
+                    )
+
+                    # Log response preview at DEBUG level to avoid exposing sensitive data
+                    logger.debug(
+                        "Response preview for debugging",
+                        extra={"response_preview": response_text[:200]},
                     )
 
                     # If we have retries left, append correction context and retry

--- a/src/services/llm/client.py
+++ b/src/services/llm/client.py
@@ -1,0 +1,275 @@
+"""
+LLM client abstraction layer for FreshUp.
+
+Provides a model-agnostic interface for LLM operations with structured output
+validation and automatic retry logic for malformed responses.
+
+Per ADR-003: LLMs handle natural language interpretation tasks (receipt parsing,
+recipe photo parsing, voice commands). All state management and business logic
+remains deterministic Python code.
+"""
+
+import json
+import logging
+from abc import ABC, abstractmethod
+from typing import TypeVar, Type
+
+import httpx
+from pydantic import BaseModel, ValidationError
+
+from src.config import get_settings
+from src.services.llm.exceptions import LLMUnavailableError, LLMResponseError
+
+logger = logging.getLogger(__name__)
+
+# Generic type for Pydantic response schemas
+T = TypeVar('T', bound=BaseModel)
+
+
+class LLMClient(ABC):
+    """
+    Abstract base class for LLM clients.
+
+    Defines the interface all LLM providers must implement, enabling
+    provider swapping without code changes (e.g., Ollama → OpenAI).
+    """
+
+    @abstractmethod
+    async def complete(
+        self,
+        prompt: str,
+        system_prompt: str,
+        response_schema: Type[T],
+    ) -> T:
+        """
+        Generate a structured completion from the LLM.
+
+        Args:
+            prompt: The user prompt/query
+            system_prompt: System-level instructions for the LLM
+            response_schema: Pydantic model class defining expected response structure
+
+        Returns:
+            Validated instance of response_schema populated with LLM output
+
+        Raises:
+            LLMUnavailableError: If the LLM service is unreachable
+            LLMResponseError: If response validation fails after all retries
+        """
+        pass
+
+    @abstractmethod
+    async def is_available(self) -> bool:
+        """
+        Check if the LLM service is available and responding.
+
+        Returns:
+            True if service is healthy, False otherwise
+
+        Note:
+            Does not raise exceptions - returns False for any error condition
+        """
+        pass
+
+
+class OllamaClient(LLMClient):
+    """
+    Ollama HTTP client implementation.
+
+    Communicates with a local Ollama server via HTTP API for inference.
+    Configured via settings: ollama_base_url, ollama_model.
+
+    Timeout configuration:
+    - Connect timeout: 5s (fail fast if Ollama is down)
+    - Read timeout: 120s (allow time for model inference)
+
+    Retry behavior:
+    - On validation failure, retries up to 2 times (3 total attempts)
+    - Appends validation error to prompt as correction context
+    - Raises LLMResponseError after exhausting retries
+    """
+
+    # Maximum number of retries on validation failure
+    MAX_RETRIES = 2
+
+    def __init__(self):
+        """Initialize OllamaClient with configuration from settings."""
+        settings = get_settings()
+        self.base_url = settings.ollama_base_url
+        self.model = settings.ollama_model
+
+        # Configure httpx client with specified timeouts
+        self.client = httpx.AsyncClient(
+            base_url=self.base_url,
+            timeout=httpx.Timeout(
+                connect=5.0,  # Connect timeout: 5 seconds
+                read=120.0,   # Read timeout: 120 seconds
+            ),
+        )
+
+    async def complete(
+        self,
+        prompt: str,
+        system_prompt: str,
+        response_schema: Type[T],
+    ) -> T:
+        """
+        Generate a structured completion from Ollama.
+
+        Implements retry logic with correction context:
+        1. Send prompt to Ollama with JSON format request
+        2. Parse response as JSON and validate against schema
+        3. On validation failure: append error to prompt and retry (up to MAX_RETRIES)
+        4. Raise LLMResponseError if all retries exhausted
+
+        Args:
+            prompt: The user prompt/query
+            system_prompt: System-level instructions for the LLM
+            response_schema: Pydantic model class defining expected response structure
+
+        Returns:
+            Validated instance of response_schema populated with LLM output
+
+        Raises:
+            LLMUnavailableError: If Ollama is unreachable (connection refused, timeout)
+            LLMResponseError: If response validation fails after all retries
+        """
+        # Track validation errors across retries for debugging
+        validation_errors: list[str] = []
+        current_prompt = prompt
+
+        for attempt in range(self.MAX_RETRIES + 1):
+            try:
+                # Request JSON-formatted response from Ollama
+                response = await self.client.post(
+                    "/api/generate",
+                    json={
+                        "model": self.model,
+                        "prompt": current_prompt,
+                        "system": system_prompt,
+                        "stream": False,
+                        "format": "json",  # Instruct Ollama to return valid JSON
+                    },
+                )
+
+                # Check HTTP status
+                response.raise_for_status()
+
+                # Extract response text from Ollama's response format
+                ollama_response = response.json()
+                response_text = ollama_response.get("response", "")
+
+                # Parse and validate against schema
+                try:
+                    # Parse JSON response
+                    response_data = json.loads(response_text)
+
+                    # Validate against Pydantic schema
+                    validated = response_schema.model_validate(response_data)
+
+                    # Success! Return validated response
+                    logger.info(
+                        "LLM completion successful",
+                        extra={
+                            "model": self.model,
+                            "attempt": attempt + 1,
+                            "schema": response_schema.__name__,
+                        },
+                    )
+                    return validated
+
+                except (json.JSONDecodeError, ValidationError) as e:
+                    # Response validation failed
+                    error_msg = f"Validation error: {str(e)}"
+                    validation_errors.append(error_msg)
+
+                    logger.warning(
+                        "LLM response validation failed",
+                        extra={
+                            "model": self.model,
+                            "attempt": attempt + 1,
+                            "error": error_msg,
+                            "response_preview": response_text[:200],
+                        },
+                    )
+
+                    # If we have retries left, append correction context and retry
+                    if attempt < self.MAX_RETRIES:
+                        # Build correction prompt with validation error
+                        correction_context = (
+                            f"\n\nPrevious response failed validation: {error_msg}\n"
+                            f"Please provide a valid JSON response matching the required schema."
+                        )
+                        current_prompt = prompt + correction_context
+                        continue  # Retry with corrected prompt
+
+                    # No retries left - raise error
+                    raise LLMResponseError(
+                        f"Response validation failed after {self.MAX_RETRIES + 1} attempts",
+                        response=response_text,
+                        validation_errors=validation_errors,
+                    )
+
+            except httpx.ConnectError as e:
+                # Connection refused - Ollama likely not running
+                raise LLMUnavailableError(
+                    f"Failed to connect to Ollama at {self.base_url}: {str(e)}"
+                ) from e
+
+            except httpx.TimeoutException as e:
+                # Request timeout
+                raise LLMUnavailableError(
+                    f"Request to Ollama timed out: {str(e)}"
+                ) from e
+
+            except httpx.HTTPStatusError as e:
+                # HTTP error response (4xx, 5xx)
+                raise LLMUnavailableError(
+                    f"Ollama returned error status {e.response.status_code}: {str(e)}"
+                ) from e
+
+        # Should never reach here due to raise inside loop, but for type safety
+        raise LLMResponseError(
+            f"Unexpected error: exhausted retries without resolution",
+            validation_errors=validation_errors,
+        )
+
+    async def is_available(self) -> bool:
+        """
+        Check if Ollama is available and responding.
+
+        Attempts to fetch the list of available models from /api/tags endpoint.
+        This is a lightweight health check that verifies both connectivity and
+        that Ollama is properly initialized.
+
+        Returns:
+            True if Ollama is healthy and responding, False otherwise
+
+        Note:
+            Never raises exceptions - returns False for any error condition
+        """
+        try:
+            response = await self.client.get("/api/tags")
+            response.raise_for_status()
+            return True
+        except Exception as e:
+            logger.debug(
+                "Ollama availability check failed",
+                extra={
+                    "error_type": type(e).__name__,
+                    "error": str(e),
+                },
+            )
+            return False
+
+    async def close(self):
+        """Close the underlying HTTP client. Should be called on shutdown."""
+        await self.client.aclose()
+
+    async def __aenter__(self):
+        """Support async context manager protocol."""
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Ensure client is closed when exiting async context."""
+        await self.close()

--- a/src/services/llm/exceptions.py
+++ b/src/services/llm/exceptions.py
@@ -1,0 +1,49 @@
+"""
+Custom exceptions for LLM client operations.
+
+Provides specific error types for different failure modes to enable
+targeted error handling and recovery strategies.
+"""
+
+
+class LLMError(Exception):
+    """Base exception for all LLM-related errors."""
+    pass
+
+
+class LLMUnavailableError(LLMError):
+    """
+    Raised when the LLM service is unreachable.
+
+    Covers scenarios like:
+    - Connection refused (service not running)
+    - Connection timeout
+    - Network errors
+
+    Indicates the issue is with availability, not response quality.
+    """
+    pass
+
+
+class LLMResponseError(LLMError):
+    """
+    Raised when the LLM response fails validation after all retries.
+
+    Indicates the LLM is available but unable to produce valid output
+    conforming to the expected schema.
+
+    Contains the original response and validation errors for debugging.
+    """
+
+    def __init__(self, message: str, response: str | None = None, validation_errors: list[str] | None = None):
+        """
+        Initialize LLMResponseError with context.
+
+        Args:
+            message: Human-readable error description
+            response: The malformed response from the LLM (if available)
+            validation_errors: List of validation error messages from retries
+        """
+        super().__init__(message)
+        self.response = response
+        self.validation_errors = validation_errors or []

--- a/tests/unit/services/test_llm_client.py
+++ b/tests/unit/services/test_llm_client.py
@@ -15,7 +15,6 @@ All tests mock httpx.AsyncClient entirely - no real HTTP calls are made.
 
 import json
 import pytest
-from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx

--- a/tests/unit/services/test_llm_client.py
+++ b/tests/unit/services/test_llm_client.py
@@ -1,0 +1,405 @@
+"""
+Unit tests for LLM client abstraction layer.
+
+Tests cover:
+- Successful completion with valid response
+- Malformed JSON response
+- Validation error with successful retry
+- Validation error exhausting retries
+- Connection timeout
+- Connection refused
+- Health check success and failure
+
+All tests mock httpx.AsyncClient entirely - no real HTTP calls are made.
+"""
+
+import json
+import pytest
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+from pydantic import BaseModel, Field
+
+from src.services.llm import OllamaClient, LLMUnavailableError, LLMResponseError
+
+
+# Test schema for validation
+class TestReceipt(BaseModel):
+    """Sample Pydantic schema for testing structured output."""
+    store_name: str = Field(..., description="Name of the store")
+    total: float = Field(..., description="Total purchase amount")
+    items: list[str] = Field(default_factory=list, description="List of items purchased")
+
+
+@pytest.fixture(autouse=True)
+def setup_test_env(monkeypatch):
+    """Set up test environment variables."""
+    from src.config import get_settings
+    get_settings.cache_clear()
+
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars")
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://localhost:11434")
+    monkeypatch.setenv("OLLAMA_MODEL", "llama3.1:8b")
+
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def mock_httpx_client():
+    """
+    Create a mock httpx.AsyncClient for testing.
+
+    Returns a mock that can be configured per-test to simulate different
+    Ollama API responses and error conditions.
+    """
+    mock = AsyncMock(spec=httpx.AsyncClient)
+    mock.aclose = AsyncMock()
+    return mock
+
+
+@pytest.mark.asyncio
+async def test_complete_success(mock_httpx_client):
+    """Test successful completion with valid JSON response."""
+    # Mock successful Ollama response
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "response": json.dumps({
+            "store_name": "Costco",
+            "total": 142.37,
+            "items": ["bananas", "milk", "eggs"]
+        })
+    }
+    mock_httpx_client.post = AsyncMock(return_value=mock_response)
+
+    # Patch httpx.AsyncClient to return our mock
+    with patch("src.services.llm.client.httpx.AsyncClient", return_value=mock_httpx_client):
+        client = OllamaClient()
+
+        result = await client.complete(
+            prompt="Parse this receipt",
+            system_prompt="You are a receipt parser",
+            response_schema=TestReceipt,
+        )
+
+        # Verify result
+        assert isinstance(result, TestReceipt)
+        assert result.store_name == "Costco"
+        assert result.total == 142.37
+        assert result.items == ["bananas", "milk", "eggs"]
+
+        # Verify API was called correctly
+        mock_httpx_client.post.assert_called_once()
+        call_args = mock_httpx_client.post.call_args
+        assert call_args[0][0] == "/api/generate"
+        assert call_args[1]["json"]["model"] == "llama3.1:8b"
+        assert call_args[1]["json"]["prompt"] == "Parse this receipt"
+        assert call_args[1]["json"]["system"] == "You are a receipt parser"
+        assert call_args[1]["json"]["stream"] is False
+        assert call_args[1]["json"]["format"] == "json"
+
+
+@pytest.mark.asyncio
+async def test_complete_malformed_json(mock_httpx_client):
+    """Test handling of malformed JSON response that exhausts retries."""
+    # Mock Ollama returning invalid JSON on all attempts
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "response": "This is not valid JSON at all"
+    }
+    mock_httpx_client.post = AsyncMock(return_value=mock_response)
+
+    with patch("src.services.llm.client.httpx.AsyncClient", return_value=mock_httpx_client):
+        client = OllamaClient()
+
+        with pytest.raises(LLMResponseError) as exc_info:
+            await client.complete(
+                prompt="Parse this receipt",
+                system_prompt="You are a receipt parser",
+                response_schema=TestReceipt,
+            )
+
+        # Verify error details
+        error = exc_info.value
+        assert "3 attempts" in str(error)  # MAX_RETRIES=2 means 3 total attempts
+        assert error.response == "This is not valid JSON at all"
+        assert len(error.validation_errors) == 3  # One error per attempt
+
+        # Verify retry behavior - should have been called 3 times (initial + 2 retries)
+        assert mock_httpx_client.post.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_complete_validation_error_with_retry_success(mock_httpx_client):
+    """Test validation error on first attempt, success on retry."""
+    # First call returns invalid schema
+    invalid_response = MagicMock()
+    invalid_response.status_code = 200
+    invalid_response.json.return_value = {
+        "response": json.dumps({
+            "store_name": "Costco",
+            # Missing required 'total' field
+            "items": ["bananas"]
+        })
+    }
+
+    # Second call returns valid schema
+    valid_response = MagicMock()
+    valid_response.status_code = 200
+    valid_response.json.return_value = {
+        "response": json.dumps({
+            "store_name": "Costco",
+            "total": 5.99,
+            "items": ["bananas"]
+        })
+    }
+
+    # Configure mock to return different responses on successive calls
+    mock_httpx_client.post = AsyncMock(side_effect=[invalid_response, valid_response])
+
+    with patch("src.services.llm.client.httpx.AsyncClient", return_value=mock_httpx_client):
+        client = OllamaClient()
+
+        result = await client.complete(
+            prompt="Parse this receipt",
+            system_prompt="You are a receipt parser",
+            response_schema=TestReceipt,
+        )
+
+        # Verify success on retry
+        assert isinstance(result, TestReceipt)
+        assert result.store_name == "Costco"
+        assert result.total == 5.99
+
+        # Verify retry happened - called twice
+        assert mock_httpx_client.post.call_count == 2
+
+        # Verify second call included correction context
+        second_call_args = mock_httpx_client.post.call_args_list[1]
+        second_prompt = second_call_args[1]["json"]["prompt"]
+        assert "Parse this receipt" in second_prompt
+        assert "Previous response failed validation" in second_prompt
+
+
+@pytest.mark.asyncio
+async def test_complete_validation_exhausts_retries(mock_httpx_client):
+    """Test validation error on all retry attempts."""
+    # All calls return schema with missing required field
+    invalid_response = MagicMock()
+    invalid_response.status_code = 200
+    invalid_response.json.return_value = {
+        "response": json.dumps({
+            "store_name": "Costco",
+            # Missing required 'total' field - will always fail validation
+        })
+    }
+    mock_httpx_client.post = AsyncMock(return_value=invalid_response)
+
+    with patch("src.services.llm.client.httpx.AsyncClient", return_value=mock_httpx_client):
+        client = OllamaClient()
+
+        with pytest.raises(LLMResponseError) as exc_info:
+            await client.complete(
+                prompt="Parse this receipt",
+                system_prompt="You are a receipt parser",
+                response_schema=TestReceipt,
+            )
+
+        # Verify error details
+        error = exc_info.value
+        assert "3 attempts" in str(error)
+        assert len(error.validation_errors) == 3
+
+        # All validation errors should mention missing field
+        for validation_error in error.validation_errors:
+            assert "total" in validation_error.lower() or "required" in validation_error.lower()
+
+
+@pytest.mark.asyncio
+async def test_complete_connection_timeout(mock_httpx_client):
+    """Test handling of connection timeout."""
+    # Simulate timeout on connection
+    mock_httpx_client.post = AsyncMock(side_effect=httpx.TimeoutException("Connect timeout"))
+
+    with patch("src.services.llm.client.httpx.AsyncClient", return_value=mock_httpx_client):
+        client = OllamaClient()
+
+        with pytest.raises(LLMUnavailableError) as exc_info:
+            await client.complete(
+                prompt="Parse this receipt",
+                system_prompt="You are a receipt parser",
+                response_schema=TestReceipt,
+            )
+
+        # Verify error message mentions timeout
+        assert "timed out" in str(exc_info.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_complete_connection_refused(mock_httpx_client):
+    """Test handling of connection refused (Ollama not running)."""
+    # Simulate connection refused
+    mock_httpx_client.post = AsyncMock(
+        side_effect=httpx.ConnectError("Connection refused")
+    )
+
+    with patch("src.services.llm.client.httpx.AsyncClient", return_value=mock_httpx_client):
+        client = OllamaClient()
+
+        with pytest.raises(LLMUnavailableError) as exc_info:
+            await client.complete(
+                prompt="Parse this receipt",
+                system_prompt="You are a receipt parser",
+                response_schema=TestReceipt,
+            )
+
+        # Verify error message mentions connection failure
+        assert "connect" in str(exc_info.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_complete_http_error_status(mock_httpx_client):
+    """Test handling of HTTP error status codes (4xx, 5xx)."""
+    # Simulate 500 Internal Server Error
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "500 Server Error",
+        request=MagicMock(),
+        response=mock_response,
+    )
+    mock_httpx_client.post = AsyncMock(return_value=mock_response)
+
+    with patch("src.services.llm.client.httpx.AsyncClient", return_value=mock_httpx_client):
+        client = OllamaClient()
+
+        with pytest.raises(LLMUnavailableError) as exc_info:
+            await client.complete(
+                prompt="Parse this receipt",
+                system_prompt="You are a receipt parser",
+                response_schema=TestReceipt,
+            )
+
+        # Verify error message mentions status code
+        assert "500" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_is_available_success(mock_httpx_client):
+    """Test health check returns True when Ollama is available."""
+    # Mock successful health check
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = MagicMock()
+    mock_httpx_client.get = AsyncMock(return_value=mock_response)
+
+    with patch("src.services.llm.client.httpx.AsyncClient", return_value=mock_httpx_client):
+        client = OllamaClient()
+
+        result = await client.is_available()
+
+        assert result is True
+        mock_httpx_client.get.assert_called_once_with("/api/tags")
+
+
+@pytest.mark.asyncio
+async def test_is_available_connection_refused(mock_httpx_client):
+    """Test health check returns False when Ollama is unreachable."""
+    # Simulate connection refused
+    mock_httpx_client.get = AsyncMock(
+        side_effect=httpx.ConnectError("Connection refused")
+    )
+
+    with patch("src.services.llm.client.httpx.AsyncClient", return_value=mock_httpx_client):
+        client = OllamaClient()
+
+        result = await client.is_available()
+
+        # Should return False, not raise exception
+        assert result is False
+
+
+@pytest.mark.asyncio
+async def test_is_available_timeout(mock_httpx_client):
+    """Test health check returns False on timeout."""
+    # Simulate timeout
+    mock_httpx_client.get = AsyncMock(
+        side_effect=httpx.TimeoutException("Timeout")
+    )
+
+    with patch("src.services.llm.client.httpx.AsyncClient", return_value=mock_httpx_client):
+        client = OllamaClient()
+
+        result = await client.is_available()
+
+        # Should return False, not raise exception
+        assert result is False
+
+
+@pytest.mark.asyncio
+async def test_is_available_http_error(mock_httpx_client):
+    """Test health check returns False on HTTP error status."""
+    # Simulate 503 Service Unavailable
+    mock_response = MagicMock()
+    mock_response.status_code = 503
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "503 Service Unavailable",
+        request=MagicMock(),
+        response=mock_response,
+    )
+    mock_httpx_client.get = AsyncMock(return_value=mock_response)
+
+    with patch("src.services.llm.client.httpx.AsyncClient", return_value=mock_httpx_client):
+        client = OllamaClient()
+
+        result = await client.is_available()
+
+        # Should return False, not raise exception
+        assert result is False
+
+
+@pytest.mark.asyncio
+async def test_client_timeout_configuration(mock_httpx_client):
+    """Test that httpx client is configured with correct timeouts."""
+    with patch("src.services.llm.client.httpx.AsyncClient") as mock_client_class:
+        mock_client_class.return_value = mock_httpx_client
+
+        client = OllamaClient()
+
+        # Verify AsyncClient was instantiated with correct timeout config
+        mock_client_class.assert_called_once()
+        call_kwargs = mock_client_class.call_args[1]
+
+        assert "timeout" in call_kwargs
+        timeout = call_kwargs["timeout"]
+        assert isinstance(timeout, httpx.Timeout)
+        assert timeout.connect == 5.0
+        assert timeout.read == 120.0
+
+
+@pytest.mark.asyncio
+async def test_async_context_manager(mock_httpx_client):
+    """Test that OllamaClient supports async context manager protocol."""
+    mock_httpx_client.aclose = AsyncMock()
+
+    with patch("src.services.llm.client.httpx.AsyncClient", return_value=mock_httpx_client):
+        async with OllamaClient() as client:
+            assert client is not None
+
+        # Verify client was closed on exit
+        mock_httpx_client.aclose.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_close_method(mock_httpx_client):
+    """Test explicit close method."""
+    mock_httpx_client.aclose = AsyncMock()
+
+    with patch("src.services.llm.client.httpx.AsyncClient", return_value=mock_httpx_client):
+        client = OllamaClient()
+        await client.close()
+
+        # Verify underlying httpx client was closed
+        mock_httpx_client.aclose.assert_called_once()


### PR DESCRIPTION
## Work in Progress

Closes #364

[Phase 2A] Implement Ollama HTTP client

**Time Estimate**: 2hr

**Description**:
Create an async LLM client abstraction with an OllamaClient implementation using httpx. Includes response validation against Pydantic schemas with retry logic for malformed output. This is the core LLM infrastructure for receipt parsing and future prompt work.

**Claude Context**:
Files to Read:
- src/config.py (Ollama settings added in prior issue)
- src/services/auth_service.py (existing service pattern reference)
- docs/FreshUp-ADR.md (Section 2A: LLM Abstraction Layer specification)

Files to Modify:
- src/services/llm/__init__.py (create)
- src/services/llm/client.py (create — base class + OllamaClient)
- src/services/llm/exceptions.py (create)
- tests/unit/services/test_llm_client.py (create)
- requirements.txt (add httpx)

Related Issues: #363 (Ollama configuration settings)

**Acceptance Criteria**:
- [ ] LLMClient base class with abstract `complete(prompt: str, system_prompt: str, response_schema: type[BaseModel]) -> BaseModel` method
- [ ] OllamaClient implementation using httpx AsyncClient with configurable base_url from settings
- [ ] Health check method `is_available() -> bool` that hits Ollama API root
- [ ] Connect timeout 5s, read timeout 120s configured on httpx client
- [ ] Response parsed as JSON and validated against provided Pydantic response_schema
- [ ] On validation failure: retry up to 2 times with validation error appended to prompt as correction context
- [ ] LLMUnavailableError raised when Ollama is unreachable (connection refused, timeout)
- [ ] LLMResponseError raised when output fails validation after all retries
- [ ] Unit tests mock httpx client entirely — no real HTTP calls: `pytest tests/unit/services/test_llm_client.py -v`
- [ ] Tests cover: successful response, malformed JSON, validation error with retry success, validation error with retry exhaustion, connection timeout, connection refused

**Verification Commands**:
```bash
pip install httpx
pytest tests/unit/services/test_llm_client.py -v
grep -r "class OllamaClient" src/services/llm/
```

**Done Definition**: Done when OllamaClient can call Ollama, validate responses against a Pydantic schema, retry on validation failures, and all unit tests pass with mocked HTTP.

**Scope Boundary**:
- DO: Create LLMClient base class and OllamaClient implementation
- DO: Add custom exceptions (LLMUnavailableError, LLMResponseError)
- DO: Implement retry logic with correction context
- DO: Write comprehensive unit tests with mocked httpx
- DO NOT: Create prompt templates (Phase 2A / "[Phase 2A] Create receipt parsing prompt template")
- DO NOT: Integrate with background worker yet (Phase 2A / "[Phase 2A] Implement background task worker")
- DO NOT: Add provider registries or strategy patterns — keep abstraction thin per ADR

**Dependencies**: After #363

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**7** files, **2** commits (+4 added, ~3 modified, -0 deleted)
- `M` src/routers/scraper.py
- `M` src/schemas/scraper.py
- `A` src/services/llm/__init__.py
- `A` src/services/llm/client.py
- `A` src/services/llm/exceptions.py
- `M` tests/routers/test_scraper.py
- `A` tests/unit/services/test_llm_client.py

### Commits
- 07120c2 feat: [Phase 2A] Implement Ollama HTTP client
- c211e84 chore: initialize work on #364 [Phase 2A] Implement Ollama HTTP client
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-03-29T18:32:18Z:**
- Created: #377 
- Updated: none