### PR TITLE
[Phase 4A] Add receipt confirmation endpoint

### DIFF
--- a/.rite-todo.md
+++ b/.rite-todo.md
@@ -1,36 +1,32 @@
-# Todo List: Task service lacks user_id filtering
+# Todo List: [Phase 4A] Add receipt confirmation endpoint
 
-## Phase 0: Requirements Clarification [COMPLETED]
-- [ ] Review task description and context
-- [ ] Document assumptions
+## Phase 0: Requirements Clarification
+- [x] completed - Review task description and make reasonable assumptions
 
-## Phase 1: Analysis [COMPLETED]
-- [ ] Check if work is already complete
-- [ ] Read relevant files
-- [ ] Search for related patterns
-- [ ] Review project documentation
-- [ ] Identify dependencies and integration points
+## Phase 1: Analysis
+- [x] completed - Check if work is already complete (not complete - files missing)
+- [x] completed - Read existing schemas and models
+- [x] completed - Review ProcessingTask model
+- [x] completed - Review inventory creation patterns
+- [x] completed - Review test patterns
 
-## Phase 2: Planning [COMPLETED]
-- [ ] Explain proposed implementation approach
-- [ ] List all files to create or modify
-- [ ] Identify potential issues or trade-offs
+## Phase 2: Planning
+- [x] completed - Design endpoint implementation
+- [x] completed - Plan service layer changes
+- [x] completed - Plan schema additions
+- [x] completed - Identify integration points
 
-## Phase 3: Implementation [COMPLETED]
-- [ ] Implement the solution
-- [ ] Follow existing code patterns
-- [ ] Add proper error handling
-- [ ] Ensure multi-tenant isolation
+## Phase 3: Implementation
+- [x] completed - Add ReceiptInventoryCandidate and request/response schemas
+- [x] completed - Create inventory_service.py with bulk create function
+- [x] completed - Create receipt_service.py with confirm function
+- [x] completed - Create receipts.py router with confirm endpoint
+- [x] completed - Register router in main.py and __init__.py
+- [x] completed - Create test_receipts.py with comprehensive tests
 
-## Phase 4: Testing & Validation [COMPLETED]
-- [ ] Write or update unit tests
-- [ ] Verify code imports/compiles
-- [ ] Run modified test files only
+## Phase 4: Testing & Validation
+- [x] completed - Verify syntax of all modified/created files
+- [x] completed - All files compile without syntax errors
 
-## Phase 5: Code Comments [COMPLETED]
-- [ ] Add inline comments for complex logic
-- [ ] Add JSDoc/TSDoc where appropriate
-
----
-Status: Completed
-Current Phase: All phases complete
+## Phase 5: Code Comments
+- [x] completed - Reviewed all code - already well-documented with comprehensive docstrings

--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,7 @@ from slowapi.errors import RateLimitExceeded
 
 from src.config import get_settings
 from src.db.database import Base, init_engine, get_engine, get_session_factory
-from src.routers import auth_router, users_router, substitutions_router, inventory_router, recipes_router, grocery_router, prepared_foods_router, scraper_router, tasks_router
+from src.routers import auth_router, users_router, substitutions_router, inventory_router, recipes_router, grocery_router, prepared_foods_router, scraper_router, tasks_router, receipts_router
 from src.middleware.rate_limit import limiter
 from src.services.task_worker import background_task_worker
 from src.services.llm.client import OllamaClient
@@ -121,6 +121,7 @@ app.include_router(grocery_router)
 app.include_router(prepared_foods_router)
 app.include_router(scraper_router)
 app.include_router(tasks_router)
+app.include_router(receipts_router)
 
 
 @app.get("/health")

--- a/src/routers/__init__.py
+++ b/src/routers/__init__.py
@@ -16,5 +16,6 @@ from src.routers.grocery import router as grocery_router
 from src.routers.prepared_foods import router as prepared_foods_router
 from src.routers.scraper import router as scraper_router
 from src.routers.tasks import router as tasks_router
+from src.routers.receipts import router as receipts_router
 
-__all__ = ["auth_router", "users_router", "substitutions_router", "inventory_router", "recipes_router", "grocery_router", "prepared_foods_router", "scraper_router", "tasks_router"]
+__all__ = ["auth_router", "users_router", "substitutions_router", "inventory_router", "recipes_router", "grocery_router", "prepared_foods_router", "scraper_router", "tasks_router", "receipts_router"]

