### PR TITLE
[Phase 2A] Add Ollama integration tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 markers =
     integration: tests that hit external services (HelloFresh, Kitchen Sanctuary)
+    asyncio: marks tests as async (deselect with '-m "not asyncio"')
 addopts = -m "not integration" --timeout=30
 timeout_method = signal
 asyncio_mode = auto

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,26 @@ managing the settings cache to prevent test pollution.
 import os
 
 import pytest
+from _pytest.python import Package
+
+
+# Patch Package class to add obj property for pytest-asyncio compatibility with Python 3.14
+# This must be done at module level before pytest_asyncio hooks are registered
+if not hasattr(Package, '_original_getattribute'):
+    _original_getattribute = Package.__getattribute__
+
+    def _patched_getattribute(self, name):
+        if name == 'obj' and not hasattr(type(self), 'obj'):
+            # Return a simple namespace that can have attributes set on it
+            class DummyObj:
+                pass
+            # Cache it on the instance
+            object.__setattr__(self, 'obj', DummyObj())
+            return object.__getattribute__(self, 'obj')
+        return _original_getattribute(self, name)
+
+    Package.__getattribute__ = _patched_getattribute
+    Package._original_getattribute = _original_getattribute
 
 
 def pytest_configure(config):


### PR DESCRIPTION
## Work in Progress

Closes #371

[Phase 2A] Add Ollama integration tests

**Time Estimate**: 1hr

**Description**:
Create integration tests that verify the Ollama receipt parsing pipeline works end-to-end against a running Ollama instance. These tests validate that sample receipt text produces plausible structured output, not just that Ollama responds.

**Claude Context**:
Files to Read:
- src/services/llm/client.py (OllamaClient implementation)
- src/services/llm/prompts/receipt.py (receipt parsing prompts)
- src/schemas/receipt.py (ReceiptParseResult schema)
- tests/unit/services/test_llm_client.py (reference for test patterns)

Files to Modify:
- tests/integration/test_ollama_receipt_parsing.py (create)
- tests/integration/__init__.py (create if needed)
- pytest.ini or pyproject.toml (add integration test marker if needed)

Related Issues: After "[Phase 2A] Implement Ollama HTTP client", After "[Phase 2A] Create receipt parsing prompt template"

**Acceptance Criteria**:
- [ ] Integration test file created at tests/integration/test_ollama_receipt_parsing.py
- [ ] Tests marked with `@pytest.mark.integration` to separate from unit tests
- [ ] Test sends sample grocery receipt text through OllamaClient with receipt parsing prompt
- [ ] Test validates returned ReceiptParseResult has non-empty store_name
- [ ] Test validates returned ReceiptParseResult has at least one line_item
- [ ] Test validates line_items contain plausible item_name values (non-empty strings)
- [ ] Test validates line_items contain numeric total_price values where present
- [ ] Test covers at least 2 different receipt formats (e.g., Costco-style, grocery store-style)
- [ ] Tests skip gracefully with clear message when Ollama is unavailable: `pytest tests/integration/ -v -m integration`
- [ ] README or docstring documents how to run integration tests (requires local Ollama with llama3.1:8b)

**Verification Commands**:
```bash
# Requires Ollama running locally with llama3.1:8b model
pytest tests/integration/test_ollama_receipt_parsing.py -v -m integration

# Skip integration tests in CI:
pytest tests/ -v --ignore=tests/integration
```

**Done Definition**: Done when integration tests pass against a running Ollama instance, validating that sample receipt text produces a ReceiptParseResult with plausible store name, date (when present), and line items containing item names and prices.

**Scope Boundary**:
- DO: Create integration tests for receipt parsing pipeline
- DO: Validate output quality (store name populated, line items present, prices numeric)
- DO: Test multiple receipt formats to verify robustness
- DO: Skip gracefully when Ollama unavailable
- DO: Document test requirements (Ollama + model)
- DO NOT: Test other LLM features (only receipt parsing for 2A)
- DO NOT: Mock Ollama — these are real integration tests
- DO NOT: Make tests part of standard CI run (require manual Ollama setup)

**Dependencies**: After "[Phase 2A] Implement Ollama HTTP client", After "[Phase 2A] Create receipt parsing prompt template"

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**1** files, **5** commits (+0 added, ~1 modified, -0 deleted)
- `M` tests/conftest.py

### Commits
- 99e344b merge: resolve pytest.ini conflict (keep main's asyncio marker description)
- 1227132 merge: resolve conflict in test_task_worker.py (keep fast poll interval)
- 15c311e Merge remote-tracking branch 'origin/main' into test/phase-2a-add-ollama-integration-tests
- c68991c Merge remote-tracking branch 'origin/main' into test/phase-2a-add-ollama-integration-tests
- bc4f77c chore: initialize work on #371 [Phase 2A] Add Ollama integration tests
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-04-03T07:21:42Z:**
- Created: #411 
- Updated: none