### PR TITLE
Handle token matching plurals and variants

### DIFF
--- a/frontend/src/utils/__tests__/pantryMatcher.test.ts
+++ b/frontend/src/utils/__tests__/pantryMatcher.test.ts
@@ -364,6 +364,34 @@ describe('pantryMatcher', () => {
       expect(result.inStockCount).toBe(1)
     })
 
+    it('matches "loaf" with "loaves" (-ves plural)', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: 'loaf' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'loaves' }),
+      ]
+
+      const result = checkIngredientAvailability(ingredients, inventoryItems)
+
+      expect(result.inStockCount).toBe(1)
+    })
+
+    it('matches "half" with "halves" (-ves plural)', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: 'half' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'halves' }),
+      ]
+
+      const result = checkIngredientAvailability(ingredients, inventoryItems)
+
+      expect(result.inStockCount).toBe(1)
+    })
+
     it('matches "cherry tomato" with "cherry tomatoes" (multi-word plural)', () => {
       const ingredients = [
         createIngredient({ ingredient_name: 'cherry tomato' }),

--- a/frontend/src/utils/__tests__/pantryMatcher.test.ts
+++ b/frontend/src/utils/__tests__/pantryMatcher.test.ts
@@ -276,6 +276,196 @@ describe('pantryMatcher', () => {
 
       expect(result.inStockCount).toBe(1)
     })
+
+    // Plural matching tests
+    it('matches "egg" recipe with "eggs" inventory (plural normalization)', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: 'egg' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'eggs' }),
+      ]
+
+      const result = checkIngredientAvailability(ingredients, inventoryItems)
+
+      expect(result.inStockCount).toBe(1)
+      expect(result.inStock[0].matchedInventoryItem?.name).toBe('eggs')
+    })
+
+    it('matches "eggs" recipe with "egg" inventory (bidirectional plural)', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: 'eggs' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'egg' }),
+      ]
+
+      const result = checkIngredientAvailability(ingredients, inventoryItems)
+
+      expect(result.inStockCount).toBe(1)
+      expect(result.inStock[0].matchedInventoryItem?.name).toBe('egg')
+    })
+
+    it('matches "tomato" with "tomatoes" (-oes plural)', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: 'tomato' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'tomatoes' }),
+      ]
+
+      const result = checkIngredientAvailability(ingredients, inventoryItems)
+
+      expect(result.inStockCount).toBe(1)
+    })
+
+    it('matches "potato" with "potatoes" (-oes plural)', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: 'potato' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'potatoes' }),
+      ]
+
+      const result = checkIngredientAvailability(ingredients, inventoryItems)
+
+      expect(result.inStockCount).toBe(1)
+    })
+
+    it('matches "berry" with "berries" (-ies plural)', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: 'berry' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'berries' }),
+      ]
+
+      const result = checkIngredientAvailability(ingredients, inventoryItems)
+
+      expect(result.inStockCount).toBe(1)
+    })
+
+    it('matches "cherry" with "cherries" (-ies plural)', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: 'cherry' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'cherries' }),
+      ]
+
+      const result = checkIngredientAvailability(ingredients, inventoryItems)
+
+      expect(result.inStockCount).toBe(1)
+    })
+
+    it('matches "cherry tomato" with "cherry tomatoes" (multi-word plural)', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: 'cherry tomato' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'cherry tomatoes' }),
+      ]
+
+      const result = checkIngredientAvailability(ingredients, inventoryItems)
+
+      expect(result.inStockCount).toBe(1)
+      expect(result.inStock[0].matchedInventoryItem?.name).toBe('cherry tomatoes')
+    })
+
+    it('matches "carrot" with "carrots" (regular -s plural)', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: 'carrot' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'carrots' }),
+      ]
+
+      const result = checkIngredientAvailability(ingredients, inventoryItems)
+
+      expect(result.inStockCount).toBe(1)
+    })
+
+    it('matches "peach" with "peaches" (-es plural)', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: 'peach' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'peaches' }),
+      ]
+
+      const result = checkIngredientAvailability(ingredients, inventoryItems)
+
+      expect(result.inStockCount).toBe(1)
+    })
+
+    it('matches "dish" with "dishes" (-es plural)', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: 'dish' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'dishes' }),
+      ]
+
+      const result = checkIngredientAvailability(ingredients, inventoryItems)
+
+      expect(result.inStockCount).toBe(1)
+    })
+
+    it('handles "glass noodles" correctly (word ending in ss)', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: 'glass noodles' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'glass noodles' }),
+      ]
+
+      const result = checkIngredientAvailability(ingredients, inventoryItems)
+
+      expect(result.inStockCount).toBe(1)
+    })
+
+    it('plural matching still prevents false positives (rice vs licorice)', () => {
+      // Ensure plural normalization doesn't break existing false-positive prevention
+      const ingredients = [
+        createIngredient({ ingredient_name: 'rice' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'licorice' }),
+      ]
+
+      const result = checkIngredientAvailability(ingredients, inventoryItems)
+
+      expect(result.inStockCount).toBe(0)
+      expect(result.outOfStock).toHaveLength(1)
+    })
+
+    it('plural matching maintains asymmetric behavior (almond flour vs flour)', () => {
+      // Ensure plural normalization doesn't break asymmetric matching
+      const ingredients = [
+        createIngredient({ ingredient_name: 'almond flour' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'flour' }),
+      ]
+
+      const result = checkIngredientAvailability(ingredients, inventoryItems)
+
+      expect(result.inStockCount).toBe(0)
+      expect(result.outOfStock).toHaveLength(1)
+    })
   })
 
   describe('areAllIngredientsInStock', () => {
@@ -408,6 +598,81 @@ describe('pantryMatcher', () => {
 
       const inventoryItems = [
         createInventoryItem({ name: 'extra virgin olive oil' }),
+      ]
+
+      const result = areAllIngredientsInStock(ingredients, inventoryItems)
+
+      expect(result).toBe(true)
+    })
+
+    // Plural matching tests for areAllIngredientsInStock
+    it('returns true when "egg" recipe matches "eggs" inventory (plural)', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: 'egg' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'eggs' }),
+      ]
+
+      const result = areAllIngredientsInStock(ingredients, inventoryItems)
+
+      expect(result).toBe(true)
+    })
+
+    it('returns true when "eggs" recipe matches "egg" inventory (bidirectional)', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: 'eggs' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'egg' }),
+      ]
+
+      const result = areAllIngredientsInStock(ingredients, inventoryItems)
+
+      expect(result).toBe(true)
+    })
+
+    it('returns true when "tomato" matches "tomatoes"', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: 'tomato' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'tomatoes' }),
+      ]
+
+      const result = areAllIngredientsInStock(ingredients, inventoryItems)
+
+      expect(result).toBe(true)
+    })
+
+    it('returns true when "cherry tomato" matches "cherry tomatoes"', () => {
+      const ingredients = [
+        createIngredient({ ingredient_name: 'cherry tomato' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ name: 'cherry tomatoes' }),
+      ]
+
+      const result = areAllIngredientsInStock(ingredients, inventoryItems)
+
+      expect(result).toBe(true)
+    })
+
+    it('returns true when all plural/singular matches are found', () => {
+      const ingredients = [
+        createIngredient({ id: 'ing-1', ingredient_name: 'egg' }),
+        createIngredient({ id: 'ing-2', ingredient_name: 'tomatoes' }),
+        createIngredient({ id: 'ing-3', ingredient_name: 'flour' }),
+      ]
+
+      const inventoryItems = [
+        createInventoryItem({ id: 'inv-1', name: 'eggs' }),
+        createInventoryItem({ id: 'inv-2', name: 'tomato' }),
+        createInventoryItem({ id: 'inv-3', name: 'all-purpose flour' }),
       ]
 
       const result = areAllIngredientsInStock(ingredients, inventoryItems)

--- a/frontend/src/utils/pantryMatcher.ts
+++ b/frontend/src/utils/pantryMatcher.ts
@@ -44,14 +44,10 @@ function normalizeWordForPlurals(word: string): string {
     return word.slice(0, -2)
   }
 
-  // Handle -ves -> -f or -fe (knives -> knife, shelves -> shelf)
+  // Handle -ves -> -f (loaves -> loaf, shelves -> shelf, halves -> half)
   if (word.endsWith('ves') && word.length > 3) {
-    // Try -fe first (knife, life, wife)
-    const baseFe = word.slice(0, -3) + 'fe'
-    // For most cases, -f is more common (shelf, half, loaf)
-    const baseF = word.slice(0, -3) + 'f'
-    // Use -f as default (covers more food items like "loaf")
-    return baseF
+    // Use -f as default (covers food items like "loaf", "half", "shelf")
+    return word.slice(0, -3) + 'f'
   }
 
   // Handle -ses -> -s (glasses -> glass - but keep for word boundaries)

--- a/frontend/src/utils/pantryMatcher.ts
+++ b/frontend/src/utils/pantryMatcher.ts
@@ -12,36 +12,116 @@ function normalizeIngredientName(name: string): string {
 }
 
 /**
+ * Normalizes a word to its singular/base form to handle plural matching
+ * Applies simple English pluralization rules for common food ingredients
+ *
+ * Examples:
+ * - "eggs" -> "egg"
+ * - "tomatoes" -> "tomato"
+ * - "berries" -> "berry"
+ * - "cherries" -> "cherry"
+ *
+ * Note: This is a lightweight approach focused on common food terms.
+ * It handles regular plurals (-s, -es) and common irregular patterns (-ies).
+ */
+function normalizeWordForPlurals(word: string): string {
+  // Skip very short words (likely not plurals, e.g., "as", "is")
+  if (word.length <= 2) {
+    return word
+  }
+
+  // Handle -ies -> -y (berries -> berry, cherries -> cherry)
+  if (word.endsWith('ies') && word.length > 3) {
+    // Check if the letter before 'ies' is a consonant (not a vowel)
+    const beforeIes = word[word.length - 4]
+    if (beforeIes && !'aeiou'.includes(beforeIes)) {
+      return word.slice(0, -3) + 'y'
+    }
+  }
+
+  // Handle -oes -> -o (tomatoes -> tomato, potatoes -> potato)
+  if (word.endsWith('oes') && word.length > 3) {
+    return word.slice(0, -2)
+  }
+
+  // Handle -ves -> -f or -fe (knives -> knife, shelves -> shelf)
+  if (word.endsWith('ves') && word.length > 3) {
+    // Try -fe first (knife, life, wife)
+    const baseFe = word.slice(0, -3) + 'fe'
+    // For most cases, -f is more common (shelf, half, loaf)
+    const baseF = word.slice(0, -3) + 'f'
+    // Use -f as default (covers more food items like "loaf")
+    return baseF
+  }
+
+  // Handle -ses -> -s (glasses -> glass - but keep for word boundaries)
+  if (word.endsWith('ses') && word.length > 4) {
+    return word.slice(0, -2)
+  }
+
+  // Handle regular -es plurals for words ending in s, x, z, ch, sh
+  // (dishes -> dish, peaches -> peach)
+  if (word.endsWith('es') && word.length > 3) {
+    const base = word.slice(0, -2)
+    // Only remove 'es' if the base ends in s, x, z, or has ch/sh pattern
+    if (base.endsWith('s') || base.endsWith('x') || base.endsWith('z') ||
+        base.endsWith('ch') || base.endsWith('sh')) {
+      return base
+    }
+  }
+
+  // Handle regular -s plural (eggs -> egg, carrots -> carrot)
+  if (word.endsWith('s') && word.length > 3) {
+    // Don't strip 's' from words that naturally end in 's' (e.g., "grass", "lentils")
+    // This is a simple heuristic: if removing 's' creates a very short word, keep it
+    const base = word.slice(0, -1)
+    // Keep words ending in 'ss' (grass, lentils would be caught earlier)
+    if (word.endsWith('ss')) {
+      return word
+    }
+    return base
+  }
+
+  return word
+}
+
+/**
  * Tokenizes an ingredient name into individual words
  * Splits on spaces, hyphens, and other delimiters
  * Filters out empty strings
+ * Normalizes each token for plural matching
  *
  * Examples:
  * - "all-purpose flour" -> ["all", "purpose", "flour"]
  * - "olive oil" -> ["olive", "oil"]
  * - "rice" -> ["rice"]
+ * - "cherry tomatoes" -> ["cherry", "tomato"]
+ * - "eggs" -> ["egg"]
  */
 function tokenizeIngredientName(name: string): string[] {
   return name
     .split(/[\s\-_/]+/) // Split on space, hyphen, underscore, slash
     .filter((word) => word.length > 0)
+    .map((word) => normalizeWordForPlurals(word)) // Normalize for plurals
 }
 
 /**
  * Checks if an ingredient name matches an inventory item name
- * Uses asymmetric word-boundary matching to prevent false positives
- * (e.g., "rice" should NOT match "licorice")
+ * Uses asymmetric word-boundary matching with plural normalization
  *
  * Matching strategy:
  * 1. Exact match after normalization
  * 2. Asymmetric word-boundary match: all recipe tokens must appear in inventory tokens
  *    (but NOT vice versa - this prevents "flour" in inventory matching "almond flour" in recipe)
+ * 3. Plural normalization: "egg" matches "eggs", "tomato" matches "tomatoes", etc.
  *
  * Examples:
  * - Recipe "flour" matches inventory "all-purpose flour" ✓ (inventory has the required ingredient)
  * - Recipe "almond flour" does NOT match inventory "flour" ✗ (inventory lacks "almond")
  * - Recipe "rice" does NOT match inventory "licorice" ✗ (rice is not a separate word)
  * - Recipe "olive oil" matches inventory "extra virgin olive oil" ✓ (both words present)
+ * - Recipe "egg" matches inventory "eggs" ✓ (plural normalization)
+ * - Recipe "cherry tomatoes" matches inventory "cherry tomato" ✓ (bidirectional plural matching)
  */
 function ingredientMatchesInventoryItem(
   ingredientName: string,

--- a/frontend/src/utils/pantryMatcher.ts
+++ b/frontend/src/utils/pantryMatcher.ts
@@ -50,8 +50,12 @@ function normalizeWordForPlurals(word: string): string {
     return word.slice(0, -3) + 'f'
   }
 
-  // Handle -ses -> -s (glasses -> glass - but keep for word boundaries)
+  // Handle -ses -> -s (glasses -> glass, but not -ases like bases -> base)
   if (word.endsWith('ses') && word.length > 4) {
+    // Check if it's -ases pattern (bases -> base, not bas)
+    if (word.endsWith('ases')) {
+      return word.slice(0, -1) // Remove just 's' to get 'base'
+    }
     return word.slice(0, -2)
   }
 
@@ -68,10 +72,10 @@ function normalizeWordForPlurals(word: string): string {
 
   // Handle regular -s plural (eggs -> egg, carrots -> carrot)
   if (word.endsWith('s') && word.length > 3) {
-    // Don't strip 's' from words that naturally end in 's' (e.g., "grass", "lentils")
+    // Don't strip 's' from words that naturally end in 's' (e.g., "grass")
     // This is a simple heuristic: if removing 's' creates a very short word, keep it
     const base = word.slice(0, -1)
-    // Keep words ending in 'ss' (grass, lentils would be caught earlier)
+    // Keep words ending in 'ss' (e.g., grass, bass)
     if (word.endsWith('ss')) {
       return word
     }


### PR DESCRIPTION
## Work in Progress

Closes #386

Handle token matching plurals and variants

<!-- sharkrite-source-issue:356 -->## From PR #383 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
This is a real functional limitation where "egg" won't match "eggs", causing false negatives. The review correctly notes this may be an intentional Phase 1 scope limitation. The original issue was about false positives (rice/licorice), not false negatives from pluralization.

## Context
The PR scope is fixing false positives in ingredient matching. Plural handling is a separate enhancement that would require adding stemming/normalization logic.

## Defer Reason
Scope exceeds time budget - plural handling requires designing a normalization strategy and is explicitly out of Phase 1 scope

---
_Created by Sharkrite assessment on 2026-03-29T18:59:47Z_
_Parent PR: #383_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+0 added, ~2 modified, -0 deleted)
- `M` frontend/src/utils/__tests__/pantryMatcher.test.ts
- `M` frontend/src/utils/pantryMatcher.ts

### Commits
- cc27e0d feat: Handle token matching plurals and variants
- f686e5c chore: initialize work on #386 Handle token matching plurals and variants
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues
 Updated: #402 
**From assessment on 2026-04-01T05:41:28Z:**
- Created: #402 
- Updated: none