### PR TITLE
[Phase 2A] Implement task status endpoint

### DIFF
--- a/alembic/versions/1b4a5239984e_add_user_id_to_processing_tasks.py
+++ b/alembic/versions/1b4a5239984e_add_user_id_to_processing_tasks.py
@@ -1,0 +1,37 @@
+"""add user_id to processing_tasks
+
+Revision ID: 1b4a5239984e
+Revises: ic6ciyat2lmp
+Create Date: 2026-03-29 14:18:56.310634
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '1b4a5239984e'
+down_revision: Union[str, None] = 'ic6ciyat2lmp'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add user_id column to processing_tasks table."""
+    with op.batch_alter_table('processing_tasks', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('user_id', sa.UUID(), nullable=False))
+        batch_op.create_foreign_key(
+            'fk_processing_tasks_user_id_users',
+            'users',
+            ['user_id'],
+            ['id']
+        )
+
+
+def downgrade() -> None:
+    """Remove user_id column from processing_tasks table."""
+    with op.batch_alter_table('processing_tasks', schema=None) as batch_op:
+        batch_op.drop_constraint('fk_processing_tasks_user_id_users', type_='foreignkey')
+        batch_op.drop_column('user_id')

--- a/src/db/models/processing_task.py
+++ b/src/db/models/processing_task.py
@@ -12,7 +12,7 @@ from uuid import UUID, uuid4
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import String, Text, DateTime, func, Index
+from sqlalchemy import String, Text, DateTime, func, Index, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column
 
 from src.db.database import Base
@@ -55,6 +55,9 @@ class ProcessingTask(Base):
 
     # Primary key
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
+
+    # User ownership
+    user_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"), nullable=False)
 
     # Task classification
     task_type: Mapped[str] = mapped_column(String(50), nullable=False)

--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,7 @@ from slowapi.errors import RateLimitExceeded
 
 from src.config import get_settings
 from src.db.database import Base, init_engine, get_engine, get_session_factory
-from src.routers import auth_router, users_router, substitutions_router, inventory_router, recipes_router, grocery_router, prepared_foods_router, scraper_router
+from src.routers import auth_router, users_router, substitutions_router, inventory_router, recipes_router, grocery_router, prepared_foods_router, scraper_router, tasks_router
 from src.middleware.rate_limit import limiter
 from src.services.task_worker import background_task_worker
 from src.services.llm.client import OllamaClient
@@ -120,6 +120,7 @@ app.include_router(recipes_router)
 app.include_router(grocery_router)
 app.include_router(prepared_foods_router)
 app.include_router(scraper_router)
+app.include_router(tasks_router)
 
 
 @app.get("/health")

--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,7 @@ from slowapi.errors import RateLimitExceeded
 
 from src.config import get_settings
 from src.db.database import Base, init_engine, get_engine, get_session_factory
-from src.routers import auth_router, users_router, substitutions_router, inventory_router, recipes_router, grocery_router, prepared_foods_router, scraper_router, tasks_router, receipts_router
+from src.routers import auth_router, users_router, substitutions_router, inventory_router, recipes_router, grocery_router, prepared_foods_router, scraper_router
 from src.middleware.rate_limit import limiter
 from src.services.task_worker import background_task_worker
 from src.services.llm.client import OllamaClient
@@ -120,8 +120,6 @@ app.include_router(recipes_router)
 app.include_router(grocery_router)
 app.include_router(prepared_foods_router)
 app.include_router(scraper_router)
-app.include_router(tasks_router)
-app.include_router(receipts_router)
 
 
 @app.get("/health")

--- a/src/main.py
+++ b/src/main.py
@@ -11,7 +11,7 @@ from slowapi.errors import RateLimitExceeded
 
 from src.config import get_settings
 from src.db.database import Base, init_engine, get_engine, get_session_factory
