### PR TITLE
Suppress silent exceptions in sitemap strategy

### DIFF
--- a/.rite-todo.md
+++ b/.rite-todo.md
@@ -1,0 +1,23 @@
+# Todo List: Suppress silent exceptions in sitemap strategy
+
+## Phase 0: Requirements Clarification
+- [x] completed - Review task description and make reasonable assumptions
+
+## Phase 1: Analysis
+- [x] completed - Understanding the issue
+
+## Phase 2: Planning
+- [x] completed - Designing the implementation
+
+## Phase 3: Implementation
+- [x] completed - Implement the solution
+- [x] completed - Add proper error handling
+- [x] completed - Include comments for complex logic
+
+## Phase 4: Testing & Validation
+- [x] completed - Run modified test files (all tests pass!)
+- [x] completed - Verified no regressions
+
+## Phase 5: Code Comments
+- [x] completed - Reviewed and confirmed adequate inline comments
+

--- a/src/services/crawlers/hellofresh_crawler.py
+++ b/src/services/crawlers/hellofresh_crawler.py
@@ -115,6 +115,8 @@ class HelloFreshCrawler:
         logger.info("Starting HelloFresh recipe URL discovery")
 
         # Strategy 1: Try sitemap.xml first
+        # Capture any exception from sitemap strategy to preserve debugging context
+        sitemap_exception = None
         try:
             urls = self._discover_from_sitemap()
             if urls:
@@ -129,13 +131,17 @@ class HelloFreshCrawler:
             # Actual network errors - log and try fallback
             # This catches all requests exceptions: ConnectionError, Timeout, HTTPError, etc.
             logger.warning(f"Sitemap strategy failed with network error: {e}, trying fallback strategy")
-            # Don't raise yet - try fallback first
+            # Don't raise yet - try fallback first, but preserve exception for chaining
+            sitemap_exception = e
         except ValueError as e:
             # Wrap parsing errors at the public API boundary
             logger.warning(f"Sitemap strategy failed with parse error: {e}, trying fallback strategy")
-            # Don't raise yet - try fallback first
+            # Don't raise yet - try fallback first, but preserve exception for chaining
+            sitemap_exception = e
         except Exception as e:
             logger.warning(f"Sitemap strategy failed: {e}, trying fallback strategy")
+            # Preserve exception for chaining
+            sitemap_exception = e
 
         # Strategy 2: Fallback to paginated category crawl
         try:
@@ -150,16 +156,34 @@ class HelloFreshCrawler:
             # This catches all requests exceptions: ConnectionError, Timeout, HTTPError, etc.
             # These are genuine network/transport issues, not programming bugs
             logger.exception(f"Paginated category strategy failed with network error: {e}")
-            raise CrawlerNetworkError(f"Network error during URL discovery: {e}") from e
+
+            # Include context from sitemap failure if both strategies failed
+            if sitemap_exception:
+                error_msg = f"Network error during URL discovery: {e}. Sitemap strategy also failed: {sitemap_exception}"
+            else:
+                error_msg = f"Network error during URL discovery: {e}"
+            raise CrawlerNetworkError(error_msg) from e
         except ValueError as e:
             # Wrap parsing errors at the public API boundary
             logger.exception(f"Paginated category strategy failed with parse error: {e}")
-            raise CrawlerParseError(f"Parse error during URL discovery: {e}") from e
+
+            # Include context from sitemap failure if both strategies failed
+            if sitemap_exception:
+                error_msg = f"Parse error during URL discovery: {e}. Sitemap strategy also failed: {sitemap_exception}"
+            else:
+                error_msg = f"Parse error during URL discovery: {e}"
+            raise CrawlerParseError(error_msg) from e
         except Exception as e:
             # Unexpected errors (including requests.InvalidURL, etc.) - wrap as base CrawlerError
             # to avoid misrepresenting error type
             logger.exception(f"Paginated category strategy failed: {e}")
-            raise CrawlerError(f"Unexpected error during URL discovery: {e}") from e
+
+            # Include context from sitemap failure if both strategies failed
+            if sitemap_exception:
+                error_msg = f"Unexpected error during URL discovery: {e}. Sitemap strategy also failed: {sitemap_exception}"
+            else:
+                error_msg = f"Unexpected error during URL discovery: {e}"
+            raise CrawlerError(error_msg) from e
 
     def _discover_from_sitemap(self) -> list[str]:
         """


### PR DESCRIPTION
## Work in Progress

Closes #396

Suppress silent exceptions in sitemap strategy

<!-- sharkrite-source-issue:361 -->## From PR #392 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
The current behavior is intentional (comments indicate "Don't raise yet - try fallback first") and the fallback pattern works correctly. Improving exception chaining for better debugging context is a valid enhancement but not a bug fix.

## Context
This is an improvement to debugging experience, not a functional issue. The code works as designed. Enhancing exception chaining when both strategies fail would be nice but exceeds the current scope of wrapping requests exceptions.

## Defer Reason
Scope exceeds time budget - requires design decision on exception chaining strategy for multi-strategy fallback patterns

---
_Created by Sharkrite assessment on 2026-03-29T20:29:39Z_
_Parent PR: #392_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+1 added, ~1 modified, -0 deleted)
- `A` .rite-todo.md
- `M` src/services/crawlers/hellofresh_crawler.py

### Commits
- 65e76e1 feat: Suppress silent exceptions in sitemap strategy
- 33c4025 chore: initialize work on #396 Suppress silent exceptions in sitemap strategy
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-04-03T19:40:00Z:**
- Created: #416 
- Updated: none