### PR TITLE
[Phase 2A] Add Ollama health check endpoint

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -15,6 +15,7 @@ from src.db.database import Base, init_engine, get_engine, get_session_factory
 from src.routers import auth_router, users_router, substitutions_router, inventory_router, recipes_router, grocery_router, prepared_foods_router, scraper_router
 from src.middleware.rate_limit import limiter
 from src.services.task_worker import background_task_worker
+from src.services.llm.client import OllamaClient
 
 logger = logging.getLogger(__name__)
 
@@ -197,6 +198,28 @@ async def health_check():
         checks["issues"] = issues
 
     return checks
+
+
+@app.get("/health/ollama")
+async def ollama_health_check():
+    """
+    Check Ollama LLM service availability.
+
+    Returns availability status and configured model name for debugging.
+    Always returns 200 OK, even when Ollama is unreachable (not a server error).
+    Allows frontend to show "LLM offline" indicator or disable LLM features.
+
+    Returns:
+        dict: {"available": bool, "model": str}
+    """
+    client = OllamaClient()
+    available = await client.is_available()
+    await client.close()
+
+    return {
+        "available": available,
+        "model": settings.ollama_model,
+    }
 
 
 if settings.environment == "local":


### PR DESCRIPTION
## Work in Progress

Closes #370

[Phase 2A] Add Ollama health check endpoint

**Time Estimate**: 30min

**Description**:
Create GET /health/ollama endpoint that reports Ollama availability status. Allows the frontend to show "LLM offline" indicator or grey out LLM-dependent features when Ollama is unreachable.

**Claude Context**:
Files to Read:
- src/main.py (existing /health endpoint pattern)
- src/services/llm/client.py (OllamaClient.is_available() method)

Files to Modify:
- src/main.py (add /health/ollama endpoint)
- tests/unit/test_health.py (add or create test file)

Related Issues: After "[Phase 2A] Implement Ollama HTTP client"

**Acceptance Criteria**:
- [ ] GET /health/ollama returns `{"available": true/false, "model": "llama3.1:8b"}`
- [ ] Uses OllamaClient.is_available() to check connectivity
- [ ] Returns available=false with 200 OK when Ollama is unreachable (not 500)
- [ ] Includes configured model name in response for debugging
- [ ] No authentication required (health checks should be public)
- [ ] Unit tests mock OllamaClient: `pytest tests/unit/test_health.py -v`

**Verification Commands**:
```bash
pytest tests/unit/test_health.py -v
curl http://localhost:8000/health/ollama
```

**Done Definition**: Done when /health/ollama returns availability status and model name, returning 200 OK regardless of Ollama reachability.

**Scope Boundary**:
- DO: Add /health/ollama endpoint
- DO: Return 200 OK with available=true/false (never 500 for unreachable Ollama)
- DO: Include model name in response
- DO NOT: Require authentication
- DO NOT: Add detailed Ollama diagnostics beyond available/unavailable

**Dependencies**: After "[Phase 2A] Implement Ollama HTTP client"

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+0 added, ~2 modified, -0 deleted)
- `M` src/main.py
- `M` src/routers/__init__.py

### Commits
- 63e7474 wip: auto-commit relevant changes for issue #370 (2026-03-29)
- ab1cb82 chore: initialize work on #370 [Phase 2A] Add Ollama health check endpoint
<!-- /sharkrite-changes-summary -->