-from src.routers import auth_router, users_router, substitutions_router, inventory_router, recipes_router, grocery_router, prepared_foods_router, scraper_router
+from src.routers import auth_router, users_router, substitutions_router, inventory_router, recipes_router, grocery_router, prepared_foods_router, scraper_router, tasks_router
 from src.middleware.rate_limit import limiter
 
 logger = logging.getLogger(__name__)
@@ -104,6 +104,7 @@ app.include_router(recipes_router)
 app.include_router(grocery_router)
 app.include_router(prepared_foods_router)
 app.include_router(scraper_router)
+app.include_router(tasks_router)
 
 
 @app.get("/health")

--- a/src/routers/__init__.py
+++ b/src/routers/__init__.py
@@ -15,5 +15,6 @@ from src.routers.recipes import router as recipes_router
 from src.routers.grocery import router as grocery_router
 from src.routers.prepared_foods import router as prepared_foods_router
 from src.routers.scraper import router as scraper_router
+from src.routers.tasks import router as tasks_router
 
-__all__ = ["auth_router", "users_router", "substitutions_router", "inventory_router", "recipes_router", "grocery_router", "prepared_foods_router", "scraper_router"]
+__all__ = ["auth_router", "users_router", "substitutions_router", "inventory_router", "recipes_router", "grocery_router", "prepared_foods_router", "scraper_router", "tasks_router"]

--- a/src/routers/__init__.py
+++ b/src/routers/__init__.py
@@ -6,6 +6,7 @@
 # - grocery.py (1F)
 # - prepared_foods.py (1G)
 # - scraper.py (2C - scraper/import endpoints)
+# - tasks.py (2A - async task status endpoints)
 
 from src.routers.auth import router as auth_router
 from src.routers.users import router as users_router
@@ -15,5 +16,6 @@ from src.routers.recipes import router as recipes_router
 from src.routers.grocery import router as grocery_router
 from src.routers.prepared_foods import router as prepared_foods_router
 from src.routers.scraper import router as scraper_router
+from src.routers.tasks import router as tasks_router
 
-__all__ = ["auth_router", "users_router", "substitutions_router", "inventory_router", "recipes_router", "grocery_router", "prepared_foods_router", "scraper_router"]
+__all__ = ["auth_router", "users_router", "substitutions_router", "inventory_router", "recipes_router", "grocery_router", "prepared_foods_router", "scraper_router", "tasks_router"]

--- a/src/routers/__init__.py
+++ b/src/routers/__init__.py
@@ -6,8 +6,6 @@
 # - grocery.py (1F)
 # - prepared_foods.py (1G)
 # - scraper.py (2C - scraper/import endpoints)
-# - tasks.py (2A - async task status endpoints)
-# - receipts.py (2A - receipt upload endpoint)
 
 from src.routers.auth import router as auth_router
 from src.routers.users import router as users_router
@@ -17,7 +15,5 @@ from src.routers.recipes import router as recipes_router
 from src.routers.grocery import router as grocery_router
 from src.routers.prepared_foods import router as prepared_foods_router
 from src.routers.scraper import router as scraper_router
-from src.routers.tasks import router as tasks_router
-from src.routers.receipts import router as receipts_router
 
-__all__ = ["auth_router", "users_router", "substitutions_router", "inventory_router", "recipes_router", "grocery_router", "prepared_foods_router", "scraper_router", "tasks_router", "receipts_router"]
+__all__ = ["auth_router", "users_router", "substitutions_router", "inventory_router", "recipes_router", "grocery_router", "prepared_foods_router", "scraper_router"]

--- a/src/routers/tasks.py
+++ b/src/routers/tasks.py
@@ -54,4 +54,11 @@ def get_task_status(
             detail=f"Task with id {task_id} not found"
         )
 
+    # Verify ownership - users can only access their own tasks
+    if task.user_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Task with id {task_id} not found"
+        )
+
     return ProcessingTaskResponse.model_validate(task)

