### PR TITLE
Broad Exception Catch Loses Error Specificity

### DIFF
--- a/src/services/crawlers/base_crawler.py
+++ b/src/services/crawlers/base_crawler.py
@@ -163,8 +163,10 @@ class RobotsTxtParser:
             parser.read()
             logger.info(f"Successfully fetched robots.txt from {robots_url}")
         except Exception as e:
-            # If robots.txt fetch fails, initialize parser with empty rules
-            # to allow all crawling (consistent with "fail-open" policy)
+            # INTENTIONAL broad catch: Fail-open policy for robots.txt
+            # We want to continue crawling even if robots.txt fetch fails for ANY reason
+            # (network errors, parsing errors, encoding issues, etc.)
+            # This is acceptable because it's a graceful degradation, not error handling
             logger.warning(f"Failed to fetch robots.txt from {robots_url}: {type(e).__name__}: {e}")
             logger.info(f"Assuming crawling is allowed for {domain}")
             # Parse empty robots.txt (allows all URLs, no crawl delay)

--- a/src/services/crawlers/hellofresh_crawler.py
+++ b/src/services/crawlers/hellofresh_crawler.py
@@ -351,7 +351,7 @@ class HelloFreshCrawler:
             try:
                 response = self.session.get(page_url, timeout=10)
                 response.raise_for_status()
-            except (requests.exceptions.RequestException, OSError, IOError) as e:
+            except (requests.exceptions.RequestException, ssl.SSLError, ssl.CertificateError, OSError, IOError) as e:
                 # Catch specific network/I/O errors only - let programming bugs propagate
                 logger.error(f"Failed to fetch page {page_num}: {e}")
                 break

--- a/src/services/crawlers/hellofresh_crawler.py
+++ b/src/services/crawlers/hellofresh_crawler.py
@@ -128,6 +128,11 @@ class HelloFreshCrawler:
         except (CrawlerNetworkError, CrawlerParseError):
             # Re-raise crawler exceptions as-is (already wrapped)
             raise
+        except requests.exceptions.InvalidURL as e:
+            # Catch malformed URLs from external sitemaps - these are external data errors
+            logger.warning(f"Sitemap strategy failed with invalid URL: {e}, trying fallback strategy")
+            # Don't raise yet - try fallback first, but preserve exception for chaining
+            sitemap_exception = e
         except requests.exceptions.RequestException as e:
             # Actual network errors - log and try fallback
             # This catches all requests exceptions: ConnectionError, Timeout, HTTPError, etc.
@@ -153,6 +158,16 @@ class HelloFreshCrawler:
         except (CrawlerNetworkError, CrawlerParseError):
             # Re-raise crawler exceptions as-is (already wrapped)
             raise
+        except requests.exceptions.InvalidURL as e:
+            # Wrap malformed URLs from external data at the public API boundary
+            logger.exception(f"Paginated category strategy failed with invalid URL: {e}")
+
+            # Include context from sitemap failure if both strategies failed
+            if sitemap_exception:
+                error_msg = f"Invalid URL during URL discovery: {e}. Sitemap strategy also failed: {sitemap_exception}"
+            else:
+                error_msg = f"Invalid URL during URL discovery: {e}"
+            raise CrawlerNetworkError(error_msg) from e
         except requests.exceptions.RequestException as e:
             # Wrap actual network errors at the public API boundary
             # This catches all requests exceptions: ConnectionError, Timeout, HTTPError, etc.

--- a/src/services/crawlers/hellofresh_crawler.py
+++ b/src/services/crawlers/hellofresh_crawler.py
@@ -133,14 +133,11 @@ class HelloFreshCrawler:
             logger.warning(f"Sitemap strategy failed with network error: {e}, trying fallback strategy")
             # Don't raise yet - try fallback first, but preserve exception for chaining
             sitemap_exception = e
-        except ValueError as e:
-            # Wrap parsing errors at the public API boundary
-            logger.warning(f"Sitemap strategy failed with parse error: {e}, trying fallback strategy")
+        except (ValueError, UnicodeDecodeError, OSError) as e:
+            # Catch specific external errors: parsing, encoding, I/O issues
+            # Programming errors (AttributeError, TypeError, KeyError) will propagate
+            logger.warning(f"Sitemap strategy failed with {type(e).__name__}: {e}, trying fallback strategy")
             # Don't raise yet - try fallback first, but preserve exception for chaining
