### PR TITLE
[Phase 2A] Implement receipt upload endpoint

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -11,7 +11,7 @@ from slowapi.errors import RateLimitExceeded
 
 from src.config import get_settings
 from src.db.database import Base, init_engine, get_engine, get_session_factory
-from src.routers import auth_router, users_router, substitutions_router, inventory_router, recipes_router, grocery_router, prepared_foods_router, scraper_router
+from src.routers import auth_router, users_router, substitutions_router, inventory_router, recipes_router, grocery_router, prepared_foods_router, scraper_router, receipts_router
 from src.middleware.rate_limit import limiter
 
 logger = logging.getLogger(__name__)
@@ -104,6 +104,7 @@ app.include_router(recipes_router)
 app.include_router(grocery_router)
 app.include_router(prepared_foods_router)
 app.include_router(scraper_router)
+app.include_router(receipts_router)
 
 
 @app.get("/health")

--- a/src/routers/__init__.py
+++ b/src/routers/__init__.py
@@ -6,6 +6,7 @@
 # - grocery.py (1F)
 # - prepared_foods.py (1G)
 # - scraper.py (2C - scraper/import endpoints)
+# - receipts.py (2A - receipt upload endpoint)
 
 from src.routers.auth import router as auth_router
 from src.routers.users import router as users_router
@@ -15,5 +16,6 @@ from src.routers.recipes import router as recipes_router
 from src.routers.grocery import router as grocery_router
 from src.routers.prepared_foods import router as prepared_foods_router
 from src.routers.scraper import router as scraper_router
+from src.routers.receipts import router as receipts_router
 
-__all__ = ["auth_router", "users_router", "substitutions_router", "inventory_router", "recipes_router", "grocery_router", "prepared_foods_router", "scraper_router"]
+__all__ = ["auth_router", "users_router", "substitutions_router", "inventory_router", "recipes_router", "grocery_router", "prepared_foods_router", "scraper_router", "receipts_router"]


### PR DESCRIPTION
## Work in Progress

Closes #367

[Phase 2A] Implement receipt upload endpoint

**Time Estimate**: 1hr

**Description**:
Create POST /receipts/parse endpoint that accepts raw receipt text, creates a ProcessingTask, and returns 202 Accepted with the task ID. This endpoint does NOT block on Ollama inference — it queues the work for the background worker.

**Claude Context**:
Files to Read:
- src/routers/grocery.py (existing router pattern)
- src/services/grocery_service.py (existing service pattern)
- docs/FreshUp-ADR.md (Section 2A: Receipt upload endpoint specification)

Files to Modify:
- src/routers/receipts.py (create)
- src/services/receipt_service.py (create)
- src/routers/__init__.py (register router)
- src/main.py (include router)
- tests/unit/routers/test_receipts.py (create)

Related Issues: After "[Phase 2A] Add ProcessingTask database model" (creates tasks in that table)

**Acceptance Criteria**:
- [ ] POST /receipts/parse accepts JSON body with `receipt_text: str` field (required, non-empty)
- [ ] Endpoint creates ProcessingTask with task_type=receipt_parse, status=pending, input_reference=receipt_text
- [ ] Returns 202 Accepted with response: `{"task_id": "<uuid>", "status": "pending"}`
- [ ] Returns 422 if receipt_text is empty or missing
- [ ] Requires authentication (uses existing auth middleware)
- [ ] Service layer handles task creation logic: `src/services/receipt_service.py`
- [ ] Unit tests cover: successful creation returns 202, empty text returns 422, missing auth returns 401: `pytest tests/unit/routers/test_receipts.py -v`

**Verification Commands**:
```bash
pytest tests/unit/routers/test_receipts.py -v
# Manual test after running server:
curl -X POST http://localhost:8000/receipts/parse \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"receipt_text": "COSTCO\nBananas 3.99\nMilk 4.50"}'
```

**Done Definition**: Done when POST /receipts/parse creates a pending task and returns 202 with task_id, and all unit tests pass.

**Scope Boundary**:
- DO: Create receipt upload endpoint with text-only input
- DO: Create receipt_service.py following existing service pattern
- DO: Return 202 Accepted immediately (no blocking on LLM)
- DO: Require authentication
- DO NOT: Accept file uploads (deferred to Phase 4B per user feedback)
- DO NOT: Process the receipt — that's the worker's job
- DO NOT: Store files in MinIO (text input only for 2A)

**Dependencies**: After "[Phase 2A] Add ProcessingTask database model"

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**15** files, **2** commits (+0 added, ~11 modified, -4 deleted)
- `M` frontend/src/components/recipe/ActionBar.tsx
- `D` frontend/src/utils/__tests__/batchPromises.test.ts
- `M` frontend/src/utils/__tests__/pantryMatcher.test.ts
- `D` frontend/src/utils/batchPromises.ts
- `M` frontend/src/utils/pantryMatcher.ts
- `M` pytest.ini
- `M` requirements.txt
- `M` src/main.py
- `M` src/routers/__init__.py
- `M` src/routers/scraper.py
- `M` src/services/llm/client.py
- `M` src/services/scraper_service.py
- `D` src/services/task_worker.py
- `M` tests/services/test_scraper_service.py
- `D` tests/unit/services/test_task_worker.py

### Commits
- 66631f3 wip: auto-commit relevant changes for issue #367 (2026-03-29)
- 4b63b3e chore: initialize work on #367 [Phase 2A] Implement receipt upload endpoint
<!-- /sharkrite-changes-summary -->