### PR TITLE
Task service lacks user_id filtering

### DIFF
--- a/.rite-todo.md
+++ b/.rite-todo.md
@@ -1,48 +1,36 @@
-# Todo List: Add InvalidURL to exception coverage
+# Todo List: Task service lacks user_id filtering
 
-## Phase 0: Requirements Clarification
-- [x] Review task description
-- [x] Make reasonable assumptions based on codebase patterns
-- [x] Document assumptions
+## Phase 0: Requirements Clarification [COMPLETED]
+- [ ] Review task description and context
+- [ ] Document assumptions
 
-## Phase 1: Analysis
-- [x] Check if work is already complete ✓ WORK IS COMPLETE
-- [x] Read relevant files (HelloFreshCrawler, KitchenSanctuaryCrawler)
-- [x] Search for InvalidURL exception handling patterns
-- [x] Review test coverage for InvalidURL handling
-- [x] Verify if work is truly complete or if there are gaps
+## Phase 1: Analysis [COMPLETED]
+- [ ] Check if work is already complete
+- [ ] Read relevant files
+- [ ] Search for related patterns
+- [ ] Review project documentation
+- [ ] Identify dependencies and integration points
 
-## WORK ALREADY COMPLETE - MERGED IN PR #428
+## Phase 2: Planning [COMPLETED]
+- [ ] Explain proposed implementation approach
+- [ ] List all files to create or modify
+- [ ] Identify potential issues or trade-offs
 
-**Finding:** The work requested in this issue was already completed and merged via PR #428
-("Inconsistent Exception Handling Between Crawlers") on 2026-04-03.
+## Phase 3: Implementation [COMPLETED]
+- [ ] Implement the solution
+- [ ] Follow existing code patterns
+- [ ] Add proper error handling
+- [ ] Ensure multi-tenant isolation
 
-**Evidence:**
-1. KitchenSanctuaryCrawler has explicit InvalidURL handling (line 135-139)
-2. HelloFreshCrawler already had InvalidURL handling (verified in both crawlers)
-3. Test coverage exists for InvalidURL wrapping (test_crawler_exceptions.py:192-207)
-4. Tests verify no leaky abstractions including InvalidURL (test_crawler_exceptions.py:274-334)
-5. All Python files have valid syntax
-6. Git history shows PR #428 is merged: commit bad821e
+## Phase 4: Testing & Validation [COMPLETED]
+- [ ] Write or update unit tests
+- [ ] Verify code imports/compiles
+- [ ] Run modified test files only
 
-**Changes made in PR #428:**
-- Added explicit `requests.exceptions.InvalidURL` exception handler to KitchenSanctuaryCrawler
-- Added docstring documenting InvalidURL -> CrawlerNetworkError mapping
-- Added test `test_invalid_url_error_wrapping` for KitchenSanctuaryCrawler
-- Added InvalidURL to the no-leaky-abstractions tests for both crawlers
-
-**Current State:**
-Both crawlers now have consistent InvalidURL exception handling:
-- KitchenSanctuaryCrawler: Catches InvalidURL, wraps in CrawlerNetworkError with message "Invalid URL during URL discovery"
-- HelloFreshCrawler: Catches InvalidURL in both strategies, wraps in CrawlerNetworkError
-- Both crawlers have comprehensive test coverage
-- No leaky abstractions - requests.exceptions never escape to callers
-
-**Recommendation:**
-This branch (feat/add-invalidurl-to-exception-coverage) contains only the initialization commit
-and has no actual work to do since PR #428 already completed the task. The PR #429 associated
-with this branch can be closed as duplicate/already completed.
+## Phase 5: Code Comments [COMPLETED]
+- [ ] Add inline comments for complex logic
+- [ ] Add JSDoc/TSDoc where appropriate
 
 ---
-**Status:** Analysis complete - Work already done
-**Current Phase:** Complete (no implementation needed)
+Status: Completed
+Current Phase: All phases complete

