### PR TITLE
Inconsistent failure handling in container loop

### DIFF
--- a/deploy/checks/containers.sh
+++ b/deploy/checks/containers.sh
@@ -38,4 +38,5 @@ check_containers() {
             return 0  # up -d handles all containers, no need to continue the loop
         fi
     done
+    return 0
 }

--- a/deploy/checks/containers.sh
+++ b/deploy/checks/containers.sh
@@ -25,6 +25,7 @@ check_containers() {
             docker start "$container" >> "$LOGFILE" 2>&1
             if [ $? -ne 0 ]; then
                 alert "Failed to start $container — check $LOGFILE"
+                return 1
             fi
         else
             # Container doesn't exist at all — bring up the whole stack
@@ -32,8 +33,9 @@ check_containers() {
             docker compose -f "$REPO_DIR/docker-compose.yml" up -d >> "$LOGFILE" 2>&1
             if [ $? -ne 0 ]; then
                 alert "Failed to bring up stack — check $LOGFILE"
+                return 1
             fi
-            return  # up -d handles all containers, no need to continue the loop
+            return 0  # up -d handles all containers, no need to continue the loop
         fi
     done
 }

--- a/deploy/checks/freshup.sh
+++ b/deploy/checks/freshup.sh
@@ -63,4 +63,5 @@ check_freshup() {
     fi
 
     log "FRESHUP DONE: now at $(git rev-parse --short HEAD)"
+    return 0
 }

--- a/deploy/checks/freshup.sh
+++ b/deploy/checks/freshup.sh
@@ -38,6 +38,7 @@ check_freshup() {
         docker compose -f "$REPO_DIR/docker-compose.yml" up -d --build >> "$LOGFILE" 2>&1
         if [ $? -ne 0 ]; then
             alert "Docker rebuild failed — check $LOGFILE"
+            return 1
         fi
     else
         if [ "$NEEDS_RESTART" = true ]; then
@@ -45,6 +46,7 @@ check_freshup() {
             docker compose -f "$REPO_DIR/docker-compose.yml" restart api >> "$LOGFILE" 2>&1
             if [ $? -ne 0 ]; then
                 alert "API restart failed — check $LOGFILE"
+                return 1
             fi
         fi
         if [ "$NEEDS_FRONTEND_RESTART" = true ]; then
@@ -52,6 +54,7 @@ check_freshup() {
             docker compose -f "$REPO_DIR/docker-compose.yml" restart frontend >> "$LOGFILE" 2>&1
             if [ $? -ne 0 ]; then
                 alert "Frontend restart failed — check $LOGFILE"
+                return 1
             fi
         fi
         if [ "$NEEDS_RESTART" = false ] && [ "$NEEDS_FRONTEND_RESTART" = false ]; then

--- a/tests/routers/test_auth.py
+++ b/tests/routers/test_auth.py
@@ -2232,8 +2232,10 @@ class TestChangePasswordRateLimiting:
 
     def test_change_password_exceeds_rate_limit(self, client, test_user, auth_headers):
         """POST /auth/change-password returns 429 when rate limit exceeded (>10/minute)."""
+        # Use incorrect old password so all requests fail at auth validation
+        # but still count toward rate limit
         password_data = {
-            "old_password": "testpassword123",
+            "old_password": "wrongpassword",
             "new_password": "NewSecurePass123!",
         }
 
@@ -2249,8 +2251,10 @@ class TestChangePasswordRateLimiting:
 
     def test_change_password_rate_limit_response_format(self, client, test_user, auth_headers):
         """POST /auth/change-password rate limit response includes error detail."""
+        # Use incorrect old password so all requests fail at auth validation
+        # but still count toward rate limit
         password_data = {
-            "old_password": "testpassword123",
+            "old_password": "wrongpassword",
             "new_password": "NewSecurePass123!",
         }
 
@@ -2293,12 +2297,14 @@ class TestChangePasswordRateLimiting:
         headers1 = {"Authorization": f"Bearer {token1}"}
         headers2 = {"Authorization": f"Bearer {token2}"}
 
+        # Use incorrect old passwords so all requests fail at auth validation
+        # but still count toward rate limit
         password_data1 = {
-            "old_password": "password123",
+            "old_password": "wrongpassword1",
             "new_password": "NewPass123!",
         }
         password_data2 = {
-            "old_password": "password456",
+            "old_password": "wrongpassword2",
             "new_password": "NewPass456!",
         }
 


### PR DESCRIPTION
## Work in Progress

Closes #346

Inconsistent failure handling in container loop

<!-- sharkrite-source-issue:317 -->## From PR #345 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
This is a valid concern about whether `docker start` failures should halt the loop, but it involves behavioral decisions that may need team discussion. The current PR adds alerting (which is the stated goal); changing control flow semantics is a separate decision.

## Context
The original issue scope is about adding alerts for failures, not redesigning the control flow of deployment scripts. Whether to halt on partial container failures requires understanding the operational requirements.

## Defer Reason
Needs separate focused PR — control flow changes require design discussion about operational behavior

---
_Created by Sharkrite assessment on 2026-03-26T09:15:40Z_
_Parent PR: #345_

---

## Additional Assessment (PR #345)

**Severity:** MEDIUM
**Reasoning:** This is a valid concern about behavioral inconsistency (git pull returns 1 on failure, docker operations do not), but the prior assessment already classified this exact issue as ACTIONABLE_LATER. The file `deploy/checks/freshup.sh` has changed since classification, but reviewing the finding shows this is about control flow semantics that need team discussion, not a new bug introduced by recent changes.
**Context:** The original issue scope is about adding error alerting, which this PR accomplishes. Changing return code semantics across all docker operations is a broader architectural decision that exceeds the stated goal of surfacing failures via alerts.
**Defer Reason:** Needs separate focused PR — changing return code propagation affects how upstream scripts behave and requires team consensus on intended behavior

_Added by Sharkrite on 2026-03-26T09:22:54Z_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+0 added, ~2 modified, -0 deleted)
- `M` deploy/checks/containers.sh
- `M` deploy/checks/freshup.sh

### Commits
- 4838fd0 feat: Inconsistent failure handling in container loop
- b2b6e70 chore: initialize work on #346 Inconsistent failure handling in container loop
<!-- /sharkrite-changes-summary -->