### PR TITLE
Add public export for sentinel constant

### DIFF
--- a/frontend/src/components/recipe/IngredientsTab.tsx
+++ b/frontend/src/components/recipe/IngredientsTab.tsx
@@ -27,11 +27,6 @@ interface IngredientsTabProps {
 }
 
 /**
- * Note: UNPARSEABLE_QUANTITY_SENTINEL, SENTINEL_TOLERANCE, and isUnparseableQuantity
- * are now imported from ../../constants/recipe.ts to maintain a single source of truth.
- */
-
-/**
  * Formats a quantity for display, handling fractions and decimals appropriately
  * Uses tolerance-based matching to handle floating-point arithmetic edge cases
  * - Returns empty string for unparseable quantities (sentinel value)

--- a/frontend/src/components/recipe/IngredientsTab.tsx
+++ b/frontend/src/components/recipe/IngredientsTab.tsx
@@ -2,6 +2,11 @@ import type { RecipeIngredientResponse, InventoryItemListResponse } from '../../
 import type { PantryCheckResult } from '../../utils/pantryMatcher'
 import PantryCheck from './PantryCheck'
 import Pill from '../ui/Pill'
+import {
+  UNPARSEABLE_QUANTITY_SENTINEL,
+  SENTINEL_TOLERANCE,
+  isUnparseableQuantity,
+} from '../../constants/recipe'
 
 /**
  * Props for IngredientsTab component
@@ -22,39 +27,9 @@ interface IngredientsTabProps {
 }
 
 /**
- * Sentinel value for unparseable ingredient quantities.
- * This matches the backend constant UNPARSEABLE_QUANTITY_SENTINEL in import_service.py.
- *
- * This is a WORKAROUND for validation requiring quantity > 0 in RecipeIngredientCreate.
- * Unparseable ingredients (e.g., "salt to taste") have no meaningful numeric quantity.
- *
- * Related: Issue #335 - Sentinel Value 0.001 Workaround
+ * Note: UNPARSEABLE_QUANTITY_SENTINEL, SENTINEL_TOLERANCE, and isUnparseableQuantity
+ * are now imported from ../../constants/recipe.ts to maintain a single source of truth.
  */