--- a/src/routers/tasks.py
+++ b/src/routers/tasks.py
@@ -32,7 +32,7 @@ def get_task_status(
     Get the status of a processing task.
 
     Returns the current status of a task and its result (if completed) or error (if failed).
-    Requires authentication.
+    Requires authentication. Users can only access their own tasks.
 
     Args:
         task_id: UUID of the task to retrieve
@@ -43,19 +43,14 @@ def get_task_status(
         ProcessingTaskResponse with task status, metadata, and result/error if applicable
 
     Raises:
-        HTTPException 404: Task not found
+        HTTPException 404: Task not found or not owned by current user
         HTTPException 401: Unauthorized (no valid token)
     """
-    task = get_task_by_id(task_id, db)
+    # Service layer enforces user_id filtering for defense-in-depth
+    task = get_task_by_id(task_id, current_user.id, db)
 
     if not task:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Task with id {task_id} not found"
-        )
-
-    # Verify ownership - users can only access their own tasks
-    if task.user_id != current_user.id:
+        # Return 404 for both not-found and unauthorized to prevent information disclosure
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Task with id {task_id} not found"

--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -11,15 +11,23 @@ from sqlalchemy.orm import Session
 from src.db.models.processing_task import ProcessingTask
 
 
-def get_task_by_id(task_id: UUID, db: Session) -> Optional[ProcessingTask]:
+def get_task_by_id(task_id: UUID, user_id: UUID, db: Session) -> Optional[ProcessingTask]:
     """
-    Retrieve a processing task by its ID.
+    Retrieve a processing task by its ID for a specific user.
+
+    Enforces multi-tenant isolation by filtering on both task_id and user_id.
+    This defense-in-depth approach ensures authorization at the service layer,
+    not just the router layer.
 
     Args:
         task_id: UUID of the task to retrieve
+        user_id: UUID of the user who owns the task
         db: Database session
 
     Returns:
-        ProcessingTask object if found, None otherwise
+        ProcessingTask object if found and owned by user, None otherwise
     """
-    return db.query(ProcessingTask).filter(ProcessingTask.id == task_id).first()
+    return db.query(ProcessingTask).filter(
+        ProcessingTask.id == task_id,
+        ProcessingTask.user_id == user_id
+    ).first()

--- a/tests/unit/services/test_task_service.py
+++ b/tests/unit/services/test_task_service.py
@@ -1,0 +1,145 @@
+"""
+Unit tests for task_service.py
+
+Tests cover:
+- get_task_by_id: Returns task when user_id matches
+- get_task_by_id: Returns None when user_id doesn't match
+- get_task_by_id: Returns None when task_id doesn't exist
+"""
+
+import pytest
+from uuid import uuid4
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from src.db.database import Base
+from src.db import models
+from src.db.models.processing_task import ProcessingTask, TaskType, TaskStatus
+from src.services.task_service import get_task_by_id
+
+
+# In-memory SQLite for testing
+TEST_DATABASE_URL = "sqlite:///:memory:"
+
+
+@pytest.fixture
+def db_session():
+    """Create a fresh database session for each test."""
+    from sqlalchemy.pool import StaticPool
+
+    _ = models
+
+    engine = create_engine(
+        TEST_DATABASE_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    Base.metadata.create_all(bind=engine)
+
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture
+def user_id():
+    """Create a test user ID."""
+    return uuid4()
+
+
+@pytest.fixture
+def other_user_id():
+    """Create another test user ID."""
+    return uuid4()
+
+
+@pytest.fixture
+def test_task(db_session, user_id):
+    """Create a test processing task."""
+    task = ProcessingTask(
+        id=uuid4(),
+        user_id=user_id,
+        task_type=TaskType.receipt_parse.value,
+        status=TaskStatus.pending.value,
+        input_reference="s3://bucket/receipts/test-receipt.jpg",
+    )
+    db_session.add(task)
+    db_session.commit()
+    db_session.refresh(task)
+    return task
+
+
+class TestGetTaskById:
+    """Tests for get_task_by_id service function."""
+
+    def test_returns_task_when_user_id_matches(self, db_session, user_id, test_task):
+        """Test that get_task_by_id returns task when user_id matches."""
+        result = get_task_by_id(test_task.id, user_id, db_session)
+
+        assert result is not None
+        assert result.id == test_task.id
+        assert result.user_id == user_id
+        assert result.task_type == TaskType.receipt_parse.value
+        assert result.status == TaskStatus.pending.value
+
+    def test_returns_none_when_user_id_does_not_match(self, db_session, other_user_id, test_task):
+        """Test that get_task_by_id returns None when user_id doesn't match."""
+        # Try to get task with wrong user_id
+        result = get_task_by_id(test_task.id, other_user_id, db_session)
+
+        assert result is None
+
+    def test_returns_none_when_task_id_does_not_exist(self, db_session, user_id):
+        """Test that get_task_by_id returns None when task_id doesn't exist."""
+        nonexistent_task_id = uuid4()
+        result = get_task_by_id(nonexistent_task_id, user_id, db_session)
+
+        assert result is None
+
+    def test_multi_tenant_isolation(self, db_session, user_id, other_user_id):
+        """Test that users cannot access tasks from other users."""
+        # Create task for user1
+        task1 = ProcessingTask(
+            id=uuid4(),
+            user_id=user_id,
+            task_type=TaskType.receipt_parse.value,
+            status=TaskStatus.completed.value,
+            input_reference="s3://bucket/receipts/user1-receipt.jpg",
+            result_reference='{"store_name": "Store A"}',
+        )
+        db_session.add(task1)
+
+        # Create task for user2
+        task2 = ProcessingTask(
+            id=uuid4(),
+            user_id=other_user_id,
+            task_type=TaskType.receipt_parse.value,
+            status=TaskStatus.completed.value,
+            input_reference="s3://bucket/receipts/user2-receipt.jpg",
+            result_reference='{"store_name": "Store B"}',
+        )
+        db_session.add(task2)
+        db_session.commit()
+
+        # User1 can access their own task
+        result1 = get_task_by_id(task1.id, user_id, db_session)
+        assert result1 is not None
+        assert result1.id == task1.id
+
+        # User1 cannot access user2's task
+        result2 = get_task_by_id(task2.id, user_id, db_session)
+        assert result2 is None
+
+        # User2 can access their own task
+        result3 = get_task_by_id(task2.id, other_user_id, db_session)
+        assert result3 is not None
+        assert result3.id == task2.id
+
+        # User2 cannot access user1's task
+        result4 = get_task_by_id(task1.id, other_user_id, db_session)
+        assert result4 is None


### PR DESCRIPTION
## Work in Progress

Closes #422

Task service lacks user_id filtering

<!-- sharkrite-source-issue:368 -->## From PR #384 Assessment

**Severity:** MEDIUM
**Category:** CodeQuality

## Issue
This is a valid defense-in-depth concern, but the current implementation is correct and secure. The router properly checks ownership before returning data. Refactoring to push authorization into the service layer is a design improvement, not a bug fix.

## Context
The acceptance criteria require authentication and proper 404 handling, both of which are satisfied. The suggestion improves maintainability but doesn't fix a security hole - unauthorized access already returns 404.

## Defer Reason
Scope exceeds time budget - architectural pattern change that doesn't fix a current bug

---
_Created by Sharkrite assessment on 2026-04-03T20:13:34Z_
_Parent PR: #384_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**4** files, **2** commits (+1 added, ~3 modified, -0 deleted)
- `M` .rite-todo.md
- `M` src/routers/tasks.py
- `M` src/services/task_service.py
- `A` tests/unit/services/test_task_service.py

### Commits
- ce96ccf feat: Task service lacks user_id filtering
- b8c8222 chore: initialize work on #422 Task service lacks user_id filtering
<!-- /sharkrite-changes-summary -->