-            sitemap_exception = e
-        except Exception as e:
-            logger.warning(f"Sitemap strategy failed: {e}, trying fallback strategy")
-            # Preserve exception for chaining
             sitemap_exception = e
 
         # Strategy 2: Fallback to paginated category crawl
@@ -163,9 +160,9 @@ class HelloFreshCrawler:
             else:
                 error_msg = f"Network error during URL discovery: {e}"
             raise CrawlerNetworkError(error_msg) from e
-        except ValueError as e:
-            # Wrap parsing errors at the public API boundary
-            logger.exception(f"Paginated category strategy failed with parse error: {e}")
+        except (ValueError, UnicodeDecodeError) as e:
+            # Wrap parsing/encoding errors at the public API boundary
+            logger.exception(f"Paginated category strategy failed with {type(e).__name__}: {e}")
 
             # Include context from sitemap failure if both strategies failed
             if sitemap_exception:
@@ -173,16 +170,16 @@ class HelloFreshCrawler:
             else:
                 error_msg = f"Parse error during URL discovery: {e}"
             raise CrawlerParseError(error_msg) from e
-        except Exception as e:
-            # Unexpected errors (including requests.InvalidURL, etc.) - wrap as base CrawlerError
-            # to avoid misrepresenting error type
-            logger.exception(f"Paginated category strategy failed: {e}")
+        except (OSError, IOError) as e:
+            # Catch I/O errors specifically (network operations, file access)
+            # These are external errors, not programming bugs
+            logger.exception(f"Paginated category strategy failed with I/O error: {e}")
 
             # Include context from sitemap failure if both strategies failed
             if sitemap_exception:
-                error_msg = f"Unexpected error during URL discovery: {e}. Sitemap strategy also failed: {sitemap_exception}"
+                error_msg = f"I/O error during URL discovery: {e}. Sitemap strategy also failed: {sitemap_exception}"
             else:
-                error_msg = f"Unexpected error during URL discovery: {e}"
+                error_msg = f"I/O error during URL discovery: {e}"
             raise CrawlerError(error_msg) from e
 
     def _discover_from_sitemap(self) -> list[str]:
@@ -217,8 +214,9 @@ class HelloFreshCrawler:
             root = ET.fromstring(response.content)
         except ET.ParseError as e:
             raise ValueError(f"Failed to parse sitemap XML from {sitemap_url}: {e}")
-        except Exception as e:
-            raise ValueError(f"Error processing sitemap from {sitemap_url}: {e}")
+        except (UnicodeDecodeError, UnicodeError) as e:
+            # Catch encoding errors specifically - these are external data issues
+            raise ValueError(f"Encoding error processing sitemap from {sitemap_url}: {e}")
 
         # Handle sitemap index (sitemaps that link to other sitemaps)
         recipe_urls = []
@@ -250,8 +248,9 @@ class HelloFreshCrawler:
                             recipe_root = ET.fromstring(recipe_response.content)
                         except ET.ParseError as e:
                             raise ValueError(f"Failed to parse recipe sitemap XML from {recipe_sitemap_url}: {e}")
-                        except Exception as e:
-                            raise ValueError(f"Error processing recipe sitemap from {recipe_sitemap_url}: {e}")
+                        except (UnicodeDecodeError, UnicodeError) as e:
+                            # Catch encoding errors specifically - these are external data issues
+                            raise ValueError(f"Encoding error processing recipe sitemap from {recipe_sitemap_url}: {e}")
                         urls = self._extract_urls_from_sitemap(recipe_root, namespace)
                         recipe_urls.extend(urls)
                     else:
@@ -337,7 +336,8 @@ class HelloFreshCrawler:
             try:
                 response = self.session.get(page_url, timeout=10)
                 response.raise_for_status()
-            except Exception as e:
+            except (requests.exceptions.RequestException, OSError, IOError) as e:
+                # Catch specific network/I/O errors only - let programming bugs propagate
                 logger.error(f"Failed to fetch page {page_num}: {e}")
                 break
 

