### PR TITLE
Monkey-patching pytest internals fragility

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,31 +3,125 @@ Pytest configuration and shared fixtures for all tests.
 
 This module provides test infrastructure improvements, particularly for
 managing the settings cache to prevent test pollution.
+
+Pytest-asyncio Compatibility Patch (Python 3.14+):
+    In Python 3.14+, pytest-asyncio expects the Package class from pytest's
+    internal API to have an 'obj' attribute that represents the package object.
+    This attribute was present in earlier pytest versions but was removed or
+    changed in the internal API refactoring.
+
+    Without this patch, pytest-asyncio's fixture collection fails when trying
+    to access Package.obj, causing test collection to fail with AttributeError.
+
+    This monkey-patch adds the missing 'obj' attribute dynamically when accessed,
+    maintaining backward compatibility with older Python/pytest versions while
+    fixing compatibility with Python 3.14+.
+
+    Related: PR #394 (Ollama integration tests)
+    Severity: MEDIUM - affects test infrastructure, not production code
 """
 
 import os
+import sys
+import warnings
 
 import pytest
 from _pytest.python import Package
 
 
-# Patch Package class to add obj property for pytest-asyncio compatibility with Python 3.14
-# This must be done at module level before pytest_asyncio hooks are registered
-if not hasattr(Package, '_original_getattribute'):
-    _original_getattribute = Package.__getattribute__
+# ============================================================================
+# PYTEST-ASYNCIO COMPATIBILITY PATCH FOR PYTHON 3.14+
+# ============================================================================
+# This patch must be applied at module level before pytest_asyncio hooks
+# are registered during test collection.
 
-    def _patched_getattribute(self, name):
-        if name == 'obj' and not hasattr(type(self), 'obj'):
-            # Return a simple namespace that can have attributes set on it
-            class DummyObj:
-                pass
-            # Cache it on the instance
-            object.__setattr__(self, 'obj', DummyObj())
-            return object.__getattribute__(self, 'obj')
-        return _original_getattribute(self, name)
+def _apply_package_obj_patch():
+    """
+    Apply monkey-patch to _pytest.python.Package for pytest-asyncio compatibility.
 
-    Package.__getattribute__ = _patched_getattribute
-    Package._original_getattribute = _original_getattribute
+    Python 3.14+ introduced changes that affect how pytest's internal Package
+    class works with pytest-asyncio. This function patches Package.__getattribute__
+    to dynamically provide an 'obj' attribute when accessed.
+
+    The patch:
+    1. Only applies on Python 3.14+ (where the issue occurs)
+    2. Checks if already patched to prevent double-patching
+    3. Validates Package class structure before patching
+    4. Fails gracefully with warnings if patching encounters issues
+
+    Returns:
+        bool: True if patch was applied successfully, False otherwise
+    """
+    # Only apply patch for Python 3.14+
+    if sys.version_info < (3, 14):
+        return False
+
+    # Check if already patched (prevents double-patching)
+    if hasattr(Package, '_original_getattribute'):
+        return True  # Already patched
+
+    try:
+        # Validate that Package class has the expected structure
+        if not hasattr(Package, '__getattribute__'):
+            warnings.warn(
+                "Cannot apply pytest-asyncio compatibility patch: "
+                "Package class missing __getattribute__ method. "
+                "Tests may fail with pytest-asyncio on Python 3.14+.",
+                RuntimeWarning,
+                stacklevel=2
+            )
+            return False
+
+        # Store original __getattribute__ method
+        _original_getattribute = Package.__getattribute__
+
+        def _patched_getattribute(self, name):
+            """
+            Patched __getattribute__ that provides 'obj' attribute on demand.
+
+            When pytest-asyncio tries to access Package.obj, this method:
+            1. Checks if 'obj' is being requested
+            2. Verifies 'obj' doesn't already exist as a class attribute
+            3. Creates a dummy object and caches it on the instance
+            4. Returns the cached obj for subsequent accesses
+
+            For all other attribute accesses, delegates to the original method.
+            """
+            if name == 'obj' and not hasattr(type(self), 'obj'):
+                # Create a simple dummy object that can have attributes set on it
+                # This satisfies pytest-asyncio's expectations without affecting
+                # actual package collection behavior
+                class DummyObj:
+                    """Placeholder object for Package.obj compatibility."""
+                    pass
+
+                # Cache the dummy obj on the instance to ensure consistency
+                # across multiple accesses within the same test collection
+                object.__setattr__(self, 'obj', DummyObj())
+                return object.__getattribute__(self, 'obj')
+
+            # For all other attributes, use the original __getattribute__
+            return _original_getattribute(self, name)
+
+        # Apply the patch
+        Package.__getattribute__ = _patched_getattribute
+        Package._original_getattribute = _original_getattribute
+
+        return True
+
+    except Exception as e:
+        # Log warning but don't fail - tests might still work on older versions
+        warnings.warn(
+            f"Failed to apply pytest-asyncio compatibility patch: {e}. "
+            f"Tests may fail with pytest-asyncio on Python 3.14+.",
+            RuntimeWarning,
+            stacklevel=2
+        )
+        return False
+
+
+# Apply the patch at module import time
+_apply_package_obj_patch()
 
 
 def pytest_configure(config):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,12 +107,24 @@ def _apply_package_obj_patch():
         Package.__getattribute__ = _patched_getattribute
         Package._original_getattribute = _original_getattribute
 
+        # Validate that the patch was applied successfully
+        if Package.__getattribute__ != _patched_getattribute:
+            warnings.warn(
+                "pytest-asyncio compatibility patch failed to apply: "
+                "__getattribute__ assignment did not take effect. "
+                "Tests may fail with pytest-asyncio on Python 3.14+.",
+                RuntimeWarning,
+                stacklevel=2
+            )
+            return False
+
         return True
 
     except Exception as e:
         # Log warning but don't fail - tests might still work on older versions
         warnings.warn(
-            f"Failed to apply pytest-asyncio compatibility patch: {e}. "
+            f"Failed to apply pytest-asyncio compatibility patch: "
+            f"{type(e).__name__}: {e}. "
             f"Tests may fail with pytest-asyncio on Python 3.14+.",
             RuntimeWarning,
             stacklevel=2


### PR DESCRIPTION
## Work in Progress

Closes #411

Monkey-patching pytest internals fragility

<!-- sharkrite-source-issue:371 -->## From PR #394 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
The monkey-patch is necessary for Python 3.14 compatibility and works correctly with defensive guards. Adding version checks and documentation improves maintainability but is not blocking for the Ollama integration tests being implemented.

## Context
This is in `conftest.py` which is shared test infrastructure, not part of the Ollama integration test implementation specified in the issue scope. The workaround is functional and the PR can merge without these improvements.

## Defer Reason
Scope exceeds time budget - documentation and version guards are infrastructure improvements unrelated to the Ollama integration test feature

---
_Created by Sharkrite assessment on 2026-04-03T07:21:42Z_
_Parent PR: #394_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**1** files, **2** commits (+0 added, ~1 modified, -0 deleted)
- `M` tests/conftest.py

### Commits
- 416b0be test: Monkey-patching pytest internals fragility
- b5ba41b chore: initialize work on #411 Monkey-patching pytest internals fragility
<!-- /sharkrite-changes-summary -->