### PR TITLE
[Phase 2A] Add ProcessingTask database model

### DIFF
--- a/alembic/versions/ic6ciyat2lmp_add_processing_tasks_table.py
+++ b/alembic/versions/ic6ciyat2lmp_add_processing_tasks_table.py
@@ -1,0 +1,51 @@
+"""add processing tasks table
+
+Revision ID: ic6ciyat2lmp
+Revises: f9d8c7b6a5e4
+Create Date: 2026-03-29 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'ic6ciyat2lmp'
+down_revision: Union[str, None] = 'f9d8c7b6a5e4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create processing_tasks table for tracking async LLM processing jobs."""
+    op.create_table(
+        'processing_tasks',
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('task_type', sa.String(length=50), nullable=False),
+        sa.Column('status', sa.String(length=50), nullable=False),
+        sa.Column('input_reference', sa.Text(), nullable=False),
+        sa.Column('result_reference', sa.Text(), nullable=True),
+        sa.Column('error_message', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
+        sa.Column('updated_at', sa.DateTime(), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
+        sa.Column('completed_at', sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+    # Create compound index for efficient pending task queries
+    with op.batch_alter_table('processing_tasks', schema=None) as batch_op:
+        batch_op.create_index(
+            'ix_processing_tasks_status_created_at',
+            ['status', 'created_at'],
+            unique=False
+        )
+
+
+def downgrade() -> None:
+    """Drop processing_tasks table and its indexes."""
+    with op.batch_alter_table('processing_tasks', schema=None) as batch_op:
+        batch_op.drop_index('ix_processing_tasks_status_created_at')
+
+    op.drop_table('processing_tasks')

--- a/src/db/models/__init__.py
+++ b/src/db/models/__init__.py
@@ -26,6 +26,7 @@ from src.db.models.grocery_list import GroceryListItem, GrocerySource
 from src.db.models.substitution import SubstitutionPreference, SubstitutionContext
 from src.db.models.consumption_pattern import ConsumptionPattern
 from src.db.models.user_recipe import UserRecipeRating
+from src.db.models.processing_task import ProcessingTask, TaskType, TaskStatus
 
 __all__ = [
     "User",
@@ -57,4 +58,7 @@ __all__ = [
     "SubstitutionContext",
     "ConsumptionPattern",
     "UserRecipeRating",
+    "ProcessingTask",
+    "TaskType",
+    "TaskStatus",
 ]

--- a/src/db/models/processing_task.py
+++ b/src/db/models/processing_task.py
@@ -1,0 +1,76 @@
+"""
+ProcessingTask model for tracking async LLM processing jobs.
+
+Tracks receipt parsing and other LLM processing tasks through their lifecycle
+from creation to completion or failure.
+"""
+
+from __future__ import annotations
+
+from enum import Enum as PyEnum
+from uuid import UUID, uuid4
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import String, Text, DateTime, func, Index
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.db.database import Base
+
+
+class TaskType(str, PyEnum):
+    """
+    Type of processing task.
+
+    Currently supports receipt parsing, with room for expansion
+    to other LLM-based processing tasks.
+    """
+    receipt_parse = "receipt_parse"
+
+
+class TaskStatus(str, PyEnum):
+    """
+    Status of a processing task through its lifecycle.
+
+    - pending: Task queued but not yet started
+    - processing: Task currently being processed
+    - completed: Task finished successfully
+    - failed: Task encountered an error
+    """
+    pending = "pending"
+    processing = "processing"
+    completed = "completed"
+    failed = "failed"
+
+
+class ProcessingTask(Base):
+    """
+    Tracks async LLM processing jobs (e.g., receipt parsing).
+
+    Processing tasks queue requests for LLM operations and track their
+    status through the processing lifecycle. Results are stored as text
+    references that can be resolved by the consuming service.
+    """
+    __tablename__ = "processing_tasks"
+
+    # Primary key
+    id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
+
+    # Task classification
+    task_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    status: Mapped[str] = mapped_column(String(50), nullable=False, default=TaskStatus.pending.value)
+
+    # Input/output references
+    input_reference: Mapped[str] = mapped_column(Text, nullable=False)
+    result_reference: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    error_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    # Timestamps
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
+    completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+
+    # Compound index for efficient pending task queries
+    __table_args__ = (
+        Index('ix_processing_tasks_status_created_at', 'status', 'created_at'),
+    )

--- a/src/schemas/task.py
+++ b/src/schemas/task.py
@@ -1,0 +1,80 @@
+"""
+Pydantic schemas for ProcessingTask endpoints.
+
+Defines request/response models for task CRUD operations and status tracking.
+"""
+
+from uuid import UUID
+from datetime import datetime
+from typing import Optional
+from pydantic import BaseModel, Field, field_validator, ConfigDict
+
+from src.db.models.processing_task import TaskType, TaskStatus
+from src.schemas.validators import validate_enum_value
+
+
+class ProcessingTaskCreate(BaseModel):
+    """Request schema for creating a new processing task."""
+
+    task_type: str = Field(..., description="Type of processing task (receipt_parse)")
+    input_reference: str = Field(..., min_length=1, description="Reference to input data (e.g., file path, URL)")
+
+    @field_validator('task_type')
+    @classmethod
+    def validate_task_type_field(cls, v: str) -> str:
+        """Ensure task_type is a valid TaskType enum value."""
+        result = validate_enum_value('task_type', v, TaskType, allow_none=False)
+        return result  # type: ignore
+
+    @field_validator('input_reference')
+    @classmethod
+    def validate_input_reference(cls, v: str) -> str:
+        """Ensure input_reference is not empty."""
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("input_reference cannot be empty or only whitespace")
+        return stripped
+
+
+class ProcessingTaskUpdate(BaseModel):
+    """Request schema for updating a processing task (typically status changes)."""
+
+    status: Optional[str] = Field(default=None, description="Task status")
+    result_reference: Optional[str] = Field(default=None, description="Reference to processing result")
+    error_message: Optional[str] = Field(default=None, description="Error message if task failed")
+    completed_at: Optional[datetime] = Field(default=None, description="Completion timestamp")
+
+    @field_validator('status')
+    @classmethod
+    def validate_status_field(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure status is a valid TaskStatus enum value if provided."""
+        return validate_enum_value('status', v, TaskStatus, allow_none=True)
+
+
+class ProcessingTaskResponse(BaseModel):
+    """Response schema for processing task data."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    task_type: str
+    status: str
+    input_reference: str
+    result_reference: Optional[str]
+    error_message: Optional[str]
+    created_at: datetime
+    updated_at: datetime
+    completed_at: Optional[datetime]
+
+
+class ProcessingTaskListResponse(BaseModel):
+    """Response schema for processing task list items (lightweight)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    task_type: str
+    status: str
+    created_at: datetime
+    updated_at: datetime
+    completed_at: Optional[datetime]


### PR DESCRIPTION
## Work in Progress

Closes #366

[Phase 2A] Add ProcessingTask database model

**Time Estimate**: 45min

**Description**:
Create the ProcessingTask SQLAlchemy model and Alembic migration for tracking async LLM processing jobs. Tasks queue receipt parsing requests and track status through the processing lifecycle.

**Claude Context**:
Files to Read:
- docs/FreshUp-ADR.md (Section 2A: ProcessingTask specification)
- src/db/models/recipe.py (existing model pattern reference)
- src/db/models/__init__.py (model registration pattern)

Files to Modify:
- src/db/models/processing_task.py (create)
- src/db/models/__init__.py (register new model)
- alembic/versions/ (new migration file)
- src/schemas/task.py (create — ProcessingTask schemas)

**Acceptance Criteria**:
- [ ] ProcessingTask model with fields: id (UUID PK), task_type (enum: receipt_parse), status (enum: pending/processing/completed/failed), input_reference (Text), result_reference (Text nullable), error_message (Text nullable), created_at, updated_at, completed_at (nullable)
- [ ] TaskType enum defined with value `receipt_parse`
- [ ] TaskStatus enum defined with values `pending`, `processing`, `completed`, `failed`
- [ ] Alembic migration creates processing_tasks table: `alembic upgrade head`
- [ ] Model registered in src/db/models/__init__.py
- [ ] ProcessingTaskCreate and ProcessingTaskResponse Pydantic schemas defined
- [ ] Migration includes index on (status, created_at) for efficient pending task queries

**Verification Commands**:
```bash
alembic upgrade head
sqlite3 data/freshup.db ".schema processing_tasks"
python -c "from src.db.models import ProcessingTask; print(ProcessingTask.__tablename__)"
```

**Done Definition**: Done when ProcessingTask table exists in database with all specified fields and the model can be imported from src.db.models.

**Scope Boundary**:
- DO: Create ProcessingTask SQLAlchemy model with all fields from ADR spec
- DO: Create Alembic migration
- DO: Create Pydantic schemas for API responses
- DO: Add index on (status, created_at)
- DO NOT: Implement task creation or status update logic (handled in endpoint/worker issues)
- DO NOT: Add result_reference FK to another table — store as text reference for now

**Dependencies**: After "[Phase 2A] Add Ollama configuration settings" (can run in parallel with client issue)

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**4** files, **2** commits (+3 added, ~1 modified, -0 deleted)
- `A` alembic/versions/ic6ciyat2lmp_add_processing_tasks_table.py
- `M` src/db/models/__init__.py
- `A` src/db/models/processing_task.py
- `A` src/schemas/task.py

### Commits
- 63a2cdb feat: [Phase 2A] Add ProcessingTask database model
- f601fa2 chore: initialize work on #366 [Phase 2A] Add ProcessingTask database model
<!-- /sharkrite-changes-summary -->