--- a/src/services/crawlers/hellofresh_crawler.py
+++ b/src/services/crawlers/hellofresh_crawler.py
@@ -6,6 +6,7 @@ category crawl fallback. Includes rate limiting and robots.txt compliance.
 """
 
 import logging
+import ssl
 import requests.exceptions
 import defusedxml.ElementTree as ET  # Use defusedxml for defense-in-depth XXE protection
 from typing import Optional
@@ -133,7 +134,11 @@ class HelloFreshCrawler:
             logger.warning(f"Sitemap strategy failed with network error: {e}, trying fallback strategy")
             # Don't raise yet - try fallback first, but preserve exception for chaining
             sitemap_exception = e
-        except (ValueError, UnicodeDecodeError, OSError) as e:
+        except (ssl.SSLError, ssl.CertificateError) as e:
+            # Catch SSL/TLS errors specifically - these are external network issues
+            logger.warning(f"Sitemap strategy failed with SSL error: {e}, trying fallback strategy")
+            sitemap_exception = e
+        except (ValueError, UnicodeDecodeError, OSError, IOError) as e:
             # Catch specific external errors: parsing, encoding, I/O issues
             # Programming errors (AttributeError, TypeError, KeyError) will propagate
             logger.warning(f"Sitemap strategy failed with {type(e).__name__}: {e}, trying fallback strategy")
@@ -159,6 +164,16 @@ class HelloFreshCrawler:
                 error_msg = f"Network error during URL discovery: {e}. Sitemap strategy also failed: {sitemap_exception}"
             else:
                 error_msg = f"Network error during URL discovery: {e}"
+            raise CrawlerNetworkError(error_msg) from e
+        except (ssl.SSLError, ssl.CertificateError) as e:
+            # Wrap SSL/TLS errors at the public API boundary
+            logger.exception(f"Paginated category strategy failed with SSL error: {e}")
+
+            # Include context from sitemap failure if both strategies failed
+            if sitemap_exception:
+                error_msg = f"SSL error during URL discovery: {e}. Sitemap strategy also failed: {sitemap_exception}"
+            else:
+                error_msg = f"SSL error during URL discovery: {e}"
             raise CrawlerNetworkError(error_msg) from e
         except (ValueError, UnicodeDecodeError) as e:
             # Wrap parsing/encoding errors at the public API boundary

--- a/src/services/crawlers/kitchen_sanctuary_crawler.py
+++ b/src/services/crawlers/kitchen_sanctuary_crawler.py
@@ -6,6 +6,7 @@ Includes rate limiting and robots.txt compliance.
 """
 
 import logging
+import ssl
 import requests.exceptions
 import defusedxml.ElementTree as ET  # Use defusedxml for defense-in-depth XXE protection
 from typing import Optional
@@ -128,6 +129,10 @@ class KitchenSanctuaryCrawler:
             # These are genuine network/transport issues, not programming bugs
             logger.exception(f"Sitemap strategy failed with network error: {e}")
             raise CrawlerNetworkError(f"Network error during URL discovery: {e}") from e
+        except (ssl.SSLError, ssl.CertificateError) as e:
+            # Wrap SSL/TLS errors at the public API boundary
+            logger.exception(f"Sitemap strategy failed with SSL error: {e}")
+            raise CrawlerNetworkError(f"SSL error during URL discovery: {e}") from e
         except (ValueError, UnicodeDecodeError) as e:
             # Wrap parsing/encoding errors at the public API boundary
             logger.exception(f"Sitemap strategy failed with {type(e).__name__}: {e}")
@@ -170,9 +175,11 @@ class KitchenSanctuaryCrawler:
                 if urls:
                     recipe_urls.extend(urls)
                     break  # Successfully found sitemap, stop trying other locations
-            except Exception as e:
-                # INTENTIONAL broad catch: Try next sitemap location if this one fails
-                # This is a fallback/retry pattern for robustness
+            except (requests.exceptions.RequestException, ssl.SSLError, ssl.CertificateError,
+                    ValueError, UnicodeDecodeError, OSError, IOError) as e:
+                # Try next sitemap location if this one fails with external errors
+                # This is a fallback/retry pattern for robustness - external errors only
+                # Programming errors (AttributeError, TypeError, KeyError) will propagate
                 logger.warning(f"Failed to fetch sitemap from {sitemap_url}: {e}")
                 continue
 
@@ -276,9 +283,11 @@ class KitchenSanctuaryCrawler:
                                 pages_fetched += 1
                             else:
                                 logger.warning(f"robots.txt disallows {sub_sitemap_url}")
