### PR TITLE
[Phase 2A] Implement background task worker

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 from contextlib import asynccontextmanager
+import asyncio
 import logging
 from typing import AsyncGenerator
 
@@ -13,6 +14,7 @@ from src.config import get_settings
 from src.db.database import Base, init_engine, get_engine, get_session_factory
 from src.routers import auth_router, users_router, substitutions_router, inventory_router, recipes_router, grocery_router, prepared_foods_router, scraper_router
 from src.middleware.rate_limit import limiter
+from src.services.task_worker import background_task_worker
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +63,20 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     init_engine(settings.database_url)
     _ensure_schema()
     _ensure_seed_data()
+
+    # Start background task worker for processing async LLM tasks (Phase 2A)
+    # Worker polls for pending tasks and processes them using OllamaClient
+    worker_task = asyncio.create_task(background_task_worker())
+
     yield
+
+    # Gracefully shut down background worker on application shutdown
+    # Cancel the task and wait for it to complete cleanup
+    worker_task.cancel()
+    try:
+        await worker_task
+    except asyncio.CancelledError:
+        pass  # Expected on clean shutdown
 
 
 app = FastAPI(

--- a/src/services/task_worker.py
+++ b/src/services/task_worker.py
@@ -1,0 +1,228 @@
+"""
+Background task worker for processing async LLM tasks.
+
+Polls for pending ProcessingTasks and processes them using OllamaClient.
+Runs as an asyncio.create_task inside the FastAPI lifespan context manager.
+
+Per ADR Section 2A: Background Task Processing
+- Sequential processing (no parallelism at household scale)
+- Graceful handling of Ollama unavailability (task stays pending)
+- Graceful handling of validation failures (task marked failed)
+- Clean shutdown on cancellation
+"""
+
+import asyncio
+import logging
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.config import get_settings
+from src.db.database import get_session_factory
+from src.db.models.processing_task import ProcessingTask, TaskStatus, TaskType
+from src.schemas.receipt import ReceiptParseResult
+from src.services.llm.client import OllamaClient
+from src.services.llm.exceptions import LLMUnavailableError, LLMResponseError
+from src.services.llm.prompts.receipt import SYSTEM_PROMPT, create_user_prompt
+
+logger = logging.getLogger(__name__)
+settings = get_settings()
+
+
+async def process_receipt_task(
+    task: ProcessingTask,
+    session: Session,
+    ollama_client: OllamaClient
+) -> None:
+    """
+    Process a single receipt parsing task.
+
+    Extracts receipt text from input_reference, sends to OllamaClient for parsing,
+    and updates the task with the result or error.
+
+    Args:
+        task: The ProcessingTask to process
+        session: Database session for updates
+        ollama_client: OllamaClient instance for LLM operations
+
+    Raises:
+        LLMUnavailableError: If Ollama is unreachable (task should stay pending)
+        LLMResponseError: If LLM response validation fails after retries
+    """
+    # Extract receipt text from input_reference
+    # For now, input_reference contains the raw receipt text directly
+    # In future, this could be a file path or S3 reference
+    receipt_text = task.input_reference
+
+    # Create user prompt from receipt text
+    user_prompt = create_user_prompt(receipt_text)
+
+    # Call Ollama to parse the receipt
+    # This raises LLMUnavailableError or LLMResponseError on failure
+    result: ReceiptParseResult = await ollama_client.complete(
+        prompt=user_prompt,
+        system_prompt=SYSTEM_PROMPT,
+        response_schema=ReceiptParseResult
+    )
+
+    # Success! Serialize result to JSON and store
+    result_json = result.model_dump_json()
+
+    # Update task status
+    task.status = TaskStatus.completed.value
+    task.result_reference = result_json
+    task.completed_at = datetime.utcnow()
+
+    session.commit()
+
+    logger.info(
+        "Receipt parsing task completed",
+        extra={
+            "task_id": str(task.id),
+            "store_name": result.store_name,
+            "line_item_count": len(result.line_items)
+        }
+    )
+
+
+async def process_pending_tasks() -> None:
+    """
+    Process all pending receipt_parse tasks sequentially.
+
+    Queries for tasks with status='pending' and task_type='receipt_parse',
+    processes each one, and updates status appropriately.
+
+    Handles Ollama unavailability gracefully by skipping tasks and leaving
+    them pending for the next poll interval.
+    """
+    # Create database session for this iteration
+    SessionFactory = get_session_factory()
+    session = SessionFactory()
+
+    try:
+        # Create Ollama client
+        async with OllamaClient() as ollama_client:
+            # Check if Ollama is available before processing
+            if not await ollama_client.is_available():
+                logger.warning(
+                    "Ollama is unavailable, skipping task processing this interval"
+                )
+                return
+
+            # Query for pending receipt_parse tasks (oldest first)
+            stmt = (
+                select(ProcessingTask)
+                .where(
+                    ProcessingTask.status == TaskStatus.pending.value,
+                    ProcessingTask.task_type == TaskType.receipt_parse.value
+                )
+                .order_by(ProcessingTask.created_at)
+            )
+            result = session.execute(stmt)
+            pending_tasks = result.scalars().all()
+
+            if not pending_tasks:
+                logger.debug("No pending tasks to process")
+                return
+
+            logger.info(
+                f"Processing {len(pending_tasks)} pending task(s)",
+                extra={"task_count": len(pending_tasks)}
+            )
+
+            # Process each task sequentially
+            for task in pending_tasks:
+                try:
+                    # Mark task as processing
+                    task.status = TaskStatus.processing.value
+                    session.commit()
+
+                    logger.info(
+                        "Processing receipt task",
+                        extra={"task_id": str(task.id)}
+                    )
+
+                    # Process the task
+                    await process_receipt_task(task, session, ollama_client)
+
+                except LLMUnavailableError as e:
+                    # Ollama became unavailable during processing
+                    # Revert task to pending and skip remaining tasks
+                    logger.warning(
+                        f"Ollama unavailable during task processing: {e}",
+                        extra={"task_id": str(task.id)}
+                    )
+                    task.status = TaskStatus.pending.value
+                    session.commit()
+                    break  # Stop processing, retry next interval
+
+                except LLMResponseError as e:
+                    # LLM validation failed after all retries
+                    # Mark task as failed with error details
+                    logger.error(
+                        f"Receipt parsing validation failed: {e}",
+                        extra={
+                            "task_id": str(task.id),
+                            "validation_errors": e.validation_errors
+                        }
+                    )
+                    task.status = TaskStatus.failed.value
+                    task.error_message = f"Validation failed after retries: {str(e)}"
+                    task.completed_at = datetime.utcnow()
+                    session.commit()
+                    # Continue to next task
+
+                except Exception as e:
+                    # Unexpected error - log and mark task as failed
+                    logger.error(
+                        f"Unexpected error processing task: {e}",
+                        extra={"task_id": str(task.id)},
+                        exc_info=True
+                    )
+                    task.status = TaskStatus.failed.value
+                    task.error_message = f"Unexpected error: {str(e)}"
+                    task.completed_at = datetime.utcnow()
+                    session.commit()
+                    # Continue to next task
+
+    finally:
+        # Always close the session
+        session.close()
+
+
+async def background_task_worker() -> None:
+    """
+    Background worker that polls for pending tasks at regular intervals.
+
+    Runs indefinitely until cancelled (on application shutdown).
+    Handles CancelledError gracefully for clean shutdown.
+    """
+    logger.info(
+        f"Background task worker started (poll interval: {settings.task_poll_interval_seconds}s)"
+    )
+
+    try:
+        while True:
+            try:
+                # Process pending tasks
+                await process_pending_tasks()
+
+            except asyncio.CancelledError:
+                # Shutdown signal received
+                raise
+
+            except Exception as e:
+                # Log unexpected errors but keep worker running
+                logger.error(
+                    f"Error in task worker iteration: {e}",
+                    exc_info=True
+                )
+
+            # Sleep until next poll interval
+            await asyncio.sleep(settings.task_poll_interval_seconds)
+
+    except asyncio.CancelledError:
+        logger.info("Background task worker shutting down gracefully")
+        raise  # Re-raise to signal completion

--- a/src/services/task_worker.py
+++ b/src/services/task_worker.py
@@ -13,8 +13,7 @@ Per ADR Section 2A: Background Task Processing
 
 import asyncio
 import logging
-from datetime import datetime
-from typing import Optional
+from datetime import datetime, timezone
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -73,7 +72,7 @@ async def process_receipt_task(
     # Update task status
     task.status = TaskStatus.completed.value
     task.result_reference = result_json
-    task.completed_at = datetime.utcnow()
+    task.completed_at = datetime.now(timezone.utc)
 
     session.commit()
 
@@ -170,7 +169,7 @@ async def process_pending_tasks() -> None:
                     )
                     task.status = TaskStatus.failed.value
                     task.error_message = f"Validation failed after retries: {str(e)}"
-                    task.completed_at = datetime.utcnow()
+                    task.completed_at = datetime.now(timezone.utc)
                     session.commit()
                     # Continue to next task
 
@@ -183,7 +182,7 @@ async def process_pending_tasks() -> None:
                     )
                     task.status = TaskStatus.failed.value
                     task.error_message = f"Unexpected error: {str(e)}"
