### PR TITLE
Missing Retry Limit for Stale Task Recovery

### DIFF
--- a/alembic/versions/lf9gmzbv5orr_add_retry_count_to_processing_tasks.py
+++ b/alembic/versions/lf9gmzbv5orr_add_retry_count_to_processing_tasks.py
@@ -1,0 +1,39 @@
+"""add retry_count to processing_tasks
+
+Revision ID: lf9gmzbv5orr
+Revises: ke8flacv4noq
+Create Date: 2026-04-03 14:30:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'lf9gmzbv5orr'
+down_revision: Union[str, None] = 'ke8flacv4noq'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add retry_count field to track stale task recovery attempts.
+
+    This field tracks how many times a task has been recovered from stale
+    "processing" status, preventing infinite retry loops for tasks that
+    consistently crash workers. When retry_count exceeds the configured
+    task_max_retry_count, the task is marked as failed instead of being
+    retried.
+    """
+    with op.batch_alter_table('processing_tasks', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column('retry_count', sa.Integer(), nullable=False, server_default='0')
+        )
+
+
+def downgrade() -> None:
+    """Remove retry_count field."""
+    with op.batch_alter_table('processing_tasks', schema=None) as batch_op:
+        batch_op.drop_column('retry_count')

--- a/src/config.py
+++ b/src/config.py
@@ -58,6 +58,8 @@ class Settings(BaseSettings):
     task_poll_interval_seconds: int = Field(default=10, gt=0)
     # Timeout for tasks stuck in "processing" status (seconds) - prevents race condition from worker crashes
     task_processing_timeout_seconds: int = Field(default=300, gt=0)
+    # Maximum retry count for stale task recovery before marking task as failed
+    task_max_retry_count: int = Field(default=3, ge=0)
 
 
 @lru_cache

--- a/src/db/models/processing_task.py
+++ b/src/db/models/processing_task.py
@@ -12,7 +12,7 @@ from uuid import UUID, uuid4
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import String, Text, DateTime, func, Index, ForeignKey
+from sqlalchemy import String, Text, DateTime, Integer, func, Index, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column
 
 from src.db.database import Base
@@ -54,6 +54,10 @@ class ProcessingTask(Base):
     The processing_started_at timestamp enables automatic recovery of tasks
     stuck in "processing" status due to worker crashes, preventing the race
     condition window between status change and task completion.
