### PR TITLE
Inconsistent Exception Handling Between Crawlers

### DIFF
--- a/src/services/crawlers/hellofresh_crawler.py
+++ b/src/services/crawlers/hellofresh_crawler.py
@@ -96,6 +96,15 @@ class HelloFreshCrawler:
         Attempts to discover URLs using sitemap.xml first, falling back to
         paginated category crawling if sitemap is unavailable or fails.
 
+        Exception Handling:
+            This method uses standardized exception handling (aligned with KitchenSanctuaryCrawler):
+            - InvalidURL -> CrawlerNetworkError
+            - RequestException (Connection, Timeout, HTTP errors) -> CrawlerNetworkError
+            - SSL/Certificate errors -> CrawlerNetworkError
+            - Parsing errors (ValueError, UnicodeDecodeError) -> CrawlerParseError
+            - I/O errors (OSError, IOError) -> CrawlerError
+            - Programming errors (AttributeError, TypeError, etc.) propagate unchanged
+
         Args:
             max_pages: Maximum number of pages to crawl (for fallback strategy only).
                       None means no limit. Used primarily for testing.

--- a/src/services/crawlers/hellofresh_crawler.py
+++ b/src/services/crawlers/hellofresh_crawler.py
@@ -140,8 +140,9 @@ class HelloFreshCrawler:
         except requests.exceptions.InvalidURL as e:
             # Wrap malformed URLs from external data at the public API boundary
             # This catches InvalidURL exceptions from external sitemaps - these are external data errors
-            logger.exception(f"Sitemap strategy failed with invalid URL: {e}")
-            raise CrawlerNetworkError(f"Invalid URL during URL discovery: {e}") from e
+            logger.warning(f"Sitemap strategy failed with invalid URL: {e}, trying fallback strategy")
+            # Don't raise yet - try fallback first, but preserve exception for chaining
+            sitemap_exception = e
         except requests.exceptions.RequestException as e:
             # Actual network errors - log and try fallback
             # This catches all requests exceptions: ConnectionError, Timeout, HTTPError, etc.

--- a/src/services/crawlers/hellofresh_crawler.py
+++ b/src/services/crawlers/hellofresh_crawler.py
@@ -138,10 +138,10 @@ class HelloFreshCrawler:
             # Re-raise crawler exceptions as-is (already wrapped)
             raise
         except requests.exceptions.InvalidURL as e:
-            # Catch malformed URLs from external sitemaps - these are external data errors
-            logger.warning(f"Sitemap strategy failed with invalid URL: {e}, trying fallback strategy")
-            # Don't raise yet - try fallback first, but preserve exception for chaining
-            sitemap_exception = e
+            # Wrap malformed URLs from external data at the public API boundary
+            # This catches InvalidURL exceptions from external sitemaps - these are external data errors
+            logger.exception(f"Sitemap strategy failed with invalid URL: {e}")
+            raise CrawlerNetworkError(f"Invalid URL during URL discovery: {e}") from e
         except requests.exceptions.RequestException as e:
             # Actual network errors - log and try fallback
             # This catches all requests exceptions: ConnectionError, Timeout, HTTPError, etc.

--- a/src/services/crawlers/kitchen_sanctuary_crawler.py
+++ b/src/services/crawlers/kitchen_sanctuary_crawler.py
@@ -97,6 +97,15 @@ class KitchenSanctuaryCrawler:
         Parses WordPress sitemap.xml to extract recipe URLs, filtering out
         non-recipe pages (category, tag, about, contact, etc.).
 
+        Exception Handling:
+            This method uses standardized exception handling (aligned with HelloFreshCrawler):
+            - InvalidURL -> CrawlerNetworkError
+            - RequestException (Connection, Timeout, HTTP errors) -> CrawlerNetworkError
+            - SSL/Certificate errors -> CrawlerNetworkError
+            - Parsing errors (ValueError, UnicodeDecodeError) -> CrawlerParseError
+            - I/O errors (OSError, IOError) -> CrawlerError
+            - Programming errors (AttributeError, TypeError, etc.) propagate unchanged
+
         Args:
             max_pages: Maximum number of sitemap pages to crawl. None means no limit.
                       Used primarily for testing.
