### PR TITLE
Task Status Race Condition Window

### DIFF
--- a/alembic/versions/jd7ekzbu3mnq_add_processing_started_at.py
+++ b/alembic/versions/jd7ekzbu3mnq_add_processing_started_at.py
@@ -1,0 +1,45 @@
+"""add processing_started_at to processing_tasks
+
+Revision ID: jd7ekzbu3mnq
+Revises: ic6ciyat2lmp
+Create Date: 2026-03-31 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'jd7ekzbu3mnq'
+down_revision: Union[str, None] = 'ic6ciyat2lmp'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add processing_started_at timestamp to track task processing start time.
+
+    This field is used to detect stale tasks stuck in "processing" status
+    due to worker crashes, enabling automatic recovery.
+    """
+    # Add processing_started_at column
+    with op.batch_alter_table('processing_tasks', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column('processing_started_at', sa.DateTime(), nullable=True)
+        )
+
+        # Add index for efficient stale task detection queries
+        batch_op.create_index(
+            'ix_processing_tasks_status_processing_started_at',
+            ['status', 'processing_started_at'],
+            unique=False
+        )
+
+
+def downgrade() -> None:
+    """Remove processing_started_at field and its index."""
+    with op.batch_alter_table('processing_tasks', schema=None) as batch_op:
+        batch_op.drop_index('ix_processing_tasks_status_processing_started_at')
+        batch_op.drop_column('processing_started_at')

--- a/src/config.py
+++ b/src/config.py
@@ -56,6 +56,8 @@ class Settings(BaseSettings):
     ollama_model: str = "llama3.1:8b"
     # Polling interval for checking task status updates (seconds)
     task_poll_interval_seconds: int = Field(default=10, gt=0)
+    # Timeout for tasks stuck in "processing" status (seconds) - prevents race condition from worker crashes
+    task_processing_timeout_seconds: int = Field(default=300, gt=0)
 
 
 @lru_cache

--- a/src/db/models/processing_task.py
+++ b/src/db/models/processing_task.py
@@ -50,6 +50,10 @@ class ProcessingTask(Base):
     Processing tasks queue requests for LLM operations and track their
     status through the processing lifecycle. Results are stored as text
     references that can be resolved by the consuming service.
+
+    The processing_started_at timestamp enables automatic recovery of tasks
+    stuck in "processing" status due to worker crashes, preventing the race
+    condition window between status change and task completion.
     """
     __tablename__ = "processing_tasks"
 
@@ -68,9 +72,11 @@ class ProcessingTask(Base):
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
+    processing_started_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
 
-    # Compound index for efficient pending task queries
+    # Compound indexes for efficient task queries
     __table_args__ = (
         Index('ix_processing_tasks_status_created_at', 'status', 'created_at'),
+        Index('ix_processing_tasks_status_processing_started_at', 'status', 'processing_started_at'),
     )

--- a/src/schemas/task.py
+++ b/src/schemas/task.py
@@ -64,6 +64,7 @@ class ProcessingTaskResponse(BaseModel):
     error_message: Optional[str]
     created_at: datetime
     updated_at: datetime
+    processing_started_at: Optional[datetime]
     completed_at: Optional[datetime]
 
 

--- a/src/services/task_worker.py
+++ b/src/services/task_worker.py
@@ -8,12 +8,13 @@ Per ADR Section 2A: Background Task Processing
 - Sequential processing (no parallelism at household scale)
 - Graceful handling of Ollama unavailability (task stays pending)
 - Graceful handling of validation failures (task marked failed)
+- Automatic recovery of stale tasks (timeout-based, prevents race condition)
 - Clean shutdown on cancellation
 """
 
 import asyncio
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -86,6 +87,67 @@ async def process_receipt_task(
     )
 
 