--- a/src/routers/tasks.py
+++ b/src/routers/tasks.py
@@ -1,0 +1,57 @@
+"""
+Task status endpoints for FreshUp.
+
+Provides endpoints for checking the status of async processing tasks
+(e.g., receipt parsing, recipe scraping). Clients poll these endpoints
+to check task completion.
+"""
+
+import logging
+from uuid import UUID
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from src.db.database import get_db
+from src.db.models.user import User
+from src.schemas.task import ProcessingTaskResponse
+from src.services.task_service import get_task_by_id
+from src.middleware.auth import get_current_user
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/tasks", tags=["tasks"])
+
+
+@router.get("/{task_id}", response_model=ProcessingTaskResponse, status_code=status.HTTP_200_OK)
+def get_task_status(
+    task_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Get the status of a processing task.
+
+    Returns the current status of a task and its result (if completed) or error (if failed).
+    Requires authentication.
+
+    Args:
+        task_id: UUID of the task to retrieve
+        current_user: Authenticated user (from JWT token)
+        db: Database session
+
+    Returns:
+        ProcessingTaskResponse with task status, metadata, and result/error if applicable
+
+    Raises:
+        HTTPException 404: Task not found
+        HTTPException 401: Unauthorized (no valid token)
+    """
+    task = get_task_by_id(task_id, db)
+
+    if not task:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Task with id {task_id} not found"
+        )
+
+    return ProcessingTaskResponse.model_validate(task)

--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -1,0 +1,25 @@
+"""
+Service layer for ProcessingTask operations.
+
+Provides business logic for task status retrieval and management.
+"""
+
+from uuid import UUID
+from typing import Optional
+from sqlalchemy.orm import Session
+
+from src.db.models.processing_task import ProcessingTask
+
+
+def get_task_by_id(task_id: UUID, db: Session) -> Optional[ProcessingTask]:
+    """
+    Retrieve a processing task by its ID.
+
+    Args:
+        task_id: UUID of the task to retrieve
+        db: Database session
+
+    Returns:
+        ProcessingTask object if found, None otherwise
+    """
+    return db.query(ProcessingTask).filter(ProcessingTask.id == task_id).first()

--- a/tests/unit/routers/test_tasks.py
+++ b/tests/unit/routers/test_tasks.py
@@ -111,10 +111,11 @@ def auth_headers(test_user):
 
 
 @pytest.fixture
-def pending_task(db_session):
+def pending_task(db_session, test_user):
     """Create a pending processing task."""
     task = ProcessingTask(
         id=uuid4(),
+        user_id=test_user.id,
         task_type=TaskType.receipt_parse.value,
         status=TaskStatus.pending.value,
         input_reference="s3://bucket/receipts/test-receipt.jpg",
@@ -126,10 +127,11 @@ def pending_task(db_session):
 
 
 @pytest.fixture
-def completed_task(db_session):
+def completed_task(db_session, test_user):
     """Create a completed processing task with result."""
     task = ProcessingTask(
         id=uuid4(),
+        user_id=test_user.id,
         task_type=TaskType.receipt_parse.value,
         status=TaskStatus.completed.value,
         input_reference="s3://bucket/receipts/completed-receipt.jpg",
@@ -143,10 +145,11 @@ def completed_task(db_session):
 
 
 @pytest.fixture
-def failed_task(db_session):
+def failed_task(db_session, test_user):
     """Create a failed processing task with error."""
     task = ProcessingTask(
         id=uuid4(),
+        user_id=test_user.id,
         task_type=TaskType.receipt_parse.value,
         status=TaskStatus.failed.value,
         input_reference="s3://bucket/receipts/bad-receipt.jpg",
@@ -229,10 +232,11 @@ class TestGetTaskStatus:
 
         assert response.status_code == 401
 
-    def test_get_task_with_processing_status(self, client, auth_headers, db_session):
+    def test_get_task_with_processing_status(self, client, auth_headers, db_session, test_user):
         """Test retrieving a task that is currently processing."""
         task = ProcessingTask(
             id=uuid4(),
+            user_id=test_user.id,
             task_type=TaskType.receipt_parse.value,
             status=TaskStatus.processing.value,
             input_reference="s3://bucket/receipts/processing-receipt.jpg",
@@ -249,3 +253,54 @@ class TestGetTaskStatus:
         assert data["result_reference"] is None
         assert data["error_message"] is None
         assert data["completed_at"] is None
+
+    def test_get_task_owned_by_another_user(self, client, db_session):
+        """Test that users cannot access tasks owned by other users."""
+        # Create another user
+        other_user = User(
+            id=uuid4(),
+            name="otheruser",
+            email="other@example.com",
+            hashed_password=hash_password("otherpassword123"),
+            role=UserRole.member.value,
+        )
+        db_session.add(other_user)
+        db_session.commit()
+        db_session.refresh(other_user)
+
+        # Create a task owned by the other user
+        other_task = ProcessingTask(
+            id=uuid4(),
+            user_id=other_user.id,
+            task_type=TaskType.receipt_parse.value,
+            status=TaskStatus.completed.value,
+            input_reference="s3://bucket/receipts/other-user-receipt.jpg",
+            result_reference='{"store_name": "Target", "total": 100.00, "items": []}',
+        )
+        db_session.add(other_task)
+        db_session.commit()
+        db_session.refresh(other_task)
+
+        # Create a test user with their own auth token
+        test_user = User(
+            id=uuid4(),
+            name="testuser",
+            email="test@example.com",
+            hashed_password=hash_password("testpassword123"),
+            role=UserRole.member.value,
+        )
+        db_session.add(test_user)
+        db_session.commit()
+        db_session.refresh(test_user)
+
+        # Create auth headers for test user
+        token = create_access_token(data={"sub": str(test_user.id)})
+        auth_headers = {"Authorization": f"Bearer {token}"}
+
+        # Try to access the other user's task
+        response = client.get(f"/tasks/{other_task.id}", headers=auth_headers)
+
+        # Should return 404 to prevent information disclosure
+        assert response.status_code == 404
+        data = response.json()
+        assert "not found" in data["detail"].lower()

--- a/tests/unit/routers/test_tasks.py
+++ b/tests/unit/routers/test_tasks.py
@@ -1,0 +1,251 @@
+"""
+Unit tests for task status endpoints.
+
+Tests cover:
+- GET /tasks/{task_id}: pending, completed, failed, not found, unauthorized
+"""
+
+import pytest
+from datetime import datetime, timezone
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from uuid import uuid4
+
+from src.db.database import Base, get_db
+from src.db import models
+from src.db.models.user import User, UserRole
+from src.db.models.processing_task import ProcessingTask, TaskType, TaskStatus
+from src.services.auth_service import hash_password, create_access_token
+
+from fastapi import FastAPI
+from src.routers import tasks_router
+
+# Create a test app without lifespan
+app = FastAPI(
+    title="FreshUp",
+    description="Privacy-first kitchen management system",
+    version="0.1.0",
+)
+
+app.include_router(tasks_router)
+
+# In-memory SQLite for testing
+TEST_DATABASE_URL = "sqlite:///:memory:"
+
+
+@pytest.fixture(autouse=True)
+def setup_test_env(monkeypatch):
+    """Set up test environment variables."""
+    from src.config import get_settings
+    get_settings.cache_clear()
+
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars")
+    monkeypatch.setenv("JWT_ALGORITHM", "HS256")
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    monkeypatch.setenv("ACCESS_TOKEN_EXPIRE_MINUTES", "43200")
+
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def db_session():
+    """Create a fresh database session for each test."""
+    from sqlalchemy.pool import StaticPool
+
+    _ = models
+
+    engine = create_engine(
+        TEST_DATABASE_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    Base.metadata.create_all(bind=engine)
+
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture
+def client(db_session):
+    """Create a test client with database session override."""
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = override_get_db
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def test_user(db_session):
+    """Create a test user."""
+    user = User(
+        id=uuid4(),
+        name="testuser",
+        email="test@example.com",
+        hashed_password=hash_password("testpassword123"),
+        role=UserRole.member.value,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def auth_headers(test_user):
+    """Create authentication headers with valid JWT token."""
+    token = create_access_token(data={"sub": str(test_user.id)})
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def pending_task(db_session):
+    """Create a pending processing task."""
+    task = ProcessingTask(
+        id=uuid4(),
+        task_type=TaskType.receipt_parse.value,
+        status=TaskStatus.pending.value,
+        input_reference="s3://bucket/receipts/test-receipt.jpg",
+    )
+    db_session.add(task)
+    db_session.commit()
+    db_session.refresh(task)
+    return task
+
+
+@pytest.fixture
+def completed_task(db_session):
+    """Create a completed processing task with result."""
+    task = ProcessingTask(
+        id=uuid4(),
+        task_type=TaskType.receipt_parse.value,
+        status=TaskStatus.completed.value,
+        input_reference="s3://bucket/receipts/completed-receipt.jpg",
+        result_reference='{"store_name": "Whole Foods", "total": 45.67, "items": []}',
+        completed_at=datetime.now(timezone.utc),
+    )
+    db_session.add(task)
+    db_session.commit()
+    db_session.refresh(task)
+    return task
+
+
+@pytest.fixture
+def failed_task(db_session):
+    """Create a failed processing task with error."""
+    task = ProcessingTask(
+        id=uuid4(),
+        task_type=TaskType.receipt_parse.value,
+        status=TaskStatus.failed.value,
+        input_reference="s3://bucket/receipts/bad-receipt.jpg",
+        error_message="Unable to parse receipt: image quality too low",
+    )
+    db_session.add(task)
+    db_session.commit()
+    db_session.refresh(task)
+    return task
+
+
+class TestGetTaskStatus:
+    """Tests for GET /tasks/{task_id} endpoint."""
+
+    def test_get_pending_task(self, client, auth_headers, pending_task):
+        """Test retrieving a pending task."""
+        response = client.get(f"/tasks/{pending_task.id}", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["id"] == str(pending_task.id)
+        assert data["task_type"] == TaskType.receipt_parse.value
+        assert data["status"] == TaskStatus.pending.value
+        assert data["input_reference"] == pending_task.input_reference
+        assert data["result_reference"] is None
+        assert data["error_message"] is None
+        assert data["completed_at"] is None
+        assert "created_at" in data
+        assert "updated_at" in data
+
+    def test_get_completed_task_with_result(self, client, auth_headers, completed_task):
+        """Test retrieving a completed task with result."""
+        response = client.get(f"/tasks/{completed_task.id}", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["id"] == str(completed_task.id)
+        assert data["status"] == TaskStatus.completed.value
+        assert data["result_reference"] is not None
+        assert data["result_reference"] == completed_task.result_reference
+        assert data["error_message"] is None
+        assert data["completed_at"] is not None
+
+    def test_get_failed_task_with_error(self, client, auth_headers, failed_task):
+        """Test retrieving a failed task with error message."""
+        response = client.get(f"/tasks/{failed_task.id}", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["id"] == str(failed_task.id)
+        assert data["status"] == TaskStatus.failed.value
+        assert data["error_message"] is not None
+        assert data["error_message"] == failed_task.error_message
+        assert data["result_reference"] is None
+
+    def test_get_nonexistent_task(self, client, auth_headers):
+        """Test retrieving a task that doesn't exist returns 404."""
+        nonexistent_id = uuid4()
+        response = client.get(f"/tasks/{nonexistent_id}", headers=auth_headers)
+
+        assert response.status_code == 404
+        data = response.json()
+        assert "not found" in data["detail"].lower()
+
+    def test_get_task_unauthorized(self, client, pending_task):
+        """Test accessing task without authentication returns 401."""
+        response = client.get(f"/tasks/{pending_task.id}")
+
+        assert response.status_code == 401
+        data = response.json()
+        assert "not authenticated" in data["detail"].lower()
+
+    def test_get_task_invalid_token(self, client, pending_task):
+        """Test accessing task with invalid token returns 401."""
+        headers = {"Authorization": "Bearer invalid_token_here"}
+        response = client.get(f"/tasks/{pending_task.id}", headers=headers)
+
+        assert response.status_code == 401
+
+    def test_get_task_with_processing_status(self, client, auth_headers, db_session):
+        """Test retrieving a task that is currently processing."""
+        task = ProcessingTask(
+            id=uuid4(),
+            task_type=TaskType.receipt_parse.value,
+            status=TaskStatus.processing.value,
+            input_reference="s3://bucket/receipts/processing-receipt.jpg",
+        )
+        db_session.add(task)
+        db_session.commit()
+        db_session.refresh(task)
+
+        response = client.get(f"/tasks/{task.id}", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == TaskStatus.processing.value
+        assert data["result_reference"] is None
+        assert data["error_message"] is None
+        assert data["completed_at"] is None


### PR DESCRIPTION
## Work in Progress

Closes #368

[Phase 2A] Implement task status endpoint

**Time Estimate**: 45min

**Description**:
Create GET /tasks/{task_id} endpoint that returns the current status of a ProcessingTask and its result if completed. Allows clients to poll for task completion after submitting a receipt for parsing.

**Claude Context**:
Files to Read:
- src/routers/receipts.py (created in prior issue — add task status here or separate router)
- src/services/receipt_service.py (extend with status lookup)
- src/schemas/task.py (ProcessingTask schemas)

Files to Modify:
- src/routers/tasks.py (create)
- src/services/task_service.py (create)
- src/routers/__init__.py (register router)
- src/main.py (include router)
- tests/unit/routers/test_tasks.py (create)

Related Issues: After "[Phase 2A] Implement receipt upload endpoint"

**Acceptance Criteria**:
- [ ] GET /tasks/{task_id} returns task status and metadata
- [ ] Response includes: task_id, task_type, status, created_at, updated_at, completed_at (if completed)
- [ ] If status=completed, response includes result field with parsed ReceiptParseResult
- [ ] If status=failed, response includes error_message field
- [ ] Returns 404 if task_id does not exist
- [ ] Requires authentication
- [ ] Unit tests cover: pending task, completed task with result, failed task with error, not found: `pytest tests/unit/routers/test_tasks.py -v`

**Verification Commands**:
```bash
pytest tests/unit/routers/test_tasks.py -v
# Manual test:
curl http://localhost:8000/tasks/{task_id} -H "Authorization: Bearer $TOKEN"
```

**Done Definition**: Done when GET /tasks/{task_id} returns correct status and result/error for all task states, and all unit tests pass.

**Scope Boundary**:
- DO: Create task status endpoint
- DO: Return parsed result when status=completed
- DO: Return error_message when status=failed
- DO: Handle 404 for unknown task_id
- DO NOT: Implement task processing logic (that's the worker)
- DO NOT: Add websocket/SSE for real-time updates (polling is sufficient per ADR)

**Dependencies**: After "[Phase 2A] Implement receipt upload endpoint"

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**12** files, **2** commits (+0 added, ~10 modified, -2 deleted)
- `M` frontend/src/utils/__tests__/pantryMatcher.test.ts
- `M` frontend/src/utils/pantryMatcher.ts
- `M` pytest.ini
- `M` requirements.txt
- `M` src/main.py
- `M` src/routers/__init__.py
- `M` src/routers/scraper.py
- `M` src/services/llm/client.py
- `M` src/services/scraper_service.py
- `D` src/services/task_worker.py
- `M` tests/services/test_scraper_service.py
- `D` tests/unit/services/test_task_worker.py

### Commits
- 4f0d780 wip: auto-commit relevant changes for issue #368 (2026-03-29)
- 47d69b9 chore: initialize work on #368 [Phase 2A] Implement task status endpoint
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues
Created: #421 #422 
**From assessment on 2026-03-29T20:23:55Z:**
- Created: #395 
- Updated: none