@@ -123,6 +132,11 @@ class KitchenSanctuaryCrawler:
         except (CrawlerNetworkError, CrawlerParseError):
             # Re-raise crawler exceptions as-is (already wrapped)
             raise
+        except requests.exceptions.InvalidURL as e:
+            # Wrap malformed URLs from external data at the public API boundary
+            # This catches InvalidURL exceptions from external sitemaps - these are external data errors
+            logger.exception(f"Sitemap strategy failed with invalid URL: {e}")
+            raise CrawlerNetworkError(f"Invalid URL during URL discovery: {e}") from e
         except requests.exceptions.RequestException as e:
             # Wrap actual network errors at the public API boundary
             # This catches all requests exceptions: ConnectionError, Timeout, HTTPError, etc.

--- a/tests/services/crawlers/test_crawler_exceptions.py
+++ b/tests/services/crawlers/test_crawler_exceptions.py
@@ -189,6 +189,25 @@ class TestKitchenSanctuaryCrawlerExceptionWrapping:
 
     @patch('src.services.crawlers.kitchen_sanctuary_crawler.KitchenSanctuaryCrawler._configure_from_robots_txt')
     @patch('src.services.crawlers.kitchen_sanctuary_crawler.KitchenSanctuaryCrawler._discover_from_sitemap')
+    def test_invalid_url_error_wrapping(self, mock_discover_sitemap, mock_robots_config):
+        """Test that requests.exceptions.InvalidURL is wrapped in CrawlerNetworkError."""
+        crawler = KitchenSanctuaryCrawler()
+
+        # Mock sitemap strategy to raise InvalidURL error
+        mock_discover_sitemap.side_effect = requests.exceptions.InvalidURL("Invalid URL format")
+
+        # Should raise CrawlerNetworkError, not requests.exceptions.InvalidURL
+        with pytest.raises(CrawlerNetworkError) as exc_info:
+            crawler.discover_recipe_urls()
+
+        # Verify the error message contains context
+        assert "Invalid URL during URL discovery" in str(exc_info.value)
+
+        # Verify original exception is chained
+        assert isinstance(exc_info.value.__cause__, requests.exceptions.InvalidURL)
+
+    @patch('src.services.crawlers.kitchen_sanctuary_crawler.KitchenSanctuaryCrawler._configure_from_robots_txt')
+    @patch('src.services.crawlers.kitchen_sanctuary_crawler.KitchenSanctuaryCrawler._discover_from_sitemap')
     def test_parse_error_wrapping(self, mock_discover_sitemap, mock_robots_config):
         """Test that ValueError from parsing is wrapped in CrawlerParseError."""
         crawler = KitchenSanctuaryCrawler()
@@ -248,15 +267,16 @@ class TestNoLeakyAbstractions:
 
     @patch('src.services.crawlers.hellofresh_crawler.HelloFreshCrawler._configure_from_robots_txt')
     @patch('src.services.crawlers.hellofresh_crawler.HelloFreshCrawler._discover_from_sitemap')
-    def test_discover_urls_never_raises_requests_exception(self, mock_discover_sitemap, mock_robots_config):
-        """Test that discover_recipe_urls never raises requests.exceptions.*"""
+    def test_hellofresh_discover_urls_never_raises_requests_exception(self, mock_discover_sitemap, mock_robots_config):
+        """Test that HelloFresh discover_recipe_urls never raises requests.exceptions.*"""
         crawler = HelloFreshCrawler()
 