-                    task.completed_at = datetime.utcnow()
+                    task.completed_at = datetime.now(timezone.utc)
                     session.commit()
                     # Continue to next task
 

--- a/tests/unit/services/test_task_worker.py
+++ b/tests/unit/services/test_task_worker.py
@@ -15,7 +15,7 @@ All tests mock OllamaClient and database operations.
 
 import asyncio
 import pytest
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -53,7 +53,7 @@ def mock_task():
     task.input_reference = "Costco\n2024-03-29\nBananas $3.99\nMilk $4.49"
     task.result_reference = None
     task.error_message = None
-    task.created_at = datetime.utcnow()
+    task.created_at = datetime.now(timezone.utc)
     task.completed_at = None
     return task
 

--- a/tests/unit/services/test_task_worker.py
+++ b/tests/unit/services/test_task_worker.py
@@ -1,0 +1,443 @@
+"""
+Unit tests for background task worker.
+
+Tests cover:
+- Successful receipt parsing task processing
+- Ollama unavailable (task stays pending)
+- LLM validation failure after retries (task marked failed)
+- Unexpected errors (task marked failed)
+- Graceful shutdown on CancelledError
+- Multiple task processing
+- Empty queue handling
+
+All tests mock OllamaClient and database operations.
+"""
+
+import asyncio
+import pytest
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from src.services.task_worker import (
+    process_receipt_task,
+    process_pending_tasks,
+    background_task_worker
+)
+from src.db.models.processing_task import ProcessingTask, TaskStatus, TaskType
+from src.schemas.receipt import ReceiptParseResult, ReceiptLineItem
+from src.services.llm.exceptions import LLMUnavailableError, LLMResponseError
+
+
+@pytest.fixture(autouse=True)
+def setup_test_env(monkeypatch):
+    """Set up test environment variables."""
+    from src.config import get_settings
+    get_settings.cache_clear()
+
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars")
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://localhost:11434")
+    monkeypatch.setenv("OLLAMA_MODEL", "llama3.1:8b")
+    monkeypatch.setenv("TASK_POLL_INTERVAL_SECONDS", "1")  # Fast polling for tests
+
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def mock_task():
+    """Create a mock ProcessingTask."""
+    task = MagicMock(spec=ProcessingTask)
+    task.id = uuid4()
+    task.task_type = TaskType.receipt_parse.value
+    task.status = TaskStatus.pending.value
+    task.input_reference = "Costco\n2024-03-29\nBananas $3.99\nMilk $4.49"
+    task.result_reference = None
+    task.error_message = None
+    task.created_at = datetime.utcnow()
+    task.completed_at = None
+    return task
+
+
+@pytest.fixture
+def mock_session():
+    """Create a mock database session."""
+    session = MagicMock()
+    session.commit = MagicMock()
+    session.close = MagicMock()
+    session.execute = MagicMock()
+    return session
+
+
+@pytest.fixture
+def mock_ollama_client():
+    """Create a mock OllamaClient."""
+    client = AsyncMock()
+    client.complete = AsyncMock()
+    client.is_available = AsyncMock(return_value=True)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def sample_receipt_result():
+    """Create a sample ReceiptParseResult."""
+    return ReceiptParseResult(
+        store_name="Costco",
+        receipt_date="2024-03-29",
+        line_items=[
+            ReceiptLineItem(
+                item_name="Bananas",
+                quantity=1.0,
+                unit_price=None,
+                total_price=3.99,
+                category_guess="produce"
+            ),
+            ReceiptLineItem(
+                item_name="Milk",
+                quantity=1.0,
+                unit_price=None,
+                total_price=4.49,
+                category_guess="dairy"
+            )
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_receipt_task_success(
+    mock_task,
+    mock_session,
+    mock_ollama_client,
+    sample_receipt_result
+):
+    """Test successful receipt task processing."""
+    # Configure mock to return valid result
+    mock_ollama_client.complete.return_value = sample_receipt_result
+
+    # Process the task
+    await process_receipt_task(mock_task, mock_session, mock_ollama_client)
+
+    # Verify OllamaClient was called correctly
+    mock_ollama_client.complete.assert_called_once()
+    call_args = mock_ollama_client.complete.call_args[1]
+    assert "Costco" in call_args["prompt"]  # Receipt text in prompt
+    assert call_args["response_schema"] == ReceiptParseResult
+
+    # Verify task was updated correctly
+    assert mock_task.status == TaskStatus.completed.value
+    assert mock_task.result_reference is not None
+    assert "Costco" in mock_task.result_reference  # JSON contains store name
+    assert mock_task.completed_at is not None
+
+    # Verify session commit was called
+    mock_session.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_process_receipt_task_ollama_unavailable(
+    mock_task,
+    mock_session,
+    mock_ollama_client
+):
+    """Test handling of Ollama unavailability - task should stay pending."""
+    # Configure mock to raise LLMUnavailableError
+    mock_ollama_client.complete.side_effect = LLMUnavailableError(
+        "Failed to connect to Ollama"
+    )
+
+    # Process should raise LLMUnavailableError
+    with pytest.raises(LLMUnavailableError):
+        await process_receipt_task(mock_task, mock_session, mock_ollama_client)
+
+    # Task status should not be modified (stays pending)
+    # Session commit should not be called
+    mock_session.commit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_process_receipt_task_validation_failure(
+    mock_task,
+    mock_session,
+    mock_ollama_client
+):
+    """Test handling of LLM validation failure - task should be marked failed."""
+    # Configure mock to raise LLMResponseError
+    validation_errors = ["Missing required field: store_name", "Invalid JSON format"]
+    mock_ollama_client.complete.side_effect = LLMResponseError(
+        "Validation failed after retries",
+        response='{"invalid": "data"}',
+        validation_errors=validation_errors
+    )
+
+    # Process should raise LLMResponseError
+    with pytest.raises(LLMResponseError):
+        await process_receipt_task(mock_task, mock_session, mock_ollama_client)
+
+    # Task status should not be modified (handled by caller)
+    # Session commit should not be called
+    mock_session.commit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_process_pending_tasks_success(
+    mock_task,
+    sample_receipt_result
+):
+    """Test processing of pending tasks - successful case."""
+    # Mock database query to return one pending task
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [mock_task]
+
+    mock_session = MagicMock()
+    mock_session.execute.return_value = mock_result
+    mock_session.commit = MagicMock()
+    mock_session.close = MagicMock()
+
+    # Mock session factory
+    mock_session_factory = MagicMock(return_value=mock_session)
+
+    # Mock OllamaClient
+    mock_ollama_client = AsyncMock()
+    mock_ollama_client.is_available.return_value = True
+    mock_ollama_client.complete.return_value = sample_receipt_result
+    mock_ollama_client.__aenter__.return_value = mock_ollama_client
+    mock_ollama_client.__aexit__.return_value = None
+
+    with patch("src.services.task_worker.get_session_factory", return_value=mock_session_factory):
+        with patch("src.services.task_worker.OllamaClient", return_value=mock_ollama_client):
+            await process_pending_tasks()
+
+    # Verify task was updated to completed
+    assert mock_task.status == TaskStatus.completed.value
+    assert mock_task.result_reference is not None
+    assert mock_task.completed_at is not None
+
+    # Verify session was closed
+    mock_session.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_process_pending_tasks_ollama_unavailable():
+    """Test handling when Ollama is unavailable - tasks should stay pending."""
+    # Mock database query (no execution needed if Ollama is down)
+    mock_session = MagicMock()
+    mock_session.close = MagicMock()
+
+    # Mock session factory
+    mock_session_factory = MagicMock(return_value=mock_session)
+
+    # Mock OllamaClient - unavailable
+    mock_ollama_client = AsyncMock()
+    mock_ollama_client.is_available.return_value = False
+    mock_ollama_client.__aenter__.return_value = mock_ollama_client
+    mock_ollama_client.__aexit__.return_value = None
+
+    with patch("src.services.task_worker.get_session_factory", return_value=mock_session_factory):
+        with patch("src.services.task_worker.OllamaClient", return_value=mock_ollama_client):
+            await process_pending_tasks()
+
+    # Verify no query was executed (early return)
+    mock_session.execute.assert_not_called()
+
+    # Verify session was closed
+    mock_session.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_process_pending_tasks_validation_failure(mock_task):
+    """Test handling of validation failure - task should be marked failed."""
+    # Mock database query to return one pending task
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [mock_task]
+
+    mock_session = MagicMock()
+    mock_session.execute.return_value = mock_result
+    mock_session.commit = MagicMock()
+    mock_session.close = MagicMock()
+
+    # Mock session factory
+    mock_session_factory = MagicMock(return_value=mock_session)
+
+    # Mock OllamaClient - validation failure
+    mock_ollama_client = AsyncMock()
+    mock_ollama_client.is_available.return_value = True
+    mock_ollama_client.complete.side_effect = LLMResponseError(
+        "Validation failed",
+        validation_errors=["Invalid schema"]
+    )
+    mock_ollama_client.__aenter__.return_value = mock_ollama_client
+    mock_ollama_client.__aexit__.return_value = None
+
+    with patch("src.services.task_worker.get_session_factory", return_value=mock_session_factory):
+        with patch("src.services.task_worker.OllamaClient", return_value=mock_ollama_client):
+            await process_pending_tasks()
+
+    # Verify task was marked as failed
+    assert mock_task.status == TaskStatus.failed.value
+    assert mock_task.error_message is not None
+    assert "Validation failed" in mock_task.error_message
+    assert mock_task.completed_at is not None
+
+    # Verify session was closed
+    mock_session.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_process_pending_tasks_ollama_unavailable_during_processing(mock_task):
+    """Test handling when Ollama becomes unavailable during processing."""
+    # Mock database query to return one pending task
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [mock_task]
+
+    mock_session = MagicMock()
+    mock_session.execute.return_value = mock_result
+    mock_session.commit = MagicMock()
+    mock_session.close = MagicMock()
+
+    # Mock session factory
+    mock_session_factory = MagicMock(return_value=mock_session)
+
+    # Mock OllamaClient - becomes unavailable during processing
+    mock_ollama_client = AsyncMock()
+    mock_ollama_client.is_available.return_value = True
+    mock_ollama_client.complete.side_effect = LLMUnavailableError(
+        "Connection lost"
+    )
+    mock_ollama_client.__aenter__.return_value = mock_ollama_client
+    mock_ollama_client.__aexit__.return_value = None
+
+    with patch("src.services.task_worker.get_session_factory", return_value=mock_session_factory):
+        with patch("src.services.task_worker.OllamaClient", return_value=mock_ollama_client):
+            await process_pending_tasks()
+
+    # Verify task was reverted to pending
+    assert mock_task.status == TaskStatus.pending.value
+
+    # Verify session was closed
+    mock_session.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_process_pending_tasks_no_tasks():
+    """Test handling when no pending tasks exist."""
+    # Mock database query to return empty list
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+
+    mock_session = MagicMock()
+    mock_session.execute.return_value = mock_result
+    mock_session.close = MagicMock()
+
+    # Mock session factory
+    mock_session_factory = MagicMock(return_value=mock_session)
+
+    # Mock OllamaClient
+    mock_ollama_client = AsyncMock()
+    mock_ollama_client.is_available.return_value = True
+    mock_ollama_client.__aenter__.return_value = mock_ollama_client
+    mock_ollama_client.__aexit__.return_value = None
+
+    with patch("src.services.task_worker.get_session_factory", return_value=mock_session_factory):
+        with patch("src.services.task_worker.OllamaClient", return_value=mock_ollama_client):
+            await process_pending_tasks()
+
+    # Verify no errors occurred
+    # Verify session was closed
+    mock_session.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_background_task_worker_graceful_shutdown():
+    """Test graceful shutdown of background worker on CancelledError."""
+    # Mock process_pending_tasks to track calls
+    call_count = 0
+
+    async def mock_process_pending_tasks():
+        nonlocal call_count
+        call_count += 1
+        await asyncio.sleep(0.1)  # Simulate some work
+
+    with patch("src.services.task_worker.process_pending_tasks", side_effect=mock_process_pending_tasks):
+        # Start worker
+        worker_task = asyncio.create_task(background_task_worker())
+
+        # Let it run for a bit
+        await asyncio.sleep(0.5)
+
+        # Cancel the worker
+        worker_task.cancel()
+
+        # Wait for graceful shutdown
+        with pytest.raises(asyncio.CancelledError):
+            await worker_task
+
+        # Verify worker was called at least once
+        assert call_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_background_task_worker_handles_errors():
+    """Test that background worker continues running after errors."""
+    call_count = 0
+
+    async def mock_process_pending_tasks():
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # Raise error on first call
+            raise RuntimeError("Simulated error")
+        # Succeed on subsequent calls
+
+    with patch("src.services.task_worker.process_pending_tasks", side_effect=mock_process_pending_tasks):
+        # Start worker
+        worker_task = asyncio.create_task(background_task_worker())
+
+        # Let it run through error and recover
+        await asyncio.sleep(2.5)
+
+        # Cancel the worker
+        worker_task.cancel()
+
+        # Wait for graceful shutdown
+        with pytest.raises(asyncio.CancelledError):
+            await worker_task
+
+        # Verify worker recovered and continued
+        assert call_count >= 2, "Worker should have recovered and continued after error"
+
+
+@pytest.mark.asyncio
+async def test_process_pending_tasks_unexpected_error(mock_task):
+    """Test handling of unexpected errors - task should be marked failed."""
+    # Mock database query to return one pending task
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [mock_task]
+
+    mock_session = MagicMock()
+    mock_session.execute.return_value = mock_result
+    mock_session.commit = MagicMock()
+    mock_session.close = MagicMock()
+
+    # Mock session factory
+    mock_session_factory = MagicMock(return_value=mock_session)
+
+    # Mock OllamaClient - unexpected error
+    mock_ollama_client = AsyncMock()
+    mock_ollama_client.is_available.return_value = True
+    mock_ollama_client.complete.side_effect = RuntimeError("Unexpected error")
+    mock_ollama_client.__aenter__.return_value = mock_ollama_client
+    mock_ollama_client.__aexit__.return_value = None
+
+    with patch("src.services.task_worker.get_session_factory", return_value=mock_session_factory):
+        with patch("src.services.task_worker.OllamaClient", return_value=mock_ollama_client):
+            await process_pending_tasks()
+
+    # Verify task was marked as failed
+    assert mock_task.status == TaskStatus.failed.value
+    assert mock_task.error_message is not None
+    assert "Unexpected error" in mock_task.error_message
+    assert mock_task.completed_at is not None
+
+    # Verify session was closed
+    mock_session.close.assert_called_once()


### PR DESCRIPTION
## Work in Progress

Closes #369

[Phase 2A] Implement background task worker

**Time Estimate**: 2hr

**Description**:
Create a background worker that polls for pending ProcessingTasks and processes them using the OllamaClient. Runs as an asyncio.create_task inside the existing async lifespan context manager, not as a separate process.

**Claude Context**:
Files to Read:
- src/main.py (existing async lifespan — worker starts here via create_task)
- src/services/llm/client.py (OllamaClient for LLM calls)
- src/services/llm/prompts/receipt.py (receipt parsing prompts)
- docs/FreshUp-ADR.md (Section 2A: Background Task Processing specification)

Files to Modify:
- src/services/task_worker.py (create)
- src/main.py (start worker in lifespan via asyncio.create_task)
- tests/unit/services/test_task_worker.py (create)

Related Issues: After "[Phase 2A] Implement task status endpoint", After "[Phase 2A] Create receipt parsing prompt template"

**Acceptance Criteria**:
- [ ] Worker function runs as asyncio.create_task() inside the async lifespan context manager in main.py
- [ ] Worker polls for status=pending tasks every TASK_POLL_INTERVAL_SECONDS
- [ ] Tasks processed sequentially (no parallelism needed at household scale)
- [ ] On task pickup: status transitions pending → processing
- [ ] On success: status → completed, result_reference stores JSON-serialized ReceiptParseResult, completed_at set
- [ ] On Ollama unavailable: task stays pending, worker skips and retries next interval
- [ ] On LLM validation failure (after retries exhausted): status → failed, error_message populated
- [ ] Worker gracefully handles shutdown (cancellation) when lifespan yields
- [ ] Unit tests mock OllamaClient and database: `pytest tests/unit/services/test_task_worker.py -v`
- [ ] Tests cover: successful processing, Ollama unavailable (task stays pending), validation failure (task fails), graceful shutdown

**Verification Commands**:
```bash
pytest tests/unit/services/test_task_worker.py -v
# Integration: submit receipt, check task transitions to completed
```

**Done Definition**: Done when the worker processes pending tasks, stores results, handles Ollama unavailability gracefully, and all unit tests pass.

**Scope Boundary**:
- DO: Implement polling worker with asyncio.create_task in lifespan
- DO: Process receipt_parse tasks using OllamaClient and receipt prompts
- DO: Handle Ollama unavailability (skip task, retry later)
- DO: Handle validation failures (mark task failed)
- DO: Store result as JSON in result_reference field
- DO NOT: Run as separate process or thread — use asyncio task
- DO NOT: Add parallelism — sequential processing is sufficient
- DO NOT: Process other task types (only receipt_parse for now)

**Dependencies**: After "[Phase 2A] Implement task status endpoint", After "[Phase 2A] Create receipt parsing prompt template"

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **2** commits (+2 added, ~1 modified, -0 deleted)
- `M` src/main.py
- `A` src/services/task_worker.py
- `A` tests/unit/services/test_task_worker.py

### Commits
- c179f65 feat: [Phase 2A] Implement background task worker
- f483db9 chore: initialize work on #369 [Phase 2A] Implement background task worker
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-03-29T19:14:51Z:**
- Created: #389 
- Updated: none