### PR TITLE
Avoid bidirectional token matching issues

### DIFF
--- a/frontend/src/utils/__tests__/pantryMatcher.test.ts
+++ b/frontend/src/utils/__tests__/pantryMatcher.test.ts
@@ -79,7 +79,9 @@ describe('pantryMatcher', () => {
       expect(result.inStock[0].matchedInventoryItem?.name).toBe('all-purpose flour')
     })
 
-    it('matches inventory items with more generic names', () => {
+    it('does NOT match specific recipe ingredient with generic inventory (asymmetric)', () => {
+      // Recipe needs "all-purpose flour" but inventory only has "flour"
+      // This should NOT match to prevent false positives
       const ingredients = [
         createIngredient({ ingredient_name: 'all-purpose flour' }),
       ]
@@ -90,8 +92,26 @@ describe('pantryMatcher', () => {
 
       const result = checkIngredientAvailability(ingredients, inventoryItems)
 
-      expect(result.inStockCount).toBe(1)
-      expect(result.inStock[0].inStock).toBe(true)
+      expect(result.inStockCount).toBe(0)
+      expect(result.outOfStock).toHaveLength(1)
+      expect(result.outOfStock[0].ingredient.ingredient_name).toBe('all-purpose flour')
+    })
+
+    it('does NOT match "almond flour" recipe with "flour" inventory', () => {
+      // This is the specific example from the issue
+      const ingredients = [
+        createIngredient({ ingredient_name: 'almond flour' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'flour' }),
+      ]
+
+      const result = checkIngredientAvailability(ingredients, inventoryItems)
+
+      expect(result.inStockCount).toBe(0)
+      expect(result.outOfStock).toHaveLength(1)
+      expect(result.outOfStock[0].ingredient.ingredient_name).toBe('almond flour')
     })
 
     it('returns all out of stock when inventory is empty', () => {
@@ -324,7 +344,7 @@ describe('pantryMatcher', () => {
       expect(result).toBe(true)
     })
 
-    it('handles partial name matching', () => {
+    it('handles partial name matching (generic recipe with specific inventory)', () => {
       const ingredients = [
         createIngredient({ ingredient_name: 'flour' }),
       ]
@@ -336,6 +356,20 @@ describe('pantryMatcher', () => {
       const result = areAllIngredientsInStock(ingredients, inventoryItems)
 
       expect(result).toBe(true)
+    })
+
+    it('returns false when specific recipe ingredient does not match generic inventory (asymmetric)', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: 'almond flour' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'flour' }),
+      ]
+
+      const result = areAllIngredientsInStock(ingredients, inventoryItems)
+
+      expect(result).toBe(false)
     })
 
     // False positive prevention tests

--- a/frontend/src/utils/pantryMatcher.ts
+++ b/frontend/src/utils/pantryMatcher.ts
@@ -29,17 +29,19 @@ function tokenizeIngredientName(name: string): string[] {
 
 /**
  * Checks if an ingredient name matches an inventory item name
- * Uses word-boundary matching to prevent false positives
+ * Uses asymmetric word-boundary matching to prevent false positives
  * (e.g., "rice" should NOT match "licorice")
  *
  * Matching strategy:
  * 1. Exact match after normalization
- * 2. Word-boundary match: all words from shorter name must appear in longer name
+ * 2. Asymmetric word-boundary match: all recipe tokens must appear in inventory tokens
+ *    (but NOT vice versa - this prevents "flour" in inventory matching "almond flour" in recipe)
  *
  * Examples:
- * - "flour" matches "all-purpose flour" ✓ (flour is a word in the longer name)
- * - "rice" does NOT match "licorice" ✗ (rice is not a separate word)
- * - "olive oil" matches "extra virgin olive oil" ✓ (both words present)
+ * - Recipe "flour" matches inventory "all-purpose flour" ✓ (inventory has the required ingredient)
+ * - Recipe "almond flour" does NOT match inventory "flour" ✗ (inventory lacks "almond")
+ * - Recipe "rice" does NOT match inventory "licorice" ✗ (rice is not a separate word)
+ * - Recipe "olive oil" matches inventory "extra virgin olive oil" ✓ (both words present)
  */
 function ingredientMatchesInventoryItem(
   ingredientName: string,
@@ -53,18 +55,14 @@ function ingredientMatchesInventoryItem(
     return true
   }
 
-  // Word-boundary matching: tokenize both names and check if all words
-  // from the shorter name appear as complete words in the longer name
+  // Asymmetric word-boundary matching: all recipe tokens must be present in inventory
+  // This ensures recipe requirements are a subset of what's available in inventory
   const ingredientTokens = tokenizeIngredientName(normalizedIngredient)
   const inventoryTokens = tokenizeIngredientName(normalizedInventory)
 
-  // Check if all tokens from the shorter name are present in the longer name
-  // This handles cases like "flour" matching "all-purpose flour"
-  const shorterTokens = ingredientTokens.length <= inventoryTokens.length ? ingredientTokens : inventoryTokens
-  const longerTokens = ingredientTokens.length <= inventoryTokens.length ? inventoryTokens : ingredientTokens
-
-  // All words from shorter name must be present in longer name
-  return shorterTokens.every((token) => longerTokens.includes(token))
+  // All words from recipe ingredient must be present in inventory item
+  // (one-directional check prevents false positives)
+  return ingredientTokens.every((token) => inventoryTokens.includes(token))
 }
 
 export interface IngredientStockStatus {


### PR DESCRIPTION
## Work in Progress

Closes #385

Avoid bidirectional token matching issues

<!-- sharkrite-source-issue:356 -->## From PR #383 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
This identifies a real functional issue where "flour" in inventory would incorrectly match "almond flour" in a recipe, producing misleading results for users. However, the original issue scope explicitly states "Name-based matching (not quantity) for stock status check" and the fix addresses the specific false positive problem (rice/licorice). Redesigning the matching semantics to be asymmetric is a separate enhancement.

## Context
The PR successfully fixes the documented false positive issue (substring matching). The bidirectional matching behavior is a design decision that warrants discussion but exceeds the scope of fixing the rice/licorice problem.

## Defer Reason
Needs separate focused PR - changing matching semantics from bidirectional to asymmetric requires design discussion and comprehensive test suite updates

---
_Created by Sharkrite assessment on 2026-03-29T18:59:47Z_
_Parent PR: #383_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+0 added, ~2 modified, -0 deleted)
- `M` frontend/src/utils/__tests__/pantryMatcher.test.ts
- `M` frontend/src/utils/pantryMatcher.ts

### Commits
- 4d61642 fix: Avoid bidirectional token matching issues
- 4c5edfb chore: initialize work on #385 Avoid bidirectional token matching issues
<!-- /sharkrite-changes-summary -->