-        # Try various requests exceptions
+        # Try various requests exceptions, including InvalidURL
         exceptions_to_test = [
             requests.exceptions.ConnectionError("Connection failed"),
             requests.exceptions.Timeout("Timeout"),
             requests.exceptions.HTTPError("HTTP Error"),
+            requests.exceptions.InvalidURL("Invalid URL format"),
             requests.exceptions.RequestException("Generic error"),
         ]
 
@@ -280,3 +300,35 @@ class TestNoLeakyAbstractions:
                 except CrawlerNetworkError:
                     # This is expected
                     pass
+
+    @patch('src.services.crawlers.kitchen_sanctuary_crawler.KitchenSanctuaryCrawler._configure_from_robots_txt')
+    @patch('src.services.crawlers.kitchen_sanctuary_crawler.KitchenSanctuaryCrawler._discover_from_sitemap')
+    def test_kitchen_sanctuary_discover_urls_never_raises_requests_exception(self, mock_discover_sitemap, mock_robots_config):
+        """Test that KitchenSanctuary discover_recipe_urls never raises requests.exceptions.*"""
+        crawler = KitchenSanctuaryCrawler()
+
+        # Try various requests exceptions, including InvalidURL
+        exceptions_to_test = [
+            requests.exceptions.ConnectionError("Connection failed"),
+            requests.exceptions.Timeout("Timeout"),
+            requests.exceptions.HTTPError("HTTP Error"),
+            requests.exceptions.InvalidURL("Invalid URL format"),
+            requests.exceptions.RequestException("Generic error"),
+        ]
+
+        for exc in exceptions_to_test:
+            # Mock sitemap strategy to fail
+            mock_discover_sitemap.side_effect = exc
+
+            # Should raise CrawlerNetworkError, not the original requests exception
+            with pytest.raises(CrawlerNetworkError):
+                crawler.discover_recipe_urls()
+
+            # Explicitly verify it does NOT raise requests.exceptions
+            try:
+                crawler.discover_recipe_urls()
+            except requests.exceptions.RequestException:
+                pytest.fail("discover_recipe_urls() leaked a requests.exceptions.RequestException")
+            except CrawlerNetworkError:
+                # This is expected
+                pass


### PR DESCRIPTION
## Work in Progress

Closes #418

Inconsistent Exception Handling Between Crawlers

<!-- sharkrite-source-issue:397 -->## From PR #417 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
This is a real functional inconsistency (different exception types caught in different crawlers for the same operations), but standardizing across crawlers via a base class extraction is architectural work that exceeds the scope of fixing the broad-catch issue.

## Context
The original issue is about replacing broad catches with specific ones, not about unifying exception handling architecture across all crawlers. The inconsistency exists but doesn't break the PR's core improvement.

## Defer Reason
Architectural refactor needed - requires extracting common exception handling to base crawler class

---
_Created by Sharkrite assessment on 2026-04-03T19:50:59Z_
_Parent PR: #417_

---

## Additional Assessment (PR #417)

**Severity:** MEDIUM
**Reasoning:** Prior assessment already classified this as ACTIONABLE_LATER on 2026-04-03T19:51:00Z. Files have changed, but the finding concerns a cross-crawler architectural pattern (fallback vs immediate-raise), not the specific code changes in this PR.
**Context:** Standardizing exception handling across crawlers via base class extraction is architectural work that exceeds the scope of fixing the broad-catch issue in individual crawlers.
**Defer Reason:** Architectural refactor needed — requires base class extraction or shared pattern definition

_Added by Sharkrite on 2026-04-03T19:58:52Z_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **2** commits (+0 added, ~3 modified, -0 deleted)
- `M` src/services/crawlers/hellofresh_crawler.py
- `M` src/services/crawlers/kitchen_sanctuary_crawler.py
- `M` tests/services/crawlers/test_crawler_exceptions.py

### Commits
- 3833d1d feat: Inconsistent Exception Handling Between Crawlers
- be3ba87 chore: initialize work on #418 Inconsistent Exception Handling Between Crawlers
<!-- /sharkrite-changes-summary -->