### PR TITLE
ZIP Code Pattern May Match Numbers in URL Paths

### DIFF
--- a/.scratchpad.md
+++ b/.scratchpad.md
@@ -1,5 +1,33 @@
 # Scratchpad
 
+## Todo List - ZIP Code Pattern May Match Numbers in URL Paths
+
+- [x] Phase 0: Requirements Clarification - Ask questions if task is ambiguous (AUTO MODE: Proceeding with reasonable assumptions)
+- [x] Phase 1: Analysis - Understanding the codebase and requirements
+  - Found ZIP_CODE pattern at src/utils/sanitize.py:61-63
+  - Pattern excludes ports (`:11434`) but NOT URL paths (`/users/12345`)
+  - Confirmed with test: URL paths are incorrectly matched as ZIP codes
+  - Need to enhance negative lookbehind to exclude forward slashes
+- [x] Phase 2: Planning - Designing the implementation approach
+  - Change pattern from `(?<!:)` to `(?<![:\/])`
+  - Add `/` to negative lookbehind character class
+  - Verified with test: all cases pass (URLs excluded, real ZIPs matched)
+  - Will add comprehensive test cases to prevent regression
+- [x] Phase 3: Implementation - Writing the code
+  - Updated ZIP_CODE pattern in src/utils/sanitize.py:63-64
+  - Added test_zip_code_pattern_excludes_url_paths()
+  - Added test_zip_code_pattern_excludes_ports()
+  - Added test_api_error_with_url_path_not_redacted() integration test
+- [x] Phase 4: Testing & Validation - Running tests and verifying correctness
+  - Verified imports compile successfully
+  - All new tests pass (URL path exclusion, port exclusion)
+  - All existing tests pass (backward compatibility maintained)
+  - Integration tests confirm URLs preserved, actual ZIPs redacted
+- [x] Phase 5: Code Comments - Adding inline comments for complex logic
+  - Comments added to ZIP_CODE pattern explaining exclusions
+  - Test docstrings reference Issue #409
+  - Code is well-documented and self-explanatory
+
 ## Encountered Issues (Needs Triage)
 
 - **2026-03-24** | `InventoryRow.tsx:181` | code-smell | Type mismatch: storage_location is string in InventoryItemListResponse but StorageLocation enum expected by StorageBadge | Affects: Type safety in inventory components | Fix: Update InventoryItemListResponse.storage_location type to StorageLocation enum in types.ts | Done: TypeScript compilation passes without type errors

--- a/src/utils/sanitize.py
+++ b/src/utils/sanitize.py
@@ -57,9 +57,11 @@ class PIIPatterns:
     )
 
     # US ZIP codes: 12345 or 12345-6789
-    # Use word boundaries and require not preceded by colon to avoid matching ports
+    # Use word boundaries and negative lookbehind to avoid matching:
+    # - Port numbers (preceded by colon): localhost:12345
+    # - URL path segments (preceded by slash): /users/12345
     ZIP_CODE: Pattern[str] = re.compile(
-        r'(?<!:)\b\d{5}(?:-\d{4})?\b'
+        r'(?<![:\/])\b\d{5}(?:-\d{4})?\b'
     )
 
 

--- a/tests/test_utils/test_sanitize.py
+++ b/tests/test_utils/test_sanitize.py
@@ -99,6 +99,38 @@ class TestPIIPatterns:
             match = PIIPatterns.ZIP_CODE.search(text)
             assert match is not None, f"Failed to match: {zip_code}"
 
+    def test_zip_code_pattern_excludes_url_paths(self):
+        """ZIP code pattern should NOT match 5-digit numbers in URL paths.
+
+        Per Issue #409: URL path segments should not be redacted as ZIP codes
+        to avoid false positives in error messages containing URLs.
+        """
+        # Should NOT match: 5-digit numbers in URL paths
+        test_cases = [
+            "http://api.example.com/users/12345",
+            "https://example.com/orders/98765/items",
+            "GET /products/54321",
+            "https://example.com/zip/12345",
+            "/api/v1/resource/11111",
+        ]
+        for url in test_cases:
+            match = PIIPatterns.ZIP_CODE.search(url)
+            assert match is None, f"Should not match URL path in: {url}"
+
+    def test_zip_code_pattern_excludes_ports(self):
+        """ZIP code pattern should NOT match port numbers.
+
+        Existing behavior: port numbers should not be redacted as ZIP codes.
+        """
+        test_cases = [
+            "http://localhost:11434/api/generate",
+            "connect to 127.0.0.1:54321",
+            "server:12345",
+        ]
+        for text in test_cases:
+            match = PIIPatterns.ZIP_CODE.search(text)
+            assert match is None, f"Should not match port in: {text}"
+
 
 class TestSanitizeExceptionMessage:
     """Test exception message sanitization."""
@@ -330,3 +362,35 @@ class TestIntegrationScenarios:
         # Verify context is preserved
         assert "IntegrityError" in result
         assert "duplicate key" in result
+
+    def test_api_error_with_url_path_not_redacted(self):
+        """
+        Test that API errors with URLs don't have path segments redacted.
+
+        Per Issue #409: URL path segments should not be redacted as ZIP codes.
+        This ensures error messages with URLs remain useful for debugging.
+        """
+        # Test case 1: REST API error with numeric ID in path
+        error_message = (
+            "Failed to fetch user: GET http://api.example.com/users/12345 "
+            "returned 404 Not Found"
+        )
+        result = sanitize_exception_message(error_message)
+
+        # URL path should NOT be redacted
+        assert "/users/12345" in result
+        assert "[ZIP_REDACTED]" not in result
+        assert "api.example.com" in result
+
+        # Test case 2: Error with both URL and actual ZIP code
+        error_message_mixed = (
+            "API error for user at 90210: "
+            "GET https://example.com/orders/98765 failed"
+        )
+        result_mixed = sanitize_exception_message(error_message_mixed)
+
+        # URL path should NOT be redacted
+        assert "/orders/98765" in result_mixed
+        # But actual ZIP code SHOULD be redacted
+        assert "90210" not in result_mixed
+        assert "[ZIP_REDACTED]" in result_mixed


### PR DESCRIPTION
## Work in Progress

Closes #409

ZIP Code Pattern May Match Numbers in URL Paths

<!-- sharkrite-source-issue:377 -->## From PR #398 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
This is a real functional concern but edge-case in nature. URL path segments being redacted as ZIP codes is a valid bug, but the primary attack surface (error messages containing PII) is addressed. The port exclusion shows awareness of the problem; path segments are a secondary concern.

## Context
While related to the original issue scope, this requires additional regex engineering and test coverage that extends beyond the core security fix. The current implementation covers the main use cases.

## Defer Reason
Scope exceeds time budget—requires careful regex design and additional test cases for URL path handling

---
_Created by Sharkrite assessment on 2026-04-03T05:59:06Z_
_Parent PR: #398_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **2** commits (+0 added, ~3 modified, -0 deleted)
- `M` .scratchpad.md
- `M` src/utils/sanitize.py
- `M` tests/test_utils/test_sanitize.py

### Commits
- 511987b feat: ZIP Code Pattern May Match Numbers in URL Paths
- 4994a01 chore: initialize work on #409 ZIP Code Pattern May Match Numbers in URL Paths
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-04-04T00:05:29Z:**
- Created: #425 
- Updated: none