### PR TITLE
[Phase 2A] Create receipt parsing prompt template

### DIFF
--- a/src/schemas/receipt.py
+++ b/src/schemas/receipt.py
@@ -1,0 +1,131 @@
+"""
+Pydantic schemas for receipt parsing.
+
+Defines the structured output format for LLM-based receipt text parsing.
+Used by OllamaClient to validate receipt parsing results from raw OCR text.
+
+Per ADR Phase 4B: Receipt parsing handles messy OCR output from grocery receipts,
+extracting store name, date, and line items with quantities and prices.
+"""
+
+from datetime import date
+from typing import Optional
+from pydantic import BaseModel, Field, field_validator
+
+from src.schemas.validators import validate_name_not_empty
+
+
+class ReceiptLineItem(BaseModel):
+    """
+    A single line item from a parsed grocery receipt.
+
+    Represents one product purchased, with optional quantity and price data.
+    Fields are optional to handle incomplete or illegible receipt data.
+    """
+
+    item_name: str = Field(
+        ...,
+        min_length=1,
+        max_length=255,
+        description="Name of the purchased item"
+    )
+    quantity: float | None = Field(
+        default=None,
+        gt=0,
+        description="Quantity purchased (if specified on receipt)"
+    )
+    unit_price: float | None = Field(
+        default=None,
+        ge=0,
+        description="Price per unit (if specified on receipt)"
+    )
+    total_price: float | None = Field(
+        default=None,
+        ge=0,
+        description="Total line item price"
+    )
+    category_guess: str | None = Field(
+        default=None,
+        max_length=100,
+        description="LLM's best guess at grocery category (e.g., produce, protein, dairy)"
+    )
+
+    @field_validator('item_name')
+    @classmethod
+    def validate_item_name_not_empty(cls, v: str) -> str:
+        """Ensure item_name is not empty or whitespace only."""
+        result = validate_name_not_empty(v)
+        return result  # type: ignore
+
+    @field_validator('quantity')
+    @classmethod
+    def validate_quantity_positive(cls, v: Optional[float]) -> Optional[float]:
+        """Ensure quantity is positive if provided."""
+        if v is not None and v <= 0:
+            raise ValueError('Quantity must be positive')
+        return v
+
+    @field_validator('unit_price')
+    @classmethod
+    def validate_unit_price_non_negative(cls, v: Optional[float]) -> Optional[float]:
+        """Ensure unit_price is non-negative if provided."""
+        if v is not None and v < 0:
+            raise ValueError('Unit price cannot be negative')
+        return v
+
+    @field_validator('total_price')
+    @classmethod
+    def validate_total_price_non_negative(cls, v: Optional[float]) -> Optional[float]:
+        """Ensure total_price is non-negative if provided."""
+        if v is not None and v < 0:
+            raise ValueError('Total price cannot be negative')
+        return v
+
+    @field_validator('category_guess')
+    @classmethod
+    def validate_category_not_empty(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure category_guess is not empty or whitespace if provided."""
+        if v is not None:
+            result = validate_name_not_empty(v)
+            return result
+        return None
+
+
+class ReceiptParseResult(BaseModel):
+    """
+    Structured output from receipt parsing.
+
+    Represents the complete parsed receipt with store metadata and line items.
+    Used as the response_schema for OllamaClient.complete() during receipt parsing.
+    """
+
+    store_name: str = Field(
+        ...,
+        min_length=1,
+        max_length=255,
+        description="Name of the store from the receipt"
+    )
+    receipt_date: date | None = Field(
+        default=None,
+        description="Date of purchase (may be None if illegible or missing)"
+    )
+    line_items: list[ReceiptLineItem] = Field(
+        ...,
+        min_length=1,
+        description="List of purchased items from the receipt"
+    )
+
+    @field_validator('store_name')
+    @classmethod
+    def validate_store_name_not_empty(cls, v: str) -> str:
+        """Ensure store_name is not empty or whitespace only."""
+        result = validate_name_not_empty(v)
+        return result  # type: ignore
+
+    @field_validator('line_items')
+    @classmethod
+    def validate_line_items_not_empty(cls, v: list[ReceiptLineItem]) -> list[ReceiptLineItem]:
+        """Ensure at least one line item is present."""
+        if not v:
+            raise ValueError('Receipt must have at least one line item')
+        return v

--- a/src/services/llm/prompts/__init__.py
+++ b/src/services/llm/prompts/__init__.py
@@ -1,0 +1,15 @@
+"""
+LLM prompt templates for FreshUp.
+
+Centralized prompt management for all LLM-based features:
+- Receipt parsing (Phase 4)
+- Recipe card OCR (Phase 2B)
+- Photo upload parsing (Phase 2D)
+- Voice command interpretation (Phase 5)
+
+Each module exports system and user prompt templates for its domain.
+"""
+
+__all__ = [
+    'receipt',
+]

--- a/src/services/llm/prompts/receipt.py
+++ b/src/services/llm/prompts/receipt.py
@@ -1,0 +1,76 @@
+"""
+Prompt templates for receipt parsing.
+
+Defines system and user prompts for Ollama-based receipt text parsing.
+Instructs the LLM to extract structured data from raw OCR text.
+
+Per ADR Phase 4B: Receipt parsing uses Tesseract OCR for initial text extraction,
+then Ollama LLM for intelligent parsing into structured line items.
+"""
+
+# System prompt: Instructs LLM to return ONLY valid JSON with no preamble
+SYSTEM_PROMPT = """You are a receipt parsing assistant. Your job is to extract structured data from grocery receipt text.
+
+You must return ONLY valid JSON matching the required schema. Do not include any preamble, explanation, markdown formatting, or additional text. Return ONLY the JSON object.
+
+The JSON schema you must follow:
+{
+  "store_name": "string (required) - Name of the store",
+  "receipt_date": "string in YYYY-MM-DD format (or null if illegible/missing)",
+  "line_items": [
+    {
+      "item_name": "string (required) - Product name",
+      "quantity": number or null - Quantity purchased,
+      "unit_price": number or null - Price per unit,
+      "total_price": number or null - Total line item price,
+      "category_guess": "string or null - Your best guess at the grocery category"
+    }
+  ]
+}
+
+Guidelines:
+- store_name: Extract the store name from the header (e.g., "Costco", "King Soopers", "Save-A-Lot")
+- receipt_date: Parse date into YYYY-MM-DD format. If illegible or missing, use null
+- item_name: Clean and normalize product names (remove extra spaces, fix obvious OCR errors)
+- quantity: Extract if visible. If not specified, use null
+- unit_price: Extract if visible (price per pound, per unit, etc.). If not specified, use null
+- total_price: Extract the line item total price. If not visible, use null
+- category_guess: Classify into common grocery categories:
+  - "produce" - fruits, vegetables
+  - "protein" - meat, poultry, seafood, eggs
+  - "dairy" - milk, cheese, yogurt
+  - "grain" - bread, pasta, rice, cereal
+  - "pantry_staple" - oil, flour, sugar, spices, canned goods
+  - "frozen" - frozen meals, ice cream
+  - "snack" - chips, cookies, candy
+  - "condiment" - sauces, dressings, spreads
+  - "beverage" - drinks (non-dairy)
+  - Use null if you cannot confidently categorize
+
+Handle OCR errors gracefully:
+- "M1LK" → "Milk"
+- "0RANGES" → "Oranges"
+- "CHlCKEN" (lowercase L instead of I) → "Chicken"
+
+Return ONLY the JSON. No markdown, no explanations."""
+
+
+# User prompt template: Accepts raw receipt text for parsing
+USER_PROMPT_TEMPLATE = """Parse the following grocery receipt text into structured JSON:
+
+{receipt_text}
+
+Remember: Return ONLY valid JSON with no additional text or formatting."""
+
+
+def create_user_prompt(receipt_text: str) -> str:
+    """
+    Create a user prompt for receipt parsing.
+
+    Args:
+        receipt_text: Raw text extracted from receipt (from OCR or digital source)
+
+    Returns:
+        Formatted prompt ready to send to LLM
+    """
+    return USER_PROMPT_TEMPLATE.format(receipt_text=receipt_text)

--- a/tests/unit/schemas/test_receipt_schema.py
+++ b/tests/unit/schemas/test_receipt_schema.py
@@ -1,0 +1,373 @@
+"""
+Unit tests for receipt parsing schemas.
+
+Tests cover validation for ReceiptLineItem and ReceiptParseResult,
+including required fields, optional fields, and validation constraints.
+"""
+
+import pytest
+from datetime import date
+from pydantic import ValidationError
+
+from src.schemas.receipt import ReceiptLineItem, ReceiptParseResult
+
+
+class TestReceiptLineItem:
+    """Tests for ReceiptLineItem schema."""
+
+    def test_valid_line_item_with_required_fields_only(self):
+        """Test creation with only required field (item_name)."""
+        item_data = {
+            "item_name": "Organic Bananas",
+        }
+        item = ReceiptLineItem(**item_data)
+        assert item.item_name == "Organic Bananas"
+        assert item.quantity is None
+        assert item.unit_price is None
+        assert item.total_price is None
+        assert item.category_guess is None
+
+    def test_valid_line_item_with_all_fields(self):
+        """Test creation with all fields populated."""
+        item_data = {
+            "item_name": "Chicken Breast",
+            "quantity": 2.5,
+            "unit_price": 5.99,
+            "total_price": 14.98,
+            "category_guess": "protein",
+        }
+        item = ReceiptLineItem(**item_data)
+        assert item.item_name == "Chicken Breast"
+        assert item.quantity == 2.5
+        assert item.unit_price == 5.99
+        assert item.total_price == 14.98
+        assert item.category_guess == "protein"
+
+    def test_item_name_cannot_be_empty(self):
+        """Test that item_name cannot be empty or whitespace only."""
+        item_data = {
+            "item_name": "   ",
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            ReceiptLineItem(**item_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("item_name",) for error in errors)
+
+    def test_quantity_must_be_positive(self):
+        """Test that quantity must be greater than 0 if provided."""
+        item_data = {
+            "item_name": "Test Item",
+            "quantity": 0,
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            ReceiptLineItem(**item_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("quantity",) for error in errors)
+
+    def test_negative_quantity_is_rejected(self):
+        """Test that negative quantity is rejected."""
+        item_data = {
+            "item_name": "Test Item",
+            "quantity": -2.5,
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            ReceiptLineItem(**item_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("quantity",) for error in errors)
+
+    def test_unit_price_must_be_non_negative(self):
+        """Test that unit_price cannot be negative."""
+        item_data = {
+            "item_name": "Test Item",
+            "unit_price": -1.99,
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            ReceiptLineItem(**item_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("unit_price",) for error in errors)
+
+    def test_total_price_must_be_non_negative(self):
+        """Test that total_price cannot be negative."""
+        item_data = {
+            "item_name": "Test Item",
+            "total_price": -5.99,
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            ReceiptLineItem(**item_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("total_price",) for error in errors)
+
+    def test_zero_prices_are_allowed(self):
+        """Test that zero prices are allowed (free items, promotional)."""
+        item_data = {
+            "item_name": "Free Sample",
+            "unit_price": 0.0,
+            "total_price": 0.0,
+        }
+        item = ReceiptLineItem(**item_data)
+        assert item.unit_price == 0.0
+        assert item.total_price == 0.0
+
+    def test_category_guess_cannot_be_empty_string(self):
+        """Test that category_guess cannot be empty or whitespace if provided."""
+        item_data = {
+            "item_name": "Test Item",
+            "category_guess": "   ",
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            ReceiptLineItem(**item_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("category_guess",) for error in errors)
+
+    def test_item_name_is_normalized(self):
+        """Test that item_name whitespace is normalized (NFC form)."""
+        item_data = {
+            "item_name": "  Café Latte  ",
+        }
+        item = ReceiptLineItem(**item_data)
+        # validate_name_not_empty strips whitespace and normalizes to NFC
+        assert item.item_name == "Café Latte"
+
+
+class TestReceiptParseResult:
+    """Tests for ReceiptParseResult schema."""
+
+    def test_valid_receipt_with_all_fields(self):
+        """Test creation with complete receipt data."""
+        receipt_data = {
+            "store_name": "Costco",
+            "receipt_date": "2026-03-28",
+            "line_items": [
+                {
+                    "item_name": "Organic Bananas",
+                    "quantity": 3.0,
+                    "unit_price": 0.59,
+                    "total_price": 1.77,
+                    "category_guess": "produce",
+                },
+                {
+                    "item_name": "Milk 1 Gallon",
+                    "total_price": 3.49,
+                    "category_guess": "dairy",
+                },
+            ],
+        }
+        receipt = ReceiptParseResult(**receipt_data)
+        assert receipt.store_name == "Costco"
+        assert receipt.receipt_date == date(2026, 3, 28)
+        assert len(receipt.line_items) == 2
+        assert receipt.line_items[0].item_name == "Organic Bananas"
+        assert receipt.line_items[1].item_name == "Milk 1 Gallon"
+
+    def test_valid_receipt_without_date(self):
+        """Test receipt parsing when date is illegible or missing."""
+        receipt_data = {
+            "store_name": "King Soopers",
+            "receipt_date": None,
+            "line_items": [
+                {
+                    "item_name": "Eggs",
+                    "total_price": 2.99,
+                },
+            ],
+        }
+        receipt = ReceiptParseResult(**receipt_data)
+        assert receipt.store_name == "King Soopers"
+        assert receipt.receipt_date is None
+        assert len(receipt.line_items) == 1
+
+    def test_store_name_is_required(self):
+        """Test that store_name is required."""
+        receipt_data = {
+            "receipt_date": "2026-03-28",
+            "line_items": [
+                {
+                    "item_name": "Test Item",
+                },
+            ],
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            ReceiptParseResult(**receipt_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("store_name",) for error in errors)
+
+    def test_store_name_cannot_be_empty(self):
+        """Test that store_name cannot be empty or whitespace only."""
+        receipt_data = {
+            "store_name": "   ",
+            "line_items": [
+                {
+                    "item_name": "Test Item",
+                },
+            ],
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            ReceiptParseResult(**receipt_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("store_name",) for error in errors)
+
+    def test_line_items_is_required(self):
+        """Test that line_items is required."""
+        receipt_data = {
+            "store_name": "Test Store",
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            ReceiptParseResult(**receipt_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("line_items",) for error in errors)
+
+    def test_line_items_cannot_be_empty_list(self):
+        """Test that line_items must have at least one item."""
+        receipt_data = {
+            "store_name": "Test Store",
+            "line_items": [],
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            ReceiptParseResult(**receipt_data)
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("line_items",) for error in errors)
+
+    def test_receipt_with_minimal_line_item_data(self):
+        """Test receipt with line items that have only item names."""
+        receipt_data = {
+            "store_name": "Save-A-Lot",
+            "line_items": [
+                {"item_name": "Item 1"},
+                {"item_name": "Item 2"},
+                {"item_name": "Item 3"},
+            ],
+        }
+        receipt = ReceiptParseResult(**receipt_data)
+        assert receipt.store_name == "Save-A-Lot"
+        assert len(receipt.line_items) == 3
+        assert all(item.quantity is None for item in receipt.line_items)
+        assert all(item.total_price is None for item in receipt.line_items)
+
+    def test_store_name_is_normalized(self):
+        """Test that store_name whitespace is normalized."""
+        receipt_data = {
+            "store_name": "  Costco  ",
+            "line_items": [
+                {"item_name": "Test Item"},
+            ],
+        }
+        receipt = ReceiptParseResult(**receipt_data)
+        assert receipt.store_name == "Costco"
+
+    def test_receipt_date_accepts_date_object(self):
+        """Test that receipt_date can be a date object."""
+        receipt_data = {
+            "store_name": "Costco",
+            "receipt_date": date(2026, 3, 28),
+            "line_items": [
+                {"item_name": "Test Item"},
+            ],
+        }
+        receipt = ReceiptParseResult(**receipt_data)
+        assert receipt.receipt_date == date(2026, 3, 28)
+
+    def test_sample_costco_receipt(self):
+        """Test parsing a realistic Costco receipt sample."""
+        receipt_data = {
+            "store_name": "Costco Wholesale",
+            "receipt_date": "2026-03-28",
+            "line_items": [
+                {
+                    "item_name": "Organic Bananas",
+                    "quantity": 3.0,
+                    "unit_price": 0.59,
+                    "total_price": 1.77,
+                    "category_guess": "produce",
+                },
+                {
+                    "item_name": "Kirkland Signature Milk 1 Gal",
+                    "quantity": 2.0,
+                    "unit_price": 3.49,
+                    "total_price": 6.98,
+                    "category_guess": "dairy",
+                },
+                {
+                    "item_name": "Rotisserie Chicken",
+                    "quantity": 1.0,
+                    "total_price": 4.99,
+                    "category_guess": "protein",
+                },
+                {
+                    "item_name": "Kirkland Signature Olive Oil",
+                    "total_price": 15.99,
+                    "category_guess": "pantry_staple",
+                },
+            ],
+        }
+        receipt = ReceiptParseResult(**receipt_data)
+        assert receipt.store_name == "Costco Wholesale"
+        assert receipt.receipt_date == date(2026, 3, 28)
+        assert len(receipt.line_items) == 4
+
+        # Verify specific items
+        bananas = receipt.line_items[0]
+        assert bananas.item_name == "Organic Bananas"
+        assert bananas.quantity == 3.0
+        assert bananas.total_price == 1.77
+        assert bananas.category_guess == "produce"
+
+        chicken = receipt.line_items[2]
+        assert chicken.item_name == "Rotisserie Chicken"
+        assert chicken.quantity == 1.0
+        assert chicken.unit_price is None  # Not specified
+        assert chicken.total_price == 4.99
+
+    def test_sample_receipt_with_ocr_errors(self):
+        """Test parsing a receipt with cleaned OCR errors."""
+        receipt_data = {
+            "store_name": "King Soopers",
+            "receipt_date": None,  # Date was illegible
+            "line_items": [
+                {
+                    "item_name": "Oranges",  # OCR said "0RANGES"
+                    "total_price": 3.99,
+                    "category_guess": "produce",
+                },
+                {
+                    "item_name": "Chicken Breast",  # OCR said "CHlCKEN"
+                    "quantity": 2.5,
+                    "unit_price": 5.99,
+                    "total_price": 14.98,
+                    "category_guess": "protein",
+                },
+            ],
+        }
+        receipt = ReceiptParseResult(**receipt_data)
+        assert receipt.store_name == "King Soopers"
+        assert receipt.receipt_date is None
+        assert len(receipt.line_items) == 2
+        assert receipt.line_items[0].item_name == "Oranges"
+        assert receipt.line_items[1].item_name == "Chicken Breast"
+
+    def test_json_schema_generation(self):
+        """Test that model_json_schema() generates valid JSON schema."""
+        schema = ReceiptParseResult.model_json_schema()
+
+        # Verify top-level structure
+        assert "properties" in schema
+        assert "required" in schema
+
+        # Verify required fields
+        assert "store_name" in schema["required"]
+        assert "line_items" in schema["required"]
+        assert "receipt_date" not in schema["required"]  # Optional
+
+        # Verify properties exist
+        assert "store_name" in schema["properties"]
+        assert "receipt_date" in schema["properties"]
+        assert "line_items" in schema["properties"]


### PR DESCRIPTION
## Work in Progress

Closes #365

[Phase 2A] Create receipt parsing prompt template

**Time Estimate**: 45min

**Description**:
Create the ReceiptParseResult Pydantic schema and receipt parsing prompt template. This defines the structured output format the LLM will produce from raw receipt text and the system/user prompts that guide extraction.

**Claude Context**:
Files to Read:
- docs/FreshUp-ADR.md (Section 2A: Receipt parsing prompt template specification)
- src/schemas/grocery.py (reference for existing schema patterns)

Files to Modify:
- src/schemas/receipt.py (create)
- src/services/llm/prompts/__init__.py (create)
- src/services/llm/prompts/receipt.py (create)
- tests/unit/schemas/test_receipt_schema.py (create)

Related Issues: After "[Phase 2A] Implement Ollama HTTP client" (uses schema for validation)

**Acceptance Criteria**:
- [ ] ReceiptParseResult Pydantic model with fields: store_name (str), receipt_date (date | None), line_items (list[ReceiptLineItem])
- [ ] ReceiptLineItem model with fields: item_name (str), quantity (float | None), unit_price (float | None), total_price (float | None), category_guess (str | None)
- [ ] System prompt instructs model to return ONLY valid JSON matching the schema, no preamble
- [ ] User prompt template accepts raw receipt text and requests structured extraction
- [ ] Schema tests validate parsing of sample receipt data: `pytest tests/unit/schemas/test_receipt_schema.py -v`
- [ ] All fields use appropriate types and Optional markers per ADR spec

**Verification Commands**:
```bash
pytest tests/unit/schemas/test_receipt_schema.py -v
python -c "from src.schemas.receipt import ReceiptParseResult; print(ReceiptParseResult.model_json_schema())"
```

**Done Definition**: Done when ReceiptParseResult schema validates sample receipt data and prompt templates are defined for the receipt parsing use case.

**Scope Boundary**:
- DO: Define ReceiptParseResult and ReceiptLineItem Pydantic models
- DO: Create system prompt for JSON-only output
- DO: Create user prompt template for receipt text input
- DO: Write schema validation tests
- DO NOT: Integrate with OllamaClient (integration happens in worker)
- DO NOT: Create other prompt templates (card OCR, photo parsing — deferred to Phase 2B/2D)

**Dependencies**: After "[Phase 2A] Implement Ollama HTTP client" (can run in parallel — no code dependency, but logically grouped)

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**4** files, **2** commits (+4 added, ~0 modified, -0 deleted)
- `A` src/schemas/receipt.py
- `A` src/services/llm/prompts/__init__.py
- `A` src/services/llm/prompts/receipt.py
- `A` tests/unit/schemas/test_receipt_schema.py

### Commits
- bffab32 feat: [Phase 2A] Create receipt parsing prompt template
- f0137ad chore: initialize work on #365 [Phase 2A] Create receipt parsing prompt template
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-03-29T18:40:53Z:**
- Created: #379 
- Updated: none