+def recover_stale_tasks(session: Session) -> int:
+    """
+    Recover tasks stuck in "processing" status beyond the timeout window.
+
+    Detects tasks that have been in "processing" status longer than
+    task_processing_timeout_seconds and resets them to "pending" for retry.
+
+    This prevents tasks from being stuck forever if the worker crashes
+    between marking a task as "processing" and completing it.
+
+    Args:
+        session: Database session for queries and updates
+
+    Returns:
+        Number of tasks recovered
+    """
+    # Calculate timeout threshold
+    timeout_threshold = datetime.now(timezone.utc) - timedelta(
+        seconds=settings.task_processing_timeout_seconds
+    )
+
+    # Query for stale processing tasks
+    stmt = (
+        select(ProcessingTask)
+        .where(
+            ProcessingTask.status == TaskStatus.processing.value,
+            ProcessingTask.processing_started_at.isnot(None),
+            ProcessingTask.processing_started_at < timeout_threshold
+        )
+    )
+    result = session.execute(stmt)
+    stale_tasks = result.scalars().all()
+
+    if not stale_tasks:
+        return 0
+
+    # Reset stale tasks to pending
+    recovered_count = 0
+    for task in stale_tasks:
+        logger.warning(
+            "Recovering stale task stuck in processing",
+            extra={
+                "task_id": str(task.id),
+                "processing_started_at": task.processing_started_at.isoformat() if task.processing_started_at else None,
+                "timeout_seconds": settings.task_processing_timeout_seconds
+            }
+        )
+        task.status = TaskStatus.pending.value
+        task.processing_started_at = None
+        recovered_count += 1
+
+    session.commit()
+
+    logger.info(
+        f"Recovered {recovered_count} stale task(s)",
+        extra={"recovered_count": recovered_count}
+    )
+
+    return recovered_count
+
+
 async def process_pending_tasks() -> None:
     """
     Process all pending receipt_parse tasks sequentially.
@@ -101,6 +163,9 @@ async def process_pending_tasks() -> None:
     session = SessionFactory()
 
     try:
+        # Recover stale tasks before processing new ones
+        recover_stale_tasks(session)
+
         # Create Ollama client
         async with OllamaClient() as ollama_client:
             # Check if Ollama is available before processing
@@ -134,8 +199,9 @@ async def process_pending_tasks() -> None:
             # Process each task sequentially
             for task in pending_tasks:
                 try:
-                    # Mark task as processing
+                    # Mark task as processing and record start time
                     task.status = TaskStatus.processing.value
+                    task.processing_started_at = datetime.now(timezone.utc)
                     session.commit()
 
                     logger.info(
@@ -154,6 +220,7 @@ async def process_pending_tasks() -> None:
                         extra={"task_id": str(task.id)}
                     )
                     task.status = TaskStatus.pending.value
+                    task.processing_started_at = None
                     session.commit()
                     break  # Stop processing, retry next interval
 

--- a/tests/unit/services/test_task_worker.py
+++ b/tests/unit/services/test_task_worker.py
@@ -22,7 +22,8 @@ from uuid import uuid4
 from src.services.task_worker import (
     process_receipt_task,
     process_pending_tasks,
-    background_task_worker
+    background_task_worker,
+    recover_stale_tasks
 )
 from src.db.models.processing_task import ProcessingTask, TaskStatus, TaskType
 from src.schemas.receipt import ReceiptParseResult, ReceiptLineItem
@@ -206,7 +207,8 @@ async def test_process_pending_tasks_success(
 
     with patch("src.services.task_worker.get_session_factory", return_value=mock_session_factory):
         with patch("src.services.task_worker.OllamaClient", return_value=mock_ollama_client):
-            await process_pending_tasks()
+            with patch("src.services.task_worker.recover_stale_tasks", return_value=0):
+                await process_pending_tasks()
 
     # Verify task was updated to completed
     assert mock_task.status == TaskStatus.completed.value
@@ -233,11 +235,14 @@ async def test_process_pending_tasks_ollama_unavailable():
     mock_ollama_client.__aenter__.return_value = mock_ollama_client
     mock_ollama_client.__aexit__.return_value = None
 
+    # Mock recover_stale_tasks since it runs before Ollama check
     with patch("src.services.task_worker.get_session_factory", return_value=mock_session_factory):
         with patch("src.services.task_worker.OllamaClient", return_value=mock_ollama_client):
-            await process_pending_tasks()
+            with patch("src.services.task_worker.recover_stale_tasks", return_value=0):
+                await process_pending_tasks()
 
-    # Verify no query was executed (early return)
+    # Verify no task query was executed (early return after Ollama check)
+    # Note: recover_stale_tasks is mocked, so no actual execute calls
     mock_session.execute.assert_not_called()
 
     # Verify session was closed
@@ -271,7 +276,8 @@ async def test_process_pending_tasks_validation_failure(mock_task):
 
     with patch("src.services.task_worker.get_session_factory", return_value=mock_session_factory):
         with patch("src.services.task_worker.OllamaClient", return_value=mock_ollama_client):
-            await process_pending_tasks()
+            with patch("src.services.task_worker.recover_stale_tasks", return_value=0):
+                await process_pending_tasks()
 
     # Verify task was marked as failed
     assert mock_task.status == TaskStatus.failed.value
@@ -309,7 +315,8 @@ async def test_process_pending_tasks_ollama_unavailable_during_processing(mock_t
 
     with patch("src.services.task_worker.get_session_factory", return_value=mock_session_factory):
         with patch("src.services.task_worker.OllamaClient", return_value=mock_ollama_client):
-            await process_pending_tasks()
+            with patch("src.services.task_worker.recover_stale_tasks", return_value=0):
+                await process_pending_tasks()
 
     # Verify task was reverted to pending
     assert mock_task.status == TaskStatus.pending.value
@@ -340,7 +347,8 @@ async def test_process_pending_tasks_no_tasks():
 
     with patch("src.services.task_worker.get_session_factory", return_value=mock_session_factory):
         with patch("src.services.task_worker.OllamaClient", return_value=mock_ollama_client):
-            await process_pending_tasks()
+            with patch("src.services.task_worker.recover_stale_tasks", return_value=0):
+                await process_pending_tasks()
 
     # Verify no errors occurred
     # Verify session was closed
@@ -434,7 +442,8 @@ async def test_process_pending_tasks_unexpected_error(mock_task):
 
     with patch("src.services.task_worker.get_session_factory", return_value=mock_session_factory):
         with patch("src.services.task_worker.OllamaClient", return_value=mock_ollama_client):
-            await process_pending_tasks()
+            with patch("src.services.task_worker.recover_stale_tasks", return_value=0):
+                await process_pending_tasks()
 
     # Verify task was marked as failed
     assert mock_task.status == TaskStatus.failed.value
@@ -444,3 +453,180 @@ async def test_process_pending_tasks_unexpected_error(mock_task):
 
     # Verify session was closed
     mock_session.close.assert_called_once()
+
+
+def test_recover_stale_tasks_no_stale_tasks():
+    """Test stale task recovery when no tasks are stale."""
+    # Mock database query to return empty list
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+
+    mock_session = MagicMock()
+    mock_session.execute.return_value = mock_result
+    mock_session.commit = MagicMock()
+
+    # Recover stale tasks
+    recovered_count = recover_stale_tasks(mock_session)
+
+    # Verify no tasks were recovered
+    assert recovered_count == 0
+    mock_session.commit.assert_not_called()
+
+
+def test_recover_stale_tasks_with_stale_tasks():
+    """Test stale task recovery when tasks exceed timeout."""
+    from datetime import timedelta
+
+    # Create mock stale task (processing for 10 minutes)
+    stale_task = MagicMock(spec=ProcessingTask)
+    stale_task.id = uuid4()
+    stale_task.status = TaskStatus.processing.value
+    stale_task.processing_started_at = datetime.now(timezone.utc) - timedelta(minutes=10)
+
+    # Mock database query to return stale task
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [stale_task]
+
+    mock_session = MagicMock()
+    mock_session.execute.return_value = mock_result
+    mock_session.commit = MagicMock()
+
+    # Recover stale tasks
+    recovered_count = recover_stale_tasks(mock_session)
+
+    # Verify task was recovered
+    assert recovered_count == 1
+    assert stale_task.status == TaskStatus.pending.value
+    assert stale_task.processing_started_at is None
+    mock_session.commit.assert_called_once()
+
+
+def test_recover_stale_tasks_multiple_tasks():
+    """Test stale task recovery with multiple stale tasks."""
+    from datetime import timedelta
+
+    # Create multiple mock stale tasks
+    stale_task1 = MagicMock(spec=ProcessingTask)
+    stale_task1.id = uuid4()
+    stale_task1.status = TaskStatus.processing.value
+    stale_task1.processing_started_at = datetime.now(timezone.utc) - timedelta(minutes=10)
+
+    stale_task2 = MagicMock(spec=ProcessingTask)
+    stale_task2.id = uuid4()
+    stale_task2.status = TaskStatus.processing.value
+    stale_task2.processing_started_at = datetime.now(timezone.utc) - timedelta(minutes=15)
+
+    # Mock database query to return both tasks
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [stale_task1, stale_task2]
+
+    mock_session = MagicMock()
+    mock_session.execute.return_value = mock_result
+    mock_session.commit = MagicMock()
+
+    # Recover stale tasks
+    recovered_count = recover_stale_tasks(mock_session)
+
+    # Verify both tasks were recovered
+    assert recovered_count == 2
+    assert stale_task1.status == TaskStatus.pending.value
+    assert stale_task1.processing_started_at is None
+    assert stale_task2.status == TaskStatus.pending.value
+    assert stale_task2.processing_started_at is None
+    mock_session.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_process_pending_tasks_calls_recovery():
+    """Test that process_pending_tasks calls stale task recovery."""
+    # Mock database query to return no pending tasks
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+
+    mock_session = MagicMock()
+    mock_session.execute.return_value = mock_result
+    mock_session.close = MagicMock()
+
+    # Mock session factory
+    mock_session_factory = MagicMock(return_value=mock_session)
+
+    # Mock OllamaClient
+    mock_ollama_client = AsyncMock()
+    mock_ollama_client.is_available.return_value = True
+    mock_ollama_client.__aenter__.return_value = mock_ollama_client
+    mock_ollama_client.__aexit__.return_value = None
+
+    # Mock recover_stale_tasks to track if it's called
+    with patch("src.services.task_worker.get_session_factory", return_value=mock_session_factory), \
+         patch("src.services.task_worker.OllamaClient", return_value=mock_ollama_client), \
+         patch("src.services.task_worker.recover_stale_tasks") as mock_recover:
+        mock_recover.return_value = 0
+
+        await process_pending_tasks()
+
+        # Verify recovery was called
+        mock_recover.assert_called_once_with(mock_session)
+
+
+@pytest.mark.asyncio
+async def test_process_pending_tasks_sets_processing_started_at(mock_task, sample_receipt_result):
+    """Test that processing_started_at is set when task status changes to processing."""
+    # Mock database query to return one pending task
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [mock_task]
+
+    mock_session = MagicMock()
+    mock_session.execute.return_value = mock_result
+    mock_session.commit = MagicMock()
+    mock_session.close = MagicMock()
+
+    # Mock session factory
+    mock_session_factory = MagicMock(return_value=mock_session)
+
+    # Mock OllamaClient
+    mock_ollama_client = AsyncMock()
+    mock_ollama_client.is_available.return_value = True
+    mock_ollama_client.complete.return_value = sample_receipt_result
+    mock_ollama_client.__aenter__.return_value = mock_ollama_client
+    mock_ollama_client.__aexit__.return_value = None
+
+    with patch("src.services.task_worker.get_session_factory", return_value=mock_session_factory), \
+         patch("src.services.task_worker.OllamaClient", return_value=mock_ollama_client), \
+         patch("src.services.task_worker.recover_stale_tasks", return_value=0):
+        await process_pending_tasks()
+
+    # Verify processing_started_at was set
+    assert mock_task.processing_started_at is not None
+    assert isinstance(mock_task.processing_started_at, datetime)
+
+
+@pytest.mark.asyncio
+async def test_process_pending_tasks_clears_processing_started_at_on_unavailable(mock_task):
+    """Test that processing_started_at is cleared when reverting to pending on LLM unavailable."""
+    # Mock database query to return one pending task
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [mock_task]
+
+    mock_session = MagicMock()
+    mock_session.execute.return_value = mock_result
+    mock_session.commit = MagicMock()
+    mock_session.close = MagicMock()
+
+    # Mock session factory
+    mock_session_factory = MagicMock(return_value=mock_session)
+
+    # Mock OllamaClient - becomes unavailable during processing
+    mock_ollama_client = AsyncMock()
+    mock_ollama_client.is_available.return_value = True
+    mock_ollama_client.complete.side_effect = LLMUnavailableError("Connection lost")
+    mock_ollama_client.__aenter__.return_value = mock_ollama_client
+    mock_ollama_client.__aexit__.return_value = None
+
+    with patch("src.services.task_worker.get_session_factory", return_value=mock_session_factory), \
+         patch("src.services.task_worker.OllamaClient", return_value=mock_ollama_client), \
+         patch("src.services.task_worker.recover_stale_tasks", return_value=0):
+        await process_pending_tasks()
+
+    # Verify task was reverted to pending and processing_started_at was cleared
+    assert mock_task.status == TaskStatus.pending.value
+    assert mock_task.processing_started_at is None


### PR DESCRIPTION
## Work in Progress

Closes #389

Task Status Race Condition Window

<!-- sharkrite-source-issue:369 -->## From PR #388 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
This is a real, verifiable concern: if the worker crashes between lines 138-139 (marking processing) and completing the task, the task becomes stuck forever. However, fixing this requires adding a recovery mechanism (timeout-based recovery, heartbeat, or stale task detection) which is architectural work beyond the current scope.

## Context


## Defer Reason
Architectural refactor needed — requires designing a recovery mechanism (stale task timeout, heartbeat, or cleanup job) that exceeds the current issue scope

---
_Created by Sharkrite assessment on 2026-03-29T19:14:51Z_
_Parent PR: #388_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**6** files, **2** commits (+1 added, ~5 modified, -0 deleted)
- `A` alembic/versions/jd7ekzbu3mnq_add_processing_started_at.py
- `M` src/config.py
- `M` src/db/models/processing_task.py
- `M` src/schemas/task.py
- `M` src/services/task_worker.py
- `M` tests/unit/services/test_task_worker.py

### Commits
- 43d1a9b feat: Task Status Race Condition Window
- f19a9f8 chore: initialize work on #389 Task Status Race Condition Window
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-04-01T05:55:10Z:**
- Created: #405 
- Updated: none