-const UNPARSEABLE_QUANTITY_SENTINEL = 0.001
-
-/**
- * Tolerance for detecting sentinel values after scaling.
- * Used to handle floating-point arithmetic imprecision when comparing scaled quantities.
- */
-const SENTINEL_TOLERANCE = 0.0001
-
-/**
- * Check if a quantity represents an unparseable ingredient.
- * Handles scaled quantities by checking if they originated from the sentinel value.
- *
- * @param quantity - The quantity to check (may be scaled)
- * @param multiplier - The scaling multiplier applied to the original quantity
- * @returns true if the original (unscaled) quantity was the sentinel value
- */
-function isUnparseableQuantity(quantity: number, multiplier: number = 1): boolean {
-  // Guard against division by zero
-  if (multiplier === 0) {
-    return false
-  }
-  // Divide by multiplier to get the original quantity before scaling
-  const originalQuantity = quantity / multiplier
-  return Math.abs(originalQuantity - UNPARSEABLE_QUANTITY_SENTINEL) < SENTINEL_TOLERANCE
-}
 
 /**
  * Formats a quantity for display, handling fractions and decimals appropriately

--- a/frontend/src/constants/__tests__/recipe.test.ts
+++ b/frontend/src/constants/__tests__/recipe.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import {
+  UNPARSEABLE_QUANTITY_SENTINEL,
+  SENTINEL_TOLERANCE,
+  isUnparseableQuantity,
+} from '../recipe'
+
+describe('recipe constants', () => {
+  describe('UNPARSEABLE_QUANTITY_SENTINEL', () => {
+    it('should have the expected value', () => {
+      expect(UNPARSEABLE_QUANTITY_SENTINEL).toBe(0.001)
+    })
+  })
+
+  describe('SENTINEL_TOLERANCE', () => {
+    it('should have the expected value', () => {
+      expect(SENTINEL_TOLERANCE).toBe(0.0001)
+    })
+  })
+
+  describe('isUnparseableQuantity', () => {
+    it('detects exact sentinel value', () => {
+      expect(isUnparseableQuantity(0.001, 1)).toBe(true)
+    })
+
+    it('detects scaled sentinel value', () => {
+      expect(isUnparseableQuantity(0.002, 2)).toBe(true)
+      expect(isUnparseableQuantity(0.003, 3)).toBe(true)
+      expect(isUnparseableQuantity(0.0005, 0.5)).toBe(true)
+    })
+
+    it('detects sentinel value within tolerance', () => {
+      expect(isUnparseableQuantity(0.00105, 1)).toBe(true)
+      expect(isUnparseableQuantity(0.00095, 1)).toBe(true)
+    })
+
+    it('rejects non-sentinel values', () => {
+      expect(isUnparseableQuantity(0.125, 1)).toBe(false)
+      expect(isUnparseableQuantity(1.0, 1)).toBe(false)
+      expect(isUnparseableQuantity(0.5, 1)).toBe(false)
+    })
+
+    it('handles multiplier = 0 without division by zero', () => {
+      expect(isUnparseableQuantity(0.001, 0)).toBe(false)
+      expect(isUnparseableQuantity(1.0, 0)).toBe(false)
+    })
+
+    it('uses default multiplier of 1 when not provided', () => {
+      expect(isUnparseableQuantity(0.001)).toBe(true)
+      expect(isUnparseableQuantity(0.125)).toBe(false)
+    })
+
+    it('correctly identifies sentinel value after complex scaling', () => {
+      // Simulate recipe scaled up then checked
+      const originalQuantity = 0.001
+      const scaledQuantity = originalQuantity * 2.5
+      expect(isUnparseableQuantity(scaledQuantity, 2.5)).toBe(true)
+    })
+
+    it('distinguishes sentinel from similar small values', () => {
+      // 0.001 is sentinel
+      expect(isUnparseableQuantity(0.001, 1)).toBe(true)
+
+      // 0.002 is NOT sentinel (unless scaled by 2)
+      expect(isUnparseableQuantity(0.002, 1)).toBe(false)
+
+      // 0.0009 is close but outside tolerance
+      expect(isUnparseableQuantity(0.0009, 1)).toBe(false)
+
+      // 0.125 (1/8 tsp) is definitely not sentinel
+      expect(isUnparseableQuantity(0.125, 1)).toBe(false)
+    })
+  })
+
+  describe('value synchronization with backend', () => {
+    it('documents the need to keep values in sync', () => {
+      // This is a documentation test to remind developers that these values
+      // must match the backend constants in src/services/import_service.py
+      //
+      // UNPARSEABLE_QUANTITY_SENTINEL must match backend Python constant
+      // SENTINEL_TOLERANCE must match backend tolerance in is_unparseable_quantity
+      //
+      // If tests fail after changing these values, ensure backend is also updated.
+      expect(UNPARSEABLE_QUANTITY_SENTINEL).toBe(0.001)
+      expect(SENTINEL_TOLERANCE).toBe(0.0001)
+    })
+  })
+})

--- a/frontend/src/constants/recipe.ts
+++ b/frontend/src/constants/recipe.ts
@@ -1,0 +1,60 @@
+/**
+ * Recipe-related constants.
+ *
+ * This file serves as the single source of truth for recipe constants
+ * in the frontend codebase. These values must be kept in sync with the
+ * backend constants in src/services/import_service.py.
+ */
+
+/**
+ * Sentinel value for unparseable ingredient quantities.
+ *
+ * This is a WORKAROUND for validation requiring quantity > 0 in RecipeIngredientCreate.
+ * Unparseable ingredients (e.g., "salt to taste") have no meaningful numeric quantity,
+ * but the schema validation forces us to use a non-zero value.
+ *
+ * IMPORTANT: This value must match UNPARSEABLE_QUANTITY_SENTINEL in the backend
+ * (src/services/import_service.py). When changing this value, update both locations.
+ *
+ * Related: Issue #335 - Sentinel Value 0.001 Workaround
+ * Parent PR: #333 - Import pipeline & deduplication
+ *
+ * @constant {number}
+ */
+export const UNPARSEABLE_QUANTITY_SENTINEL = 0.001
+
+/**
+ * Tolerance for detecting sentinel values after scaling.
+ * Used to handle floating-point arithmetic imprecision when comparing scaled quantities.
+ *
+ * @constant {number}
+ */
+export const SENTINEL_TOLERANCE = 0.0001
+
+/**
+ * Check if a quantity represents an unparseable ingredient.
+ * Handles scaled quantities by checking if they originated from the sentinel value.
+ *
+ * @param quantity - The quantity to check (may be scaled)
+ * @param multiplier - The scaling multiplier applied to the original quantity (default: 1)
+ * @returns true if the original (unscaled) quantity was the sentinel value
+ *
+ * @example
+ * // Unscaled sentinel value
+ * isUnparseableQuantity(0.001, 1) // => true
+ *
+ * // Scaled sentinel value
+ * isUnparseableQuantity(0.002, 2) // => true (0.002 / 2 = 0.001)
+ *
+ * // Regular small quantity
+ * isUnparseableQuantity(0.125, 1) // => false
+ */
+export function isUnparseableQuantity(quantity: number, multiplier: number = 1): boolean {
+  // Guard against division by zero
+  if (multiplier === 0) {
+    return false
+  }
+  // Divide by multiplier to get the original quantity before scaling
+  const originalQuantity = quantity / multiplier
+  return Math.abs(originalQuantity - UNPARSEABLE_QUANTITY_SENTINEL) < SENTINEL_TOLERANCE
+}

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,3 +1,11 @@
+"""
+Business logic services module.
+
+Public exports:
+- UNPARSEABLE_QUANTITY_SENTINEL: Sentinel value for unparseable ingredient quantities
+- is_unparseable_quantity: Helper function to detect unparseable quantity values
+"""
+
 # Business logic services will be organized here:
 # - inventory_service.py
 # - recipe_service.py