--- a/src/routers/receipts.py
+++ b/src/routers/receipts.py
@@ -1,0 +1,117 @@
+"""
+Receipt processing endpoints for FreshUp.
+
+Provides endpoints for users to confirm parsed receipt data and add items
+to their inventory. All endpoints are scoped to the authenticated user.
+
+Logging Policy:
+    User-provided item names are NOT logged as they may contain sensitive
+    health information (e.g., prescription names, dietary restrictions).
+    Logs include operational metadata (user_id, task_id, timestamps) for
+    debugging while protecting user privacy per OWASP recommendations.
+"""
+
+import logging
+from uuid import UUID
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError, IntegrityError
+
+from src.db.database import get_db
+from src.db.models.user import User
+from src.schemas.receipt import (
+    ReceiptConfirmRequest,
+    ReceiptConfirmResponse,
+)
+from src.schemas.inventory import InventoryItemResponse
+from src.services.receipt_service import confirm_receipt_items
+from src.middleware.auth import get_current_user
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/receipts", tags=["receipts"])
+
+
+@router.post(
+    "/{task_id}/confirm",
+    response_model=ReceiptConfirmResponse,
+    status_code=status.HTTP_201_CREATED
+)
+def confirm_receipt(
+    task_id: UUID,
+    request: ReceiptConfirmRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Confirm receipt inventory candidates and create inventory items.
+
+    Users review parsed receipt items, optionally edit quantities/categories,
+    and confirm to add items to their inventory. This endpoint creates
+    InventoryItem records from the confirmed candidates.
+
+    Multi-tenant isolation: Only the user who created the parsing task can
+    confirm its items. Task ownership is validated at the service layer.
+
+    Args:
+        task_id: UUID of the receipt parsing task to confirm
+        request: ReceiptConfirmRequest with list of inventory candidates
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        ReceiptConfirmResponse with created item count and full item details
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If task doesn't exist or doesn't belong to user
+        HTTPException(400): If task status is not "completed"
+        HTTPException(422): If validation fails (empty items, invalid enums, etc.)
+        HTTPException(500): If database error occurs during creation
+    """
+    try:
+        # Confirm items via service layer (validates task ownership and status)
+        created_items = confirm_receipt_items(
+            task_id=task_id,
+            candidates=request.items,
+            user_id=current_user.id,
+            db=db
+        )
+
+        # Convert to response schemas
+        items_response = [
+            InventoryItemResponse.model_validate(item)
+            for item in created_items
+        ]
+
+        logger.info(
+            f"User {current_user.id} confirmed {len(created_items)} items "
+            f"from task {task_id}"
+        )
+
+        return ReceiptConfirmResponse(
+            created_count=len(created_items),
+            items=items_response
+        )
+
+    except IntegrityError as e:
+        logger.error(
+            f"Integrity error during receipt confirmation for user {current_user.id}, "
+            f"task {task_id}"
+        )
+        logger.debug(f"Integrity error occurred during receipt confirmation: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Receipt confirmation failed due to data integrity violation"
+        )
+
+    except SQLAlchemyError as e:
+        logger.error(
+            f"Database error during receipt confirmation for user {current_user.id}, "
+            f"task {task_id}"
+        )
+        logger.debug(f"Database error occurred during receipt confirmation: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while confirming the receipt"
+        )

--- a/src/schemas/receipt.py
+++ b/src/schemas/receipt.py
@@ -228,6 +228,7 @@ class ReceiptConfirmRequest(BaseModel):
     items: list[ReceiptInventoryCandidate] = Field(
         ...,
         min_length=1,
+        max_length=200,
         description="List of confirmed items to add to inventory (must not be empty)"
     )
 

--- a/src/schemas/receipt.py
+++ b/src/schemas/receipt.py
@@ -12,7 +12,9 @@ from datetime import date
 from typing import Optional
 from pydantic import BaseModel, Field, field_validator
 
-from src.schemas.validators import validate_name_not_empty
+from src.db.models.inventory_item import Category, UnitType, StorageLocation
+from src.schemas.validators import validate_name_not_empty, validate_enum_value, validate_non_negative
+from src.schemas.inventory import InventoryItemResponse
 
 
 class ReceiptLineItem(BaseModel):
@@ -129,3 +131,129 @@ class ReceiptParseResult(BaseModel):
         if not v:
             raise ValueError('Receipt must have at least one line item')
         return v
+
+
+class ReceiptInventoryCandidate(BaseModel):
+    """
+    A receipt line item ready for inventory confirmation.
+
+    Represents a parsed receipt item that users can review, edit, and confirm
+    to add to their inventory. Users can override any field before confirmation.
+
+    This schema bridges the gap between LLM-parsed receipt data (ReceiptLineItem)
+    and confirmed inventory items (InventoryItem).
+    """
+
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=255,
+        description="Item name (user can override parsed value)"
+    )
+    quantity: float = Field(
+        ...,
+        gt=0,
+        description="Quantity to add to inventory"
+    )
+    unit: str = Field(
+        ...,
+        description="Unit of measurement (must be valid UnitType enum value)"
+    )
+    category: str = Field(
+        ...,
+        description="Item category (must be valid Category enum value)"
+    )
+    storage_location: str = Field(
+        ...,
+        description="Storage location: pantry, fridge, or freezer"
+    )
+    price: Optional[float] = Field(
+        default=None,
+        ge=0,
+        description="Price of the item (nullable, deferred)"
+    )
+
+    @field_validator('name')
+    @classmethod
+    def validate_name_field(cls, v: str) -> str:
+        """Ensure name is not empty or whitespace only."""
+        result = validate_name_not_empty(v)
+        return result  # type: ignore
+
+    @field_validator('quantity')
+    @classmethod
+    def validate_quantity_field(cls, v: float) -> float:
+        """Ensure quantity is positive."""
+        result = validate_non_negative('Quantity', v, allow_none=False)
+        if result is not None and result <= 0:
+            raise ValueError('Quantity must be positive')
+        return result  # type: ignore
+
+    @field_validator('price')
+    @classmethod
+    def validate_price_field(cls, v: Optional[float]) -> Optional[float]:
+        """Ensure price is non-negative if provided."""
+        return validate_non_negative('Price', v, allow_none=True)
+
+    @field_validator('unit')
+    @classmethod
+    def validate_unit_field(cls, v: str) -> str:
+        """Ensure unit is a valid UnitType enum value."""
+        result = validate_enum_value('Unit', v, UnitType, allow_none=False)
+        return result  # type: ignore
+
+    @field_validator('category')
+    @classmethod
+    def validate_category_field(cls, v: str) -> str:
+        """Ensure category is a valid Category enum value."""
+        result = validate_enum_value('Category', v, Category, allow_none=False)
+        return result  # type: ignore
+
+    @field_validator('storage_location')
+    @classmethod
+    def validate_storage_location_field(cls, v: str) -> str:
+        """Ensure storage_location is a valid StorageLocation enum value."""
+        result = validate_enum_value('Storage location', v, StorageLocation, allow_none=False)
+        return result  # type: ignore
+
+
+class ReceiptConfirmRequest(BaseModel):
+    """
+    Request body for receipt confirmation endpoint.
+
+    Contains the list of inventory candidates that the user has reviewed
+    and confirmed for addition to their inventory.
+    """
+
+    items: list[ReceiptInventoryCandidate] = Field(
+        ...,
+        min_length=1,
+        description="List of confirmed items to add to inventory (must not be empty)"
+    )
+
+    @field_validator('items')
+    @classmethod
+    def validate_items_not_empty(cls, v: list[ReceiptInventoryCandidate]) -> list[ReceiptInventoryCandidate]:
+        """Ensure at least one item is present."""
+        if not v:
+            raise ValueError('Must confirm at least one item')
+        return v
+
+
+class ReceiptConfirmResponse(BaseModel):
+    """
+    Response body for successful receipt confirmation.
+
+    Returns the count of created items and their full details including
+    generated IDs and timestamps.
+    """
+
+    created_count: int = Field(
+        ...,
+        ge=0,
+        description="Number of inventory items created"
+    )
+    items: list[InventoryItemResponse] = Field(
+        ...,
+        description="List of created inventory items with IDs"
+    )

--- a/src/services/inventory_service.py
+++ b/src/services/inventory_service.py
@@ -1,0 +1,76 @@
+"""
+Service layer for inventory item operations.
+
+Provides business logic for creating and managing inventory items,
+including bulk operations for receipt confirmation.
+"""
+
+import logging
+from uuid import UUID
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError, IntegrityError
+
+from src.db.models.inventory_item import InventoryItem, Shareability
+from src.schemas.inventory import InventoryItemCreate
+
+logger = logging.getLogger(__name__)
+
+
+def create_inventory_items_bulk(
+    items_data: list[InventoryItemCreate],
+    user_id: UUID,
+    db: Session
+) -> list[InventoryItem]:
+    """
+    Create multiple inventory items in a single transaction.
+
+    Used by receipt confirmation to atomically create all confirmed items.
+    If any item fails validation or creation, the entire transaction is rolled back
+    to maintain data consistency.
+
+    Args:
+        items_data: List of inventory item creation schemas
+        user_id: ID of the user creating the items (added_by field)
+        db: Database session
+
+    Returns:
+        List of created InventoryItem objects with generated IDs
+
+    Raises:
+        IntegrityError: If data integrity constraint is violated
+        SQLAlchemyError: If database operation fails
+    """
+    created_items = []
+
+    try:
+        for item_data in items_data:
+            # Create inventory item, overriding added_by with authenticated user
+            item_dict = item_data.model_dump(exclude={'added_by'})
+            new_item = InventoryItem(
+                **item_dict,
+                added_by=user_id,
+            )
+            db.add(new_item)
+            created_items.append(new_item)
+
+        # Commit all items atomically
+        db.commit()
+
+        # Refresh all items to get generated IDs and defaults
+        for item in created_items:
+            db.refresh(item)
+
+        logger.info(f"Created {len(created_items)} inventory items for user {user_id}")
+        return created_items
+
+    except IntegrityError as e:
+        db.rollback()
+        logger.error(f"Integrity error during bulk inventory item creation for user {user_id}")
+        logger.debug(f"Integrity error occurred during bulk inventory item creation: {e}")
+        raise
+
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during bulk inventory item creation for user {user_id}")
+        logger.debug(f"Database error occurred during bulk inventory item creation: {e}")
+        raise

--- a/src/services/inventory_service.py
+++ b/src/services/inventory_service.py
@@ -10,7 +10,7 @@ from uuid import UUID
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError, IntegrityError
 
-from src.db.models.inventory_item import InventoryItem, Shareability
+from src.db.models.inventory_item import InventoryItem
 from src.schemas.inventory import InventoryItemCreate
 
 logger = logging.getLogger(__name__)

--- a/src/services/receipt_service.py
+++ b/src/services/receipt_service.py
@@ -1,0 +1,93 @@
+"""
+Service layer for receipt processing operations.
+
+Provides business logic for receipt confirmation and inventory item creation
+from parsed receipt data.
+"""
+
+import logging
+from uuid import UUID
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from src.db.models.processing_task import ProcessingTask, TaskStatus
+from src.db.models.inventory_item import InventoryItem
+from src.schemas.receipt import ReceiptInventoryCandidate
+from src.schemas.inventory import InventoryItemCreate
+from src.services.task_service import get_task_by_id
+from src.services.inventory_service import create_inventory_items_bulk
+
+logger = logging.getLogger(__name__)
+
+
+def confirm_receipt_items(
+    task_id: UUID,
+    candidates: list[ReceiptInventoryCandidate],
+    user_id: UUID,
+    db: Session
+) -> list[InventoryItem]:
+    """
+    Confirm receipt inventory candidates and create inventory items.
+
+    Validates that the task exists, belongs to the user, and has completed successfully
+    before creating inventory items from the confirmed candidates.
+
+    Multi-tenant isolation: Service layer validates task ownership to ensure users
+    can only confirm their own receipt parsing tasks (defense-in-depth).
+
+    Args:
+        task_id: ID of the receipt parsing task to confirm
+        candidates: List of user-reviewed inventory candidates to create
+        user_id: ID of the authenticated user
+        db: Database session
+
+    Returns:
+        List of created InventoryItem objects
+
+    Raises:
+        HTTPException(404): If task doesn't exist or doesn't belong to user
+        HTTPException(400): If task status is not "completed"
+    """
+    # Retrieve task with multi-tenant isolation (defense-in-depth)
+    task = get_task_by_id(task_id, user_id, db)
+
+    if not task:
+        logger.warning(f"Task {task_id} not found for user {user_id}")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Receipt parsing task not found"
+        )
+
+    # Validate task has completed successfully
+    if task.status != TaskStatus.completed.value:
+        logger.warning(
+            f"Attempt to confirm non-completed task {task_id} "
+            f"(status: {task.status}) by user {user_id}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Cannot confirm receipt: task status is '{task.status}', must be 'completed'"
+        )
+
+    # Convert candidates to InventoryItemCreate schemas
+    items_to_create = [
+        InventoryItemCreate(
+            name=candidate.name,
+            quantity=candidate.quantity,
+            unit=candidate.unit,
+            category=candidate.category,
+            storage_location=candidate.storage_location,
+            price=candidate.price,
+            added_by=user_id,  # Will be overridden by service layer for security
+        )
+        for candidate in candidates
+    ]
+
+    # Create inventory items atomically
+    created_items = create_inventory_items_bulk(items_to_create, user_id, db)
+
+    logger.info(
+        f"Confirmed {len(created_items)} items from task {task_id} for user {user_id}"
+    )
+
+    return created_items

--- a/tests/routers/test_receipts.py
+++ b/tests/routers/test_receipts.py
@@ -1,0 +1,597 @@
+"""
+Integration tests for receipt confirmation endpoints.
+
+Tests cover:
+- POST /receipts/{task_id}/confirm: confirm receipt items and create inventory
+- Task validation: existence, status, ownership
+- Multi-tenant isolation: users can only confirm their own tasks
+- Authentication requirements
+- Input validation: empty items, invalid enums, etc.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from uuid import uuid4
+from datetime import datetime, timezone
+
+from src.db.database import Base, get_db
+from src.db import models
+from src.db.models.user import User, UserRole
+from src.db.models.inventory_item import InventoryItem, Category, UnitType, StorageLocation
+from src.db.models.processing_task import ProcessingTask, TaskStatus, TaskType
+from src.services.auth_service import hash_password, create_access_token
+
+from fastapi import FastAPI
+from src.routers import receipts_router
+
+# Create a test app without lifespan
+app = FastAPI(
+    title="FreshUp",
+    description="Privacy-first kitchen management system",
+    version="0.1.0",
+)
+
+# Register the receipts router
+app.include_router(receipts_router)
+
+
+# Create an in-memory SQLite database for testing
+TEST_DATABASE_URL = "sqlite:///:memory:"
+
+
+@pytest.fixture(autouse=True)
+def setup_test_env(monkeypatch):
+    """Set up test environment variables."""
+    from src.config import get_settings
+    get_settings.cache_clear()
+
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars")
+    monkeypatch.setenv("JWT_ALGORITHM", "HS256")
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    monkeypatch.setenv("ACCESS_TOKEN_EXPIRE_MINUTES", "43200")
+
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def db_session():
+    """Create a fresh database session for each test."""
+    from sqlalchemy.pool import StaticPool
+
+    # Import models to ensure all SQLAlchemy model classes are registered
+    # with Base.metadata before create_all() is called
+    _ = models
+
+    engine = create_engine(
+        TEST_DATABASE_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+@pytest.fixture
+def client(db_session):
+    """Create a test client with database dependency override."""
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def test_user(db_session):
+    """Create a test user."""
+    user = User(
+        id=uuid4(),
+        email="test@example.com",
+        name="testuser",
+        hashed_password=hash_password("testpassword"),
+        role=UserRole.member.value,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def other_user(db_session):
+    """Create another test user for multi-tenant isolation tests."""
+    user = User(
+        id=uuid4(),
+        email="other@example.com",
+        name="otheruser",
+        hashed_password=hash_password("otherpassword"),
+        role=UserRole.member.value,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def auth_headers(test_user):
+    """Generate authentication headers for test user."""
+    token = create_access_token({"sub": str(test_user.id)})
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def other_auth_headers(other_user):
+    """Generate authentication headers for other user."""
+    token = create_access_token({"sub": str(other_user.id)})
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def completed_task(db_session, test_user):
+    """Create a completed processing task for test user."""
+    task = ProcessingTask(
+        id=uuid4(),
+        user_id=test_user.id,
+        task_type=TaskType.receipt_parse.value,
+        status=TaskStatus.completed.value,
+        input_reference="s3://receipts/test-receipt.jpg",
+        result_reference="s3://parsed/test-receipt.json",
+    )
+    db_session.add(task)
+    db_session.commit()
+    db_session.refresh(task)
+    return task
+
+
+@pytest.fixture
+def pending_task(db_session, test_user):
+    """Create a pending processing task for test user."""
+    task = ProcessingTask(
+        id=uuid4(),
+        user_id=test_user.id,
+        task_type=TaskType.receipt_parse.value,
+        status=TaskStatus.pending.value,
+        input_reference="s3://receipts/test-receipt.jpg",
+    )
+    db_session.add(task)
+    db_session.commit()
+    db_session.refresh(task)
+    return task
+
+
+@pytest.fixture
+def other_user_task(db_session, other_user):
+    """Create a completed task for other user (multi-tenant test)."""
+    task = ProcessingTask(
+        id=uuid4(),
+        user_id=other_user.id,
+        task_type=TaskType.receipt_parse.value,
+        status=TaskStatus.completed.value,
+        input_reference="s3://receipts/other-receipt.jpg",
+        result_reference="s3://parsed/other-receipt.json",
+    )
+    db_session.add(task)
+    db_session.commit()
+    db_session.refresh(task)
+    return task
+
+
+# --- Success Cases ---
+
+
+def test_confirm_receipt_success(client, db_session, test_user, completed_task, auth_headers):
+    """Test successful receipt confirmation creates inventory items."""
+    request_data = {
+        "items": [
+            {
+                "name": "Bananas",
+                "quantity": 2.0,
+                "unit": "bunch",
+                "category": "produce",
+                "storage_location": "pantry",
+            },
+            {
+                "name": "Milk",
+                "quantity": 1.0,
+                "unit": "gallon",
+                "category": "dairy",
+                "storage_location": "fridge",
+                "price": 3.99,
+            },
+        ]
+    }
+
+    response = client.post(
+        f"/receipts/{completed_task.id}/confirm",
+        json=request_data,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["created_count"] == 2
+    assert len(data["items"]) == 2
+
+    # Verify first item
+    item1 = data["items"][0]
+    assert item1["name"] == "Bananas"
+    assert item1["quantity"] == 2.0
+    assert item1["unit"] == "bunch"
+    assert item1["category"] == "produce"
+    assert item1["storage_location"] == "pantry"
+    assert item1["added_by"] == str(test_user.id)
+    assert "id" in item1
+    assert "date_added" in item1
+
+    # Verify second item
+    item2 = data["items"][1]
+    assert item2["name"] == "Milk"
+    assert item2["quantity"] == 1.0
+    assert item2["unit"] == "gallon"
+    assert item2["category"] == "dairy"
+    assert item2["storage_location"] == "fridge"
+    assert item2["price"] == 3.99
+    assert item2["added_by"] == str(test_user.id)
+
+    # Verify items exist in database
+    db_items = db_session.query(InventoryItem).filter(
+        InventoryItem.added_by == test_user.id
+    ).all()
+    assert len(db_items) == 2
+
+
+def test_confirm_receipt_with_partial_override(client, db_session, test_user, completed_task, auth_headers):
+    """Test that users can override specific fields from parsed receipt."""
+    request_data = {
+        "items": [
+            {
+                "name": "Organic Bananas",  # User edited name
+                "quantity": 3.0,  # User edited quantity
+                "unit": "bunch",
+                "category": "produce",
+                "storage_location": "fridge",  # User changed storage location
+            },
+        ]
+    }
+
+    response = client.post(
+        f"/receipts/{completed_task.id}/confirm",
+        json=request_data,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["created_count"] == 1
+
+    item = data["items"][0]
+    assert item["name"] == "Organic Bananas"
+    assert item["quantity"] == 3.0
+    assert item["storage_location"] == "fridge"
+
+
+# --- Error Cases: Task Not Found ---
+
+
+def test_confirm_receipt_task_not_found(client, auth_headers):
+    """Test confirmation fails when task doesn't exist."""
+    fake_task_id = uuid4()
+    request_data = {
+        "items": [
+            {
+                "name": "Bananas",
+                "quantity": 2.0,
+                "unit": "bunch",
+                "category": "produce",
+                "storage_location": "pantry",
+            },
+        ]
+    }
+
+    response = client.post(
+        f"/receipts/{fake_task_id}/confirm",
+        json=request_data,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+# --- Error Cases: Task Not Completed ---
+
+
+def test_confirm_receipt_task_not_completed(client, pending_task, auth_headers):
+    """Test confirmation fails when task status is not 'completed'."""
+    request_data = {
+        "items": [
+            {
+                "name": "Bananas",
+                "quantity": 2.0,
+                "unit": "bunch",
+                "category": "produce",
+                "storage_location": "pantry",
+            },
+        ]
+    }
+
+    response = client.post(
+        f"/receipts/{pending_task.id}/confirm",
+        json=request_data,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 400
+    assert "completed" in response.json()["detail"].lower()
+    assert "pending" in response.json()["detail"].lower()
+
+
+# --- Error Cases: Multi-Tenant Isolation ---
+
+
+def test_confirm_receipt_task_owned_by_other_user(client, other_user_task, auth_headers):
+    """Test users cannot confirm tasks owned by other users."""
+    request_data = {
+        "items": [
+            {
+                "name": "Bananas",
+                "quantity": 2.0,
+                "unit": "bunch",
+                "category": "produce",
+                "storage_location": "pantry",
+            },
+        ]
+    }
+
+    response = client.post(
+        f"/receipts/{other_user_task.id}/confirm",
+        json=request_data,
+        headers=auth_headers,
+    )
+
+    # Should return 404 (not 403) to prevent information leakage
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+# --- Error Cases: Authentication ---
+
+
+def test_confirm_receipt_no_auth(client, completed_task):
+    """Test confirmation requires authentication."""
+    request_data = {
+        "items": [
+            {
+                "name": "Bananas",
+                "quantity": 2.0,
+                "unit": "bunch",
+                "category": "produce",
+                "storage_location": "pantry",
+            },
+        ]
+    }
+
+    response = client.post(
+        f"/receipts/{completed_task.id}/confirm",
+        json=request_data,
+    )
+
+    assert response.status_code == 401
+
+
+def test_confirm_receipt_invalid_token(client, completed_task):
+    """Test confirmation fails with invalid token."""
+    request_data = {
+        "items": [
+            {
+                "name": "Bananas",
+                "quantity": 2.0,
+                "unit": "bunch",
+                "category": "produce",
+                "storage_location": "pantry",
+            },
+        ]
+    }
+
+    response = client.post(
+        f"/receipts/{completed_task.id}/confirm",
+        json=request_data,
+        headers={"Authorization": "Bearer invalid-token"},
+    )
+
+    assert response.status_code == 401
+
+
+# --- Error Cases: Validation ---
+
+
+def test_confirm_receipt_empty_items(client, completed_task, auth_headers):
+    """Test confirmation fails when items array is empty."""
+    request_data = {"items": []}
+
+    response = client.post(
+        f"/receipts/{completed_task.id}/confirm",
+        json=request_data,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422
+
+
+def test_confirm_receipt_invalid_unit(client, completed_task, auth_headers):
+    """Test confirmation fails when unit is not a valid UnitType enum."""
+    request_data = {
+        "items": [
+            {
+                "name": "Bananas",
+                "quantity": 2.0,
+                "unit": "invalid_unit",
+                "category": "produce",
+                "storage_location": "pantry",
+            },
+        ]
+    }
+
+    response = client.post(
+        f"/receipts/{completed_task.id}/confirm",
+        json=request_data,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422
+
+
+def test_confirm_receipt_invalid_category(client, completed_task, auth_headers):
+    """Test confirmation fails when category is not a valid Category enum."""
+    request_data = {
+        "items": [
+            {
+                "name": "Bananas",
+                "quantity": 2.0,
+                "unit": "bunch",
+                "category": "invalid_category",
+                "storage_location": "pantry",
+            },
+        ]
+    }
+
+    response = client.post(
+        f"/receipts/{completed_task.id}/confirm",
+        json=request_data,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422
+
+
+def test_confirm_receipt_invalid_storage_location(client, completed_task, auth_headers):
+    """Test confirmation fails when storage_location is not a valid StorageLocation enum."""
+    request_data = {
+        "items": [
+            {
+                "name": "Bananas",
+                "quantity": 2.0,
+                "unit": "bunch",
+                "category": "produce",
+                "storage_location": "invalid_location",
+            },
+        ]
+    }
+
+    response = client.post(
+        f"/receipts/{completed_task.id}/confirm",
+        json=request_data,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422
+
+
+def test_confirm_receipt_negative_quantity(client, completed_task, auth_headers):
+    """Test confirmation fails when quantity is negative."""
+    request_data = {
+        "items": [
+            {
+                "name": "Bananas",
+                "quantity": -1.0,
+                "unit": "bunch",
+                "category": "produce",
+                "storage_location": "pantry",
+            },
+        ]
+    }
+
+    response = client.post(
+        f"/receipts/{completed_task.id}/confirm",
+        json=request_data,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422
+
+
+def test_confirm_receipt_zero_quantity(client, completed_task, auth_headers):
+    """Test confirmation fails when quantity is zero."""
+    request_data = {
+        "items": [
+            {
+                "name": "Bananas",
+                "quantity": 0.0,
+                "unit": "bunch",
+                "category": "produce",
+                "storage_location": "pantry",
+            },
+        ]
+    }
+
+    response = client.post(
+        f"/receipts/{completed_task.id}/confirm",
+        json=request_data,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422
+
+
+def test_confirm_receipt_negative_price(client, completed_task, auth_headers):
+    """Test confirmation fails when price is negative."""
+    request_data = {
+        "items": [
+            {
+                "name": "Bananas",
+                "quantity": 2.0,
+                "unit": "bunch",
+                "category": "produce",
+                "storage_location": "pantry",
+                "price": -5.99,
+            },
+        ]
+    }
+
+    response = client.post(
+        f"/receipts/{completed_task.id}/confirm",
+        json=request_data,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422
+
+
+def test_confirm_receipt_empty_name(client, completed_task, auth_headers):
+    """Test confirmation fails when name is empty or whitespace."""
+    request_data = {
+        "items": [
+            {
+                "name": "   ",
+                "quantity": 2.0,
+                "unit": "bunch",
+                "category": "produce",
+                "storage_location": "pantry",
+            },
+        ]
+    }
+
+    response = client.post(
+        f"/receipts/{completed_task.id}/confirm",
+        json=request_data,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422


### PR DESCRIPTION
## Work in Progress

Closes #433

[Phase 4A] Add receipt confirmation endpoint

**Time Estimate**: 1hr

**Description**:
Create POST /receipts/{task_id}/confirm endpoint that accepts user-confirmed inventory candidates from a parsed receipt and creates InventoryItem records. Users review the parsed items (from polling endpoint), optionally edit quantities/categories, and confirm to add items to their inventory.

**Claude Context**:
Files to Read:
- src/routers/receipts.py (existing receipts router from Issue #2)
- src/services/receipt_service.py (existing service with mapping function from Issue #4)
- src/schemas/receipt.py (ReceiptInventoryCandidate schema from Issue #4)
- src/schemas/inventory.py (InventoryItemCreate schema)
- src/db/models/inventory_item.py (InventoryItem model)
- src/services/inventory_service.py (existing inventory creation patterns)

Files to Modify:
- src/routers/receipts.py (add POST /receipts/{task_id}/confirm endpoint)
- src/services/receipt_service.py (add confirm_receipt_items function)
- src/schemas/receipt.py (add ReceiptConfirmRequest, ReceiptConfirmResponse schemas)
- tests/routers/test_receipts.py (extend with confirmation tests)

**Acceptance Criteria**:
- [ ] POST /receipts/{task_id}/confirm accepts JSON body: `{"items": [ReceiptInventoryCandidate...]}`
- [ ] Each item in request can override: name, quantity, unit, category, storage_location (user corrections)
- [ ] Endpoint validates task_id exists and status="completed" (cannot confirm incomplete parse)
- [ ] Creates InventoryItem records for each confirmed item using inventory_service
- [ ] Returns 201 Created with `{"created_count": N, "items": [InventoryItemResponse...]}`
- [ ] Returns 404 if task_id doesn't exist
- [ ] Returns 400 if task status is not "completed"
- [ ] Returns 401 if not authenticated
- [ ] Returns 422 if items array is empty or malformed
- [ ] Service layer handles bulk InventoryItem creation
- [ ] Tests cover: success case, partial override, task not found, task not completed, auth errors

**Verification Commands**:
```bash
pytest tests/routers/test_receipts.py::test_confirm_receipt -v
# Manual test
curl -X POST http://localhost:8000/receipts/{task_id}/confirm \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"items": [{"name": "Bananas", "quantity": 1.0, "unit": "bunch", "category": "produce", "storage_location": "counter"}]}'
```

**Done Definition**: Done when POST /receipts/{task_id}/confirm creates InventoryItem records from user-confirmed candidates and returns the created items.

**Scope Boundary**:
- DO: Create confirmation endpoint with item override support
- DO: Validate task exists and is completed before confirming
- DO: Create InventoryItem records via inventory_service
- DO: Allow user to override any field from the parsed candidates
- DO NOT: Implement grocery list reconciliation (deferred — natural user expectation but out of scope for 4A, will be addressed in future phase)
- DO NOT: Implement item deduplication against existing inventory
- DO NOT: Handle price field (nullable, deferred)

**Dependencies**: After #3 (task status polling), After #4 (mapping service provides candidate schema)

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**8** files, **2** commits (+4 added, ~4 modified, -0 deleted)
- `M` .rite-todo.md
- `M` src/main.py
- `M` src/routers/__init__.py
- `A` src/routers/receipts.py
- `M` src/schemas/receipt.py
- `A` src/services/inventory_service.py
- `A` src/services/receipt_service.py
- `A` tests/routers/test_receipts.py

### Commits
- 6c10400 feat: [Phase 4A] Add receipt confirmation endpoint
- 0bdfee8 chore: initialize work on #433 [Phase 4A] Add receipt confirmation endpoint
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-04-04T22:58:06Z:**
- Created: #439 
- Updated: none