-                        except Exception as e:
-                            # INTENTIONAL broad catch: Continue processing other sub-sitemaps
-                            # if one fails (robustness pattern for partial failures)
+                        except (requests.exceptions.RequestException, ssl.SSLError, ssl.CertificateError,
+                                ValueError, UnicodeDecodeError, OSError, IOError) as e:
+                            # Continue processing other sub-sitemaps if one fails with external errors
+                            # Robustness pattern for partial failures - external errors only
+                            # Programming errors (AttributeError, TypeError, KeyError) will propagate
                             logger.warning(f"Failed to fetch sub-sitemap {sub_sitemap_url}: {e}")
                             continue
         else:

--- a/src/services/crawlers/kitchen_sanctuary_crawler.py
+++ b/src/services/crawlers/kitchen_sanctuary_crawler.py
@@ -128,15 +128,14 @@ class KitchenSanctuaryCrawler:
             # These are genuine network/transport issues, not programming bugs
             logger.exception(f"Sitemap strategy failed with network error: {e}")
             raise CrawlerNetworkError(f"Network error during URL discovery: {e}") from e
-        except ValueError as e:
-            # Wrap parsing errors at the public API boundary
-            logger.exception(f"Sitemap strategy failed with parse error: {e}")
+        except (ValueError, UnicodeDecodeError) as e:
+            # Wrap parsing/encoding errors at the public API boundary
+            logger.exception(f"Sitemap strategy failed with {type(e).__name__}: {e}")
             raise CrawlerParseError(f"Parse error during URL discovery: {e}") from e