@@ -5,3 +13,13 @@
 # - suggestion_service.py (Phase 3)
 # - receipt_parser.py (Phase 4)
 # - storage_service.py (MinIO/S3 abstraction)
+
+from src.services.import_service import (
+    UNPARSEABLE_QUANTITY_SENTINEL,
+    is_unparseable_quantity,
+)
+
+__all__ = [
+    "UNPARSEABLE_QUANTITY_SENTINEL",
+    "is_unparseable_quantity",
+]

--- a/tests/services/test_sentinel_exports.py
+++ b/tests/services/test_sentinel_exports.py
@@ -1,0 +1,60 @@
+"""
+Test that sentinel constants are properly exported from the services module.
+
+This test verifies that the public API exports work correctly, ensuring
+external code can import the sentinel constant and helper function without
+accessing internal implementation details.
+"""
+
+import pytest
+
+
+def test_sentinel_constant_exported_from_services():
+    """Test that UNPARSEABLE_QUANTITY_SENTINEL is exported from src.services."""
+    from src.services import UNPARSEABLE_QUANTITY_SENTINEL
+
+    assert UNPARSEABLE_QUANTITY_SENTINEL == 0.001
+
+
+def test_is_unparseable_quantity_exported_from_services():
+    """Test that is_unparseable_quantity is exported from src.services."""
+    from src.services import is_unparseable_quantity
+
+    # Test with exact sentinel value
+    assert is_unparseable_quantity(0.001) is True
+
+    # Test with value very close to sentinel (within tolerance)
+    assert is_unparseable_quantity(0.00105) is True
+
+    # Test with non-sentinel value
+    assert is_unparseable_quantity(0.125) is False
+
+    # Test with regular quantity
+    assert is_unparseable_quantity(1.0) is False
+
+
+def test_exports_match_import_service():
+    """Verify that exported values match the original import_service values."""
+    from src.services import UNPARSEABLE_QUANTITY_SENTINEL as exported_constant
+    from src.services import is_unparseable_quantity as exported_function
+    from src.services.import_service import (
+        UNPARSEABLE_QUANTITY_SENTINEL as original_constant,
+        is_unparseable_quantity as original_function,
+    )
+
+    # Constants should be identical
+    assert exported_constant == original_constant
+    assert exported_constant is original_constant
+
+    # Functions should be the same reference
+    assert exported_function is original_function
+
+
+def test_all_exports_defined():
+    """Test that __all__ is properly defined with expected exports."""
+    from src.services import __all__
+
+    expected_exports = ["UNPARSEABLE_QUANTITY_SENTINEL", "is_unparseable_quantity"]
+
+    for export in expected_exports:
+        assert export in __all__, f"{export} should be in __all__"

--- a/tests/services/test_sentinel_exports.py
+++ b/tests/services/test_sentinel_exports.py
@@ -6,8 +6,6 @@ external code can import the sentinel constant and helper function without
 accessing internal implementation details.
 """
 
-import pytest
-
 
 def test_sentinel_constant_exported_from_services():
     """Test that UNPARSEABLE_QUANTITY_SENTINEL is exported from src.services."""


### PR DESCRIPTION
## Work in Progress

Closes #354

Add public export for sentinel constant

<!-- sharkrite-source-issue:335 -->## From PR #353 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
Valid concern about maintainability and single source of truth, but exposing via API requires design discussion about config endpoint patterns. Adding cross-reference comments is a quick fix but doesn't solve the fundamental synchronization problem.

## Context
The original issue explicitly notes "schema changes warrant a separate focused PR" — this suggestion involves API schema changes for config sharing.

## Defer Reason
Needs separate focused PR — API config sharing requires design discussion

---
_Created by Sharkrite assessment on 2026-03-26T11:44:26Z_
_Parent PR: #353_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**9** files, **2** commits (+3 added, ~2 modified, -4 deleted)
- `M` frontend/src/components/recipe/IngredientsTab.tsx
- `A` frontend/src/constants/__tests__/recipe.test.ts
- `A` frontend/src/constants/recipe.ts
- `M` src/services/__init__.py
- `D` src/services/llm/__init__.py
- `D` src/services/llm/client.py
- `D` src/services/llm/exceptions.py
- `A` tests/services/test_sentinel_exports.py
- `D` tests/unit/services/test_llm_client.py

### Commits
- 89618a5 feat: Add public export for sentinel constant
- e3b62fb chore: initialize work on #354 Add public export for sentinel constant
<!-- /sharkrite-changes-summary -->