### PR TITLE
Missing Index on user_id Foreign Key

### DIFF
--- a/alembic/versions/ke8flacv4noq_add_index_to_processing_tasks_user_id.py
+++ b/alembic/versions/ke8flacv4noq_add_index_to_processing_tasks_user_id.py
@@ -1,0 +1,45 @@
+"""add index to processing_tasks user_id
+
+Revision ID: ke8flacv4noq
+Revises: 1b4a5239984e
+Create Date: 2026-04-03 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'ke8flacv4noq'
+down_revision: Union[str, None] = '1b4a5239984e'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """
+    Add index to processing_tasks.user_id for query optimization.
+
+    While the current task status endpoint (GET /tasks/{task_id}) queries by
+    primary key first, this index provides:
+    - Performance optimization for foreign key constraints
+    - Future support for user-specific task listing (GET /users/{user_id}/tasks)
+    - Query planner hints for multi-tenant isolation checks
+
+    This is a standard best practice for foreign key columns in multi-tenant
+    systems to ensure efficient data access patterns as the application scales.
+    """
+    with op.batch_alter_table('processing_tasks', schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f('ix_processing_tasks_user_id'),
+            ['user_id'],
+            unique=False
+        )
+
+
+def downgrade() -> None:
+    """Remove index from processing_tasks.user_id."""
+    with op.batch_alter_table('processing_tasks', schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f('ix_processing_tasks_user_id'))

--- a/src/db/models/processing_task.py
+++ b/src/db/models/processing_task.py
@@ -12,7 +12,7 @@ from uuid import UUID, uuid4
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import String, Text, DateTime, func, Index
+from sqlalchemy import String, Text, DateTime, func, Index, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column
 
 from src.db.database import Base
@@ -60,6 +60,9 @@ class ProcessingTask(Base):
     # Primary key
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
 
+    # User ownership for multi-tenant isolation
+    user_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"), nullable=False)
+
     # Task classification
     task_type: Mapped[str] = mapped_column(String(50), nullable=False)
     status: Mapped[str] = mapped_column(String(50), nullable=False, default=TaskStatus.pending.value)
@@ -75,8 +78,12 @@ class ProcessingTask(Base):
     processing_started_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
 
-    # Compound indexes for efficient task queries
+    # Indexes for efficient task queries
     __table_args__ = (
+        # Compound index for pending task queries
         Index('ix_processing_tasks_status_created_at', 'status', 'created_at'),
+        # Compound index for stale task detection
         Index('ix_processing_tasks_status_processing_started_at', 'status', 'processing_started_at'),
+        # Single-column index for user-specific queries and foreign key performance
+        Index('ix_processing_tasks_user_id', 'user_id'),
     )


### PR DESCRIPTION
## Work in Progress

Closes #395

Missing Index on user_id Foreign Key

<!-- sharkrite-source-issue:368 -->## From PR #384 Assessment

**Severity:** HIGH
**Category:** ScopeCreep

## Issue
The index is a valid optimization for future queries, but the current task status endpoint queries by `task_id` (primary key) first, then checks `user_id` ownership. There is no user-specific listing query in scope. This is a speculative performance concern for queries that don't exist yet.

## Context
The acceptance criteria focuses on GET /tasks/{task_id} functionality. User listing endpoints are not part of this issue. The current query pattern (lookup by task_id, then check user_id) does not benefit from a user_id index.

## Defer Reason
Scope exceeds time budget - index is for anticipated future queries, not current functionality

---
_Created by Sharkrite assessment on 2026-03-29T20:23:55Z_
_Parent PR: #384_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **3** commits (+1 added, ~1 modified, -0 deleted)
- `A` alembic/versions/ke8flacv4noq_add_index_to_processing_tasks_user_id.py
- `M` src/db/models/processing_task.py

### Commits
- 1ca1c90 feat: Missing Index on user_id Foreign Key
- b00804d Merge remote-tracking branch 'origin/main' into feat/missing-index-on-userid-foreign-key
- 859a62e chore: initialize work on #395 Missing Index on user_id Foreign Key
<!-- /sharkrite-changes-summary -->