-        except Exception as e:
-            # Unexpected errors (including requests.InvalidURL, etc.) - wrap as base CrawlerError
-            # to avoid misrepresenting error type
-            logger.exception(f"Sitemap strategy failed: {e}")
-            raise CrawlerError(f"Unexpected error during URL discovery: {e}") from e
+        except (OSError, IOError) as e:
+            # Catch I/O errors specifically - these are external errors, not programming bugs
+            logger.exception(f"Sitemap strategy failed with I/O error: {e}")
+            raise CrawlerError(f"I/O error during URL discovery: {e}") from e
 
     def _discover_from_sitemap(self, max_pages: Optional[int] = None) -> list[str]:
         """
@@ -172,6 +171,8 @@ class KitchenSanctuaryCrawler:
                     recipe_urls.extend(urls)
                     break  # Successfully found sitemap, stop trying other locations
             except Exception as e:
+                # INTENTIONAL broad catch: Try next sitemap location if this one fails
+                # This is a fallback/retry pattern for robustness
                 logger.warning(f"Failed to fetch sitemap from {sitemap_url}: {e}")
                 continue
 
@@ -219,8 +220,9 @@ class KitchenSanctuaryCrawler:
             root = ET.fromstring(response.content)
         except ET.ParseError as e:
             raise ValueError(f"Failed to parse sitemap XML from {sitemap_url}: {e}")
-        except Exception as e:
-            raise ValueError(f"Error processing sitemap from {sitemap_url}: {e}")
+        except (UnicodeDecodeError, UnicodeError) as e:
+            # Catch encoding errors specifically - these are external data issues
+            raise ValueError(f"Encoding error processing sitemap from {sitemap_url}: {e}")
 
         # Define sitemap XML namespace for parsing
         namespace = {'ns': 'http://www.sitemaps.org/schemas/sitemap/0.9'}
@@ -264,8 +266,9 @@ class KitchenSanctuaryCrawler:
                                     sub_root = ET.fromstring(sub_response.content)
                                 except ET.ParseError as e:
                                     raise ValueError(f"Failed to parse sub-sitemap XML from {sub_sitemap_url}: {e}")
-                                except Exception as e:
-                                    raise ValueError(f"Error processing sub-sitemap from {sub_sitemap_url}: {e}")
+                                except (UnicodeDecodeError, UnicodeError) as e:
+                                    # Catch encoding errors specifically - these are external data issues
+                                    raise ValueError(f"Encoding error processing sub-sitemap from {sub_sitemap_url}: {e}")
 
                                 # Extract URLs from sub-sitemap
                                 urls = self._extract_recipe_urls_from_sitemap(sub_root, namespace)
@@ -274,6 +277,8 @@ class KitchenSanctuaryCrawler:
                             else:
                                 logger.warning(f"robots.txt disallows {sub_sitemap_url}")
                         except Exception as e:
+                            # INTENTIONAL broad catch: Continue processing other sub-sitemaps
+                            # if one fails (robustness pattern for partial failures)
                             logger.warning(f"Failed to fetch sub-sitemap {sub_sitemap_url}: {e}")
                             continue
         else:

--- a/tests/services/crawlers/test_crawler_exceptions.py
+++ b/tests/services/crawlers/test_crawler_exceptions.py
@@ -122,29 +122,47 @@ class TestHelloFreshCrawlerExceptionWrapping:
 
     @patch('src.services.crawlers.hellofresh_crawler.HelloFreshCrawler._configure_from_robots_txt')
     @patch('src.services.crawlers.hellofresh_crawler.HelloFreshCrawler._discover_from_sitemap')
-    def test_unexpected_error_wrapping(self, mock_discover_sitemap, mock_robots_config):
-        """Test that unexpected exceptions are wrapped in base CrawlerError."""
+    def test_programming_errors_propagate(self, mock_discover_sitemap, mock_robots_config):
+        """Test that programming errors (AttributeError, TypeError, etc.) propagate without wrapping.
+
+        This is the desired behavior after fixing broad exception catching.
+        Programming errors should NOT be caught so they can be debugged easily.
+        """
         crawler = HelloFreshCrawler()
 
-        # Mock sitemap strategy to fail with unexpected error (will be caught and fallback attempted)
-        mock_discover_sitemap.side_effect = RuntimeError("Unexpected runtime error")
+        # Mock sitemap strategy to fail with programming error
+        mock_discover_sitemap.side_effect = AttributeError("'NoneType' object has no attribute 'find'")
 
-        # Mock the fallback pagination to also fail with unexpected error
+        # Programming errors should propagate from sitemap strategy
+        # (they are NOT caught by the specific exception handlers)
+        with pytest.raises(AttributeError) as exc_info:
+            crawler.discover_recipe_urls()
+
+        # Verify the original programming error propagates unchanged
+        assert "'NoneType' object has no attribute 'find'" in str(exc_info.value)
+
+    @patch('src.services.crawlers.hellofresh_crawler.HelloFreshCrawler._configure_from_robots_txt')
+    @patch('src.services.crawlers.hellofresh_crawler.HelloFreshCrawler._discover_from_sitemap')
+    def test_io_error_wrapping(self, mock_discover_sitemap, mock_robots_config):
+        """Test that I/O errors are wrapped in base CrawlerError."""
+        crawler = HelloFreshCrawler()
+
+        # Mock sitemap strategy to succeed (return empty list to trigger fallback)
+        mock_discover_sitemap.return_value = []
+
+        # Mock the fallback pagination to fail with I/O error
         with patch.object(crawler, '_discover_from_paginated_categories') as mock_paginated:
-            mock_paginated.side_effect = RuntimeError("Unexpected runtime error")
+            mock_paginated.side_effect = OSError("Connection refused")
 
-            # Should raise CrawlerError (base class), not RuntimeError
+            # Should raise CrawlerError (base class) for I/O errors
             with pytest.raises(CrawlerError) as exc_info:
                 crawler.discover_recipe_urls()
 
-            # Verify it's not a subclass (should be base CrawlerError)
-            assert type(exc_info.value) == CrawlerError
-
             # Verify the error message contains context
-            assert "Unexpected error during URL discovery" in str(exc_info.value)
+            assert "I/O error during URL discovery" in str(exc_info.value)
 
             # Verify original exception is chained
-            assert isinstance(exc_info.value.__cause__, RuntimeError)
+            assert isinstance(exc_info.value.__cause__, OSError)
 
 
 class TestKitchenSanctuaryCrawlerExceptionWrapping:
@@ -187,25 +205,42 @@ class TestKitchenSanctuaryCrawlerExceptionWrapping:
 
     @patch('src.services.crawlers.kitchen_sanctuary_crawler.KitchenSanctuaryCrawler._configure_from_robots_txt')
     @patch('src.services.crawlers.kitchen_sanctuary_crawler.KitchenSanctuaryCrawler._discover_from_sitemap')
-    def test_unexpected_error_wrapping(self, mock_discover_sitemap, mock_robots_config):
-        """Test that unexpected exceptions are wrapped in base CrawlerError."""
+    def test_programming_errors_propagate(self, mock_discover_sitemap, mock_robots_config):
+        """Test that programming errors (TypeError, AttributeError, etc.) propagate without wrapping.
+
+        This is the desired behavior after fixing broad exception catching.
+        Programming errors should NOT be caught so they can be debugged easily.
+        """
         crawler = KitchenSanctuaryCrawler()
 
-        # Mock sitemap strategy to raise unexpected error
-        mock_discover_sitemap.side_effect = RuntimeError("Unexpected runtime error")
+        # Mock sitemap strategy to raise programming error
+        mock_discover_sitemap.side_effect = TypeError("'int' object is not iterable")
 
-        # Should raise CrawlerError (base class), not RuntimeError
+        # Programming errors should propagate without wrapping
+        with pytest.raises(TypeError) as exc_info:
+            crawler.discover_recipe_urls()
+
+        # Verify the original programming error propagates unchanged
+        assert "'int' object is not iterable" in str(exc_info.value)
+
+    @patch('src.services.crawlers.kitchen_sanctuary_crawler.KitchenSanctuaryCrawler._configure_from_robots_txt')
+    @patch('src.services.crawlers.kitchen_sanctuary_crawler.KitchenSanctuaryCrawler._discover_from_sitemap')
+    def test_io_error_wrapping(self, mock_discover_sitemap, mock_robots_config):
+        """Test that I/O errors are wrapped in base CrawlerError."""
+        crawler = KitchenSanctuaryCrawler()
+
+        # Mock sitemap strategy to raise I/O error
+        mock_discover_sitemap.side_effect = IOError("Network unreachable")
+
+        # Should raise CrawlerError (base class) for I/O errors
         with pytest.raises(CrawlerError) as exc_info:
             crawler.discover_recipe_urls()
 
-        # Verify it's not a subclass (should be base CrawlerError)
-        assert type(exc_info.value) == CrawlerError
-
         # Verify the error message contains context
-        assert "Unexpected error during URL discovery" in str(exc_info.value)
+        assert "I/O error during URL discovery" in str(exc_info.value)
 
         # Verify original exception is chained
-        assert isinstance(exc_info.value.__cause__, RuntimeError)
+        assert isinstance(exc_info.value.__cause__, IOError)
 
 
 class TestNoLeakyAbstractions:


### PR DESCRIPTION
## Work in Progress

Closes #397

Broad Exception Catch Loses Error Specificity

<!-- sharkrite-source-issue:361 -->## From PR #392 Assessment

**Severity:** HIGH
**Category:** CodeQuality

## Issue
The concern about catching all `Exception` types and wrapping them is valid - programming bugs like `AttributeError`, `TypeError` would be obscured. However, this is an architectural decision about error handling philosophy that goes beyond the PR's scope of wrapping `requests.exceptions` in custom types.

## Context
The original issue specifically targets "Leaky Abstraction: requests.exceptions Coupling." The PR correctly wraps requests exceptions. Changing how non-requests exceptions are handled is a separate design decision requiring team consensus.

## Defer Reason
Architectural refactor needed - requires design discussion on exception handling philosophy for programming errors vs external errors

---
_Created by Sharkrite assessment on 2026-03-30T01:26:16Z_
_Parent PR: #392_

---

## Additional Assessment (PR #392)

**Severity:** MEDIUM
**Reasoning:** This is substantively the same concern as the prior "Broad Exception Catch Loses Error Specificity" finding which was classified as ACTIONABLE_LATER. The concern about catching all `Exception` types and potentially masking programming bugs like `AttributeError`, `TypeError` remains valid but is an architectural decision about error handling philosophy.
**Context:** The original issue scope is about wrapping `requests.exceptions` in custom types to fix leaky abstraction. Changing the fallback exception handling strategy is a separate architectural decision that goes beyond that scope.
**Defer Reason:** Architectural refactor needed - requires decision on exception handling philosophy

_Added by Sharkrite on 2026-03-30T01:29:51Z_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**4** files, **2** commits (+0 added, ~4 modified, -0 deleted)
- `M` src/services/crawlers/base_crawler.py
- `M` src/services/crawlers/hellofresh_crawler.py
- `M` src/services/crawlers/kitchen_sanctuary_crawler.py
- `M` tests/services/crawlers/test_crawler_exceptions.py

### Commits
- a05e6f2 fix: Broad Exception Catch Loses Error Specificity
- b006f4d chore: initialize work on #397 Broad Exception Catch Loses Error Specificity
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues
Created: #419  Updated: #418 
**From assessment on 2026-04-03T19:50:59Z:**
- Created: #418 
- Updated: none