+
+    The retry_count field tracks how many times a task has been recovered
+    from stale status, preventing infinite retry loops for tasks that
+    consistently crash workers.
     """
     __tablename__ = "processing_tasks"
 
@@ -71,6 +75,9 @@ class ProcessingTask(Base):
     input_reference: Mapped[str] = mapped_column(Text, nullable=False)
     result_reference: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     error_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    # Retry tracking for stale task recovery
+    retry_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())

--- a/src/services/task_worker.py
+++ b/src/services/task_worker.py
@@ -93,16 +93,18 @@ def recover_stale_tasks(session: Session) -> int:
     Recover tasks stuck in "processing" status beyond the timeout window.
 
     Detects tasks that have been in "processing" status longer than
-    task_processing_timeout_seconds and resets them to "pending" for retry.
+    task_processing_timeout_seconds and either resets them to "pending"
+    for retry or marks them as "failed" if retry limit exceeded.
 
     This prevents tasks from being stuck forever if the worker crashes
-    between marking a task as "processing" and completing it.
+    between marking a task as "processing" and completing it, while also
+    preventing infinite retry loops for tasks that consistently crash workers.
 
     Args:
         session: Database session for queries and updates
 
     Returns:
-        Number of tasks recovered
+        Number of tasks recovered (includes both retried and failed tasks)
     """
     # Calculate timeout threshold
     timeout_threshold = datetime.now(timezone.utc) - timedelta(
@@ -124,19 +126,42 @@ def recover_stale_tasks(session: Session) -> int:
     if not stale_tasks:
         return 0
 
-    # Reset stale tasks to pending
+    # Process stale tasks: retry or fail based on retry count
     recovered_count = 0
     for task in stale_tasks:
-        logger.warning(
-            "Recovering stale task stuck in processing",
-            extra={
-                "task_id": str(task.id),
-                "processing_started_at": task.processing_started_at.isoformat() if task.processing_started_at else None,
-                "timeout_seconds": settings.task_processing_timeout_seconds
-            }
-        )
-        task.status = TaskStatus.pending.value
-        task.processing_started_at = None
+        # Check if retry limit exceeded
+        if task.retry_count >= settings.task_max_retry_count:
+            # Mark task as failed - retry limit exceeded
+            logger.warning(
+                "Task failed: retry limit exceeded",
+                extra={
+                    "task_id": str(task.id),
+                    "retry_count": task.retry_count,
+                    "max_retry_count": settings.task_max_retry_count,
+                    "processing_started_at": task.processing_started_at.isoformat() if task.processing_started_at else None
+                }
+            )
+            task.status = TaskStatus.failed.value
+            task.error_message = (
+                f"Task exceeded maximum retry limit ({settings.task_max_retry_count}) "
+                f"after repeated stale task recovery attempts"
+            )
+            task.completed_at = datetime.now(timezone.utc)
+        else:
+            # Reset to pending and increment retry count
+            logger.warning(
+                "Recovering stale task stuck in processing",
+                extra={
+                    "task_id": str(task.id),
+                    "retry_count": task.retry_count,
+                    "processing_started_at": task.processing_started_at.isoformat() if task.processing_started_at else None,
+                    "timeout_seconds": settings.task_processing_timeout_seconds
+                }
+            )
+            task.status = TaskStatus.pending.value
+            task.processing_started_at = None
+            task.retry_count += 1
+
         recovered_count += 1
 
     session.commit()

--- a/src/services/task_worker.py
+++ b/src/services/task_worker.py
@@ -104,7 +104,7 @@ def recover_stale_tasks(session: Session) -> int:
         session: Database session for queries and updates
 
     Returns:
-        Number of tasks recovered (includes both retried and failed tasks)
+        Number of tasks processed (includes both retried and failed tasks)
     """
     # Calculate timeout threshold
     timeout_threshold = datetime.now(timezone.utc) - timedelta(
@@ -127,7 +127,7 @@ def recover_stale_tasks(session: Session) -> int:
         return 0
 
     # Process stale tasks: retry or fail based on retry count
-    recovered_count = 0
+    processed_count = 0
     for task in stale_tasks:
         # Check if retry limit exceeded
         if task.retry_count >= settings.task_max_retry_count:
@@ -162,16 +162,16 @@ def recover_stale_tasks(session: Session) -> int:
             task.processing_started_at = None
             task.retry_count += 1
 
-        recovered_count += 1
+        processed_count += 1
 
     session.commit()
 
     logger.info(
-        f"Recovered {recovered_count} stale task(s)",
-        extra={"recovered_count": recovered_count}
+        f"Processed {processed_count} stale task(s)",
+        extra={"processed_count": processed_count}
     )
 
-    return recovered_count
+    return processed_count
 
 
 async def process_pending_tasks() -> None:

--- a/tests/unit/services/test_task_worker.py
+++ b/tests/unit/services/test_task_worker.py
@@ -56,6 +56,7 @@ def mock_task():
     task.error_message = None
     task.created_at = datetime.now(timezone.utc)
     task.completed_at = None
+    task.retry_count = 0
     return task
 
 
@@ -482,6 +483,7 @@ def test_recover_stale_tasks_with_stale_tasks():
     stale_task.id = uuid4()
     stale_task.status = TaskStatus.processing.value
     stale_task.processing_started_at = datetime.now(timezone.utc) - timedelta(minutes=10)
+    stale_task.retry_count = 0
 
     # Mock database query to return stale task
     mock_result = MagicMock()
@@ -494,10 +496,11 @@ def test_recover_stale_tasks_with_stale_tasks():
     # Recover stale tasks
     recovered_count = recover_stale_tasks(mock_session)
 
-    # Verify task was recovered
+    # Verify task was recovered and retry_count incremented
     assert recovered_count == 1
     assert stale_task.status == TaskStatus.pending.value
     assert stale_task.processing_started_at is None
+    assert stale_task.retry_count == 1
     mock_session.commit.assert_called_once()
 
 
@@ -510,11 +513,13 @@ def test_recover_stale_tasks_multiple_tasks():
     stale_task1.id = uuid4()
     stale_task1.status = TaskStatus.processing.value
     stale_task1.processing_started_at = datetime.now(timezone.utc) - timedelta(minutes=10)
+    stale_task1.retry_count = 0
 
     stale_task2 = MagicMock(spec=ProcessingTask)
     stale_task2.id = uuid4()
     stale_task2.status = TaskStatus.processing.value
     stale_task2.processing_started_at = datetime.now(timezone.utc) - timedelta(minutes=15)
+    stale_task2.retry_count = 1
 
     # Mock database query to return both tasks
     mock_result = MagicMock()
@@ -527,12 +532,14 @@ def test_recover_stale_tasks_multiple_tasks():
     # Recover stale tasks
     recovered_count = recover_stale_tasks(mock_session)
 
-    # Verify both tasks were recovered
+    # Verify both tasks were recovered and retry_counts incremented
     assert recovered_count == 2
     assert stale_task1.status == TaskStatus.pending.value
     assert stale_task1.processing_started_at is None
+    assert stale_task1.retry_count == 1
     assert stale_task2.status == TaskStatus.pending.value
     assert stale_task2.processing_started_at is None
+    assert stale_task2.retry_count == 2
     mock_session.commit.assert_called_once()
 
 
@@ -630,3 +637,134 @@ async def test_process_pending_tasks_clears_processing_started_at_on_unavailable
     # Verify task was reverted to pending and processing_started_at was cleared
     assert mock_task.status == TaskStatus.pending.value
     assert mock_task.processing_started_at is None
+
+
+def test_recover_stale_tasks_retry_limit_exceeded():
+    """Test that tasks exceeding retry limit are marked as failed."""
+    from datetime import timedelta
+    from src.config import get_settings
+
+    settings = get_settings()
+
+    # Create mock stale task that has already hit retry limit
+    stale_task = MagicMock(spec=ProcessingTask)
+    stale_task.id = uuid4()
+    stale_task.status = TaskStatus.processing.value
+    stale_task.processing_started_at = datetime.now(timezone.utc) - timedelta(minutes=10)
+    stale_task.retry_count = settings.task_max_retry_count  # Already at limit
+
+    # Mock database query to return stale task
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [stale_task]
+
+    mock_session = MagicMock()
+    mock_session.execute.return_value = mock_result
+    mock_session.commit = MagicMock()
+
+    # Recover stale tasks
+    recovered_count = recover_stale_tasks(mock_session)
+
+    # Verify task was marked as failed (not retried)
+    assert recovered_count == 1
+    assert stale_task.status == TaskStatus.failed.value
+    assert stale_task.error_message is not None
+    assert "retry limit" in stale_task.error_message.lower()
+    assert stale_task.completed_at is not None
+    # retry_count should NOT be incremented when task fails
+    assert stale_task.retry_count == settings.task_max_retry_count
+    mock_session.commit.assert_called_once()
+
+
+def test_recover_stale_tasks_mixed_retry_scenarios():
+    """Test recovery with mix of tasks: some to retry, some to fail."""
+    from datetime import timedelta
+    from src.config import get_settings
+
+    settings = get_settings()
+
+    # Create task 1: below retry limit (will be retried)
+    task1 = MagicMock(spec=ProcessingTask)
+    task1.id = uuid4()
+    task1.status = TaskStatus.processing.value
+    task1.processing_started_at = datetime.now(timezone.utc) - timedelta(minutes=10)
+    task1.retry_count = 1
+
+    # Create task 2: at retry limit (will be failed)
+    task2 = MagicMock(spec=ProcessingTask)
+    task2.id = uuid4()
+    task2.status = TaskStatus.processing.value
+    task2.processing_started_at = datetime.now(timezone.utc) - timedelta(minutes=15)
+    task2.retry_count = settings.task_max_retry_count
+
+    # Create task 3: below retry limit (will be retried)
+    task3 = MagicMock(spec=ProcessingTask)
+    task3.id = uuid4()
+    task3.status = TaskStatus.processing.value
+    task3.processing_started_at = datetime.now(timezone.utc) - timedelta(minutes=20)
+    task3.retry_count = 0
+
+    # Mock database query to return all tasks
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [task1, task2, task3]
+
+    mock_session = MagicMock()
+    mock_session.execute.return_value = mock_result
+    mock_session.commit = MagicMock()
+
+    # Recover stale tasks
+    recovered_count = recover_stale_tasks(mock_session)
+
+    # Verify all tasks were processed
+    assert recovered_count == 3
+
+    # Task 1: should be retried (retry_count incremented)
+    assert task1.status == TaskStatus.pending.value
+    assert task1.processing_started_at is None
+    assert task1.retry_count == 2
+
+    # Task 2: should be failed (at limit)
+    assert task2.status == TaskStatus.failed.value
+    assert task2.error_message is not None
+    assert task2.completed_at is not None
+    assert task2.retry_count == settings.task_max_retry_count
+
+    # Task 3: should be retried (retry_count incremented)
+    assert task3.status == TaskStatus.pending.value
+    assert task3.processing_started_at is None
+    assert task3.retry_count == 1
+
+    mock_session.commit.assert_called_once()
+
+
+def test_recover_stale_tasks_zero_retry_limit():
+    """Test recovery when retry limit is set to 0 (no retries allowed)."""
+    from datetime import timedelta
+
+    # Create stale task with retry_count = 0
+    stale_task = MagicMock(spec=ProcessingTask)
+    stale_task.id = uuid4()
+    stale_task.status = TaskStatus.processing.value
+    stale_task.processing_started_at = datetime.now(timezone.utc) - timedelta(minutes=10)
+    stale_task.retry_count = 0
+
+    # Mock database query
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [stale_task]
+
+    mock_session = MagicMock()
+    mock_session.execute.return_value = mock_result
+    mock_session.commit = MagicMock()
+
+    # Temporarily set retry limit to 0
+    with patch("src.services.task_worker.settings") as mock_settings:
+        mock_settings.task_max_retry_count = 0
+        mock_settings.task_processing_timeout_seconds = 300
+
+        # Recover stale tasks
+        recovered_count = recover_stale_tasks(mock_session)
+
+    # With limit=0 and retry_count=0, task should be failed (0 >= 0)
+    assert recovered_count == 1
+    assert stale_task.status == TaskStatus.failed.value
+    assert stale_task.error_message is not None
+    mock_session.commit.assert_called_once()


### PR DESCRIPTION
## Work in Progress

Closes #405

Missing Retry Limit for Stale Task Recovery

<!-- sharkrite-source-issue:389 -->## From PR #404 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
This is a valid bug risk concern - tasks that consistently crash workers will cycle indefinitely. However, implementing retry tracking requires adding a new database field, migration, and logic changes that constitute architectural work beyond the immediate race condition fix.

## Context
The original issue scope was specifically to prevent tasks from being stuck permanently after worker crashes. Adding retry limiting is a separate concern that enhances the recovery mechanism but is not required for the core fix to function correctly.

## Defer Reason
Architectural refactor needed — requires new database field, migration, and logic changes that exceed the immediate scope of preventing stuck tasks

---
_Created by Sharkrite assessment on 2026-04-01T05:55:10Z_
_Parent PR: #404_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**5** files, **2** commits (+1 added, ~4 modified, -0 deleted)
- `A` alembic/versions/lf9gmzbv5orr_add_retry_count_to_processing_tasks.py
- `M` src/config.py
- `M` src/db/models/processing_task.py
- `M` src/services/task_worker.py
- `M` tests/unit/services/test_task_worker.py

### Commits
- 7b329ee feat: Missing Retry Limit for Stale Task Recovery
- eaf6d7b chore: initialize work on #405 Missing Retry Limit for Stale Task Recovery
<!-- /sharkrite-changes-summary -->