### PR TITLE
[Phase 4A] Add receipt submission endpoint

### DIFF
--- a/src/routers/receipts.py
+++ b/src/routers/receipts.py
@@ -1,14 +1,15 @@
 """
 Receipt processing endpoints for FreshUp.
 
-Provides endpoints for users to confirm parsed receipt data and add items
-to their inventory. All endpoints are scoped to the authenticated user.
+Provides endpoints for users to submit receipts for async LLM parsing and
+confirm parsed receipt data to add items to their inventory. All endpoints
+are scoped to the authenticated user.
 
 Logging Policy:
-    User-provided item names are NOT logged as they may contain sensitive
-    health information (e.g., prescription names, dietary restrictions).
-    Logs include operational metadata (user_id, task_id, timestamps) for
-    debugging while protecting user privacy per OWASP recommendations.
+    Receipt text content is NOT logged as it may contain sensitive information
+    (e.g., prescription names, dietary restrictions). Logs include operational
+    metadata (user_id, task_id, timestamps) for debugging while protecting
+    user privacy per OWASP recommendations.
 """
 
 import logging
@@ -20,16 +21,72 @@ from sqlalchemy.exc import SQLAlchemyError, IntegrityError
 from src.db.database import get_db
 from src.db.models.user import User
 from src.schemas.receipt import (
+    ReceiptSubmitRequest,
+    ReceiptSubmitResponse,
     ReceiptConfirmRequest,
     ReceiptConfirmResponse,
 )
 from src.schemas.inventory import InventoryItemResponse
-from src.services.receipt_service import confirm_receipt_items
+from src.services.receipt_service import submit_receipt, confirm_receipt_items
 from src.middleware.auth import get_current_user
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/receipts", tags=["receipts"])
+
+
+@router.post(
+    "",
+    response_model=ReceiptSubmitResponse,
+    status_code=status.HTTP_202_ACCEPTED
+)
+def submit_receipt_for_processing(
+    request: ReceiptSubmitRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Submit receipt text for async LLM parsing.
+
+    Accepts receipt text (e.g., from Costco digital receipt copy-paste) and
+    optional store name, creates a ProcessingTask for background LLM parsing,
+    and returns 202 Accepted with task ID for status polling.
+
+    This is text-only input for digital receipts. File upload is handled
+    separately in Phase 4B.
+
+    Multi-tenant isolation: Task is created with current_user.id for ownership.
+
+    Args:
+        request: ReceiptSubmitRequest with receipt_text and optional store_name
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        ReceiptSubmitResponse with task_id, status='pending', and message
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(422): If receipt_text is empty, too short, or too long
+        HTTPException(500): If database error occurs during task creation
+    """
+    # Submit receipt via service layer
+    task = submit_receipt(
+        receipt_text=request.receipt_text,
+        user_id=current_user.id,
+        db=db,
+        store_name=request.store_name,
+    )
+
+    logger.info(
+        f"Receipt submitted: user_id={current_user.id}, task_id={task.id}"
+    )
+
+    return ReceiptSubmitResponse(
+        task_id=task.id,
+        status=task.status,
+        message="Receipt submitted for processing"
+    )
 
 
 @router.post(

--- a/src/routers/receipts.py
+++ b/src/routers/receipts.py
@@ -78,10 +78,6 @@ def submit_receipt_for_processing(
         store_name=request.store_name,
     )
 
-    logger.info(
-        f"Receipt submitted: user_id={current_user.id}, task_id={task.id}"
-    )
-
     return ReceiptSubmitResponse(
         task_id=task.id,
         status=task.status,

--- a/src/schemas/receipt.py
+++ b/src/schemas/receipt.py
@@ -10,6 +10,7 @@ extracting store name, date, and line items with quantities and prices.
 
 from datetime import date
 from typing import Optional
+from uuid import UUID
 from pydantic import BaseModel, Field, field_validator
 
 from src.db.models.inventory_item import Category, UnitType, StorageLocation
@@ -257,4 +258,66 @@ class ReceiptConfirmResponse(BaseModel):
     items: list[InventoryItemResponse] = Field(
         ...,
         description="List of created inventory items with IDs"
+    )
+
+
+class ReceiptSubmitRequest(BaseModel):
+    """
+    Request body for receipt submission endpoint.
+
+    Accepts receipt text (e.g., from Costco copy-paste) and optional store name
+    for async LLM parsing. Creates a ProcessingTask for background processing.
+    """
+
+    receipt_text: str = Field(
+        ...,
+        min_length=10,
+        max_length=50000,
+        description="Receipt text content (digital receipt copy-paste or OCR output)"
+    )
+    store_name: Optional[str] = Field(
+        default=None,
+        max_length=255,
+        description="Optional store name for store-specific parsing hints (e.g., 'Costco')"
+    )
+
+    @field_validator('receipt_text')
+    @classmethod
+    def validate_receipt_text_not_empty(cls, v: str) -> str:
+        """Ensure receipt_text is not empty or whitespace only."""
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError('Receipt text cannot be empty or only whitespace')
+        return stripped
+
+    @field_validator('store_name')
+    @classmethod
+    def validate_store_name_not_empty(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure store_name is not empty or whitespace if provided."""
+        if v is not None:
+            stripped = v.strip()
+            if not stripped:
+                raise ValueError('Store name cannot be empty or only whitespace')
+            return stripped
+        return None
+
+
+class ReceiptSubmitResponse(BaseModel):
+    """
+    Response body for successful receipt submission.
+
+    Returns task ID for polling status and result retrieval.
+    """
+
+    task_id: UUID = Field(
+        ...,
+        description="Processing task ID for status polling"
+    )
+    status: str = Field(
+        ...,
+        description="Task status (will be 'pending' on submission)"
+    )
+    message: str = Field(
+        ...,
+        description="Human-readable message"
     )

--- a/src/services/receipt_service.py
+++ b/src/services/receipt_service.py
@@ -86,9 +86,11 @@ def submit_receipt(
             detail="An error occurred while submitting the receipt"
         )
 
+    # Sanitize store_name for logging to prevent log injection
+    safe_store_name = store_name.replace('\n', ' ').replace('\r', ' ') if store_name else None
     logger.info(
         f"Receipt submitted for processing: user_id={user_id}, "
-        f"task_id={task.id}, store_name={store_name}"
+        f"task_id={task.id}, store_name={safe_store_name}"
     )
 
     return task

--- a/src/services/receipt_service.py
+++ b/src/services/receipt_service.py
@@ -1,16 +1,19 @@
 """
 Service layer for receipt processing operations.
 
-Provides business logic for receipt confirmation and inventory item creation
-from parsed receipt data.
+Provides business logic for receipt submission, confirmation, and inventory
+item creation from parsed receipt data.
 """
 
+import json
 import logging
+from typing import Optional
 from uuid import UUID
 from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError, IntegrityError
 
-from src.db.models.processing_task import ProcessingTask, TaskStatus
+from src.db.models.processing_task import ProcessingTask, TaskStatus, TaskType
 from src.db.models.inventory_item import InventoryItem
 from src.schemas.receipt import ReceiptInventoryCandidate
 from src.schemas.inventory import InventoryItemCreate
@@ -18,6 +21,77 @@ from src.services.task_service import get_task_by_id
 from src.services.inventory_service import create_inventory_items_bulk
 
 logger = logging.getLogger(__name__)
+
+
+def submit_receipt(
+    receipt_text: str,
+    user_id: UUID,
+    db: Session,
+    store_name: Optional[str] = None,
+) -> ProcessingTask:
+    """
+    Submit receipt text for async LLM parsing.
+
+    Creates a ProcessingTask with task_type='receipt_parse' and stores
+    the receipt text and optional store name as JSON in input_reference.
+    The background task worker will pick up and process this task.
+
+    Args:
+        receipt_text: Receipt text content (digital copy-paste or OCR output)
+        user_id: ID of the authenticated user submitting the receipt
+        db: Database session
+        store_name: Optional store name for store-specific parsing hints
+
+    Returns:
+        ProcessingTask: Created task with status='pending'
+
+    Raises:
+        HTTPException(500): If database error occurs during task creation
+    """
+    # Create JSON input_reference matching task worker expectations
+    # (see task_worker.py lines 68-83 for JSON format parsing)
+    input_data = {
+        "receipt_text": receipt_text,
+        "store_name": store_name
+    }
+    input_reference = json.dumps(input_data)
+
+    # Create ProcessingTask
+    task = ProcessingTask(
+        user_id=user_id,
+        task_type=TaskType.receipt_parse.value,
+        status=TaskStatus.pending.value,
+        input_reference=input_reference,
+    )
+
+    db.add(task)
+
+    try:
+        db.commit()
+        db.refresh(task)
+    except IntegrityError as e:
+        db.rollback()
+        logger.error(f"Integrity error during receipt submission for user {user_id}")
+        logger.debug(f"Integrity error occurred during receipt submission: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Receipt submission failed due to data integrity violation"
+        )
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during receipt submission for user {user_id}")
+        logger.debug(f"Database error occurred during receipt submission: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while submitting the receipt"
+        )
+
+    logger.info(
+        f"Receipt submitted for processing: user_id={user_id}, "
+        f"task_id={task.id}, store_name={store_name}"
+    )
+
+    return task
 
 
 def confirm_receipt_items(

--- a/tests/routers/test_receipts.py
+++ b/tests/routers/test_receipts.py
@@ -296,6 +296,49 @@ def test_submit_receipt_invalid_token(client):
     assert response.status_code == 401
 
 
+# --- Error Cases: Multi-Tenant Isolation ---
+
+
+def test_submit_receipt_creates_task_for_authenticated_user_only(
+    client, db_session, test_user, other_user, auth_headers
+):
+    """Test that submitted receipts create tasks owned by the authenticated user only.
+
+    Multi-tenant isolation: Verify that when a user submits a receipt, the created
+    task belongs to them and not to any other user in the system.
+    """
+    request_data = {
+        "receipt_text": "TARGET\n04/01/2026\nApples 5.99\nBread 2.49",
+        "store_name": "Target"
+    }
+
+    response = client.post(
+        "/receipts",
+        json=request_data,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 202
+    data = response.json()
+    task_id = UUID(data["task_id"])
+
+    # Verify task exists and belongs to authenticated user (test_user)
+    task = db_session.query(ProcessingTask).filter(
+        ProcessingTask.id == task_id
+    ).first()
+    assert task is not None
+    assert task.user_id == test_user.id
+
+    # Verify task does NOT belong to other_user
+    assert task.user_id != other_user.id
+
+    # Verify other_user has no tasks
+    other_user_tasks = db_session.query(ProcessingTask).filter(
+        ProcessingTask.user_id == other_user.id
+    ).all()
+    assert len(other_user_tasks) == 0
+
+
 # --- Error Cases: Validation ---
 
 

--- a/tests/routers/test_receipts.py
+++ b/tests/routers/test_receipts.py
@@ -1,12 +1,13 @@
 """
-Integration tests for receipt confirmation endpoints.
+Integration tests for receipt endpoints.
 
 Tests cover:
+- POST /receipts: submit receipt text for async LLM parsing
 - POST /receipts/{task_id}/confirm: confirm receipt items and create inventory
 - Task validation: existence, status, ownership
 - Multi-tenant isolation: users can only confirm their own tasks
 - Authentication requirements
-- Input validation: empty items, invalid enums, etc.
+- Input validation: empty items, invalid enums, receipt text length, etc.
 """
 
 import pytest
@@ -192,6 +193,208 @@ def other_user_task(db_session, other_user):
     db_session.refresh(task)
     return task
 
+
+# --- Receipt Submission Tests ---
+
+# --- Success Cases ---
+
+
+def test_submit_receipt_success(client, db_session, test_user, auth_headers):
+    """Test successful receipt submission creates ProcessingTask."""
+    request_data = {
+        "receipt_text": "COSTCO WHOLESALE\n04/01/2026\nBananas 3.99\nMilk 4.59",
+        "store_name": "Costco"
+    }
+
+    response = client.post(
+        "/receipts",
+        json=request_data,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 202
+    data = response.json()
+    assert "task_id" in data
+    assert data["status"] == "pending"
+    assert data["message"] == "Receipt submitted for processing"
+
+    # Verify task exists in database
+    # Convert string UUID from JSON response to UUID object for database query
+    from uuid import UUID
+    task_id = UUID(data["task_id"])
+    task = db_session.query(ProcessingTask).filter(
+        ProcessingTask.id == task_id
+    ).first()
+    assert task is not None
+    assert task.user_id == test_user.id
+    assert task.task_type == TaskType.receipt_parse.value
+    assert task.status == TaskStatus.pending.value
+
+    # Verify input_reference contains JSON with receipt_text and store_name
+    import json
+    input_data = json.loads(task.input_reference)
+    assert input_data["receipt_text"] == request_data["receipt_text"]
+    assert input_data["store_name"] == request_data["store_name"]
+
+
+def test_submit_receipt_without_store_name(client, db_session, test_user, auth_headers):
+    """Test receipt submission without store_name (optional field)."""
+    request_data = {
+        "receipt_text": "Generic Store\n04/01/2026\nBananas 3.99"
+    }
+
+    response = client.post(
+        "/receipts",
+        json=request_data,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 202
+    data = response.json()
+    assert "task_id" in data
+    assert data["status"] == "pending"
+
+    # Verify task exists with null store_name
+    # Convert string UUID from JSON response to UUID object for database query
+    from uuid import UUID
+    task_id = UUID(data["task_id"])
+    task = db_session.query(ProcessingTask).filter(
+        ProcessingTask.id == task_id
+    ).first()
+    import json
+    input_data = json.loads(task.input_reference)
+    assert input_data["receipt_text"] == request_data["receipt_text"]
+    assert input_data["store_name"] is None
+
+
+# --- Error Cases: Authentication ---
+
+
+def test_submit_receipt_no_auth(client):
+    """Test receipt submission requires authentication."""
+    request_data = {
+        "receipt_text": "COSTCO WHOLESALE\n04/01/2026\nBananas 3.99"
+    }
+
+    response = client.post(
+        "/receipts",
+        json=request_data,
+    )
+
+    assert response.status_code == 401
+
+
+def test_submit_receipt_invalid_token(client):
+    """Test receipt submission fails with invalid token."""
+    request_data = {
+        "receipt_text": "COSTCO WHOLESALE\n04/01/2026\nBananas 3.99"
+    }
+
+    response = client.post(
+        "/receipts",
+        json=request_data,
+        headers={"Authorization": "Bearer invalid-token"},
+    )
+
+    assert response.status_code == 401
+
+
+# --- Error Cases: Validation ---
+
+
+def test_submit_receipt_empty_text(client, auth_headers):
+    """Test receipt submission fails when receipt_text is empty."""
+    request_data = {
+        "receipt_text": ""
+    }
+
+    response = client.post(
+        "/receipts",
+        json=request_data,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422
+
+
+def test_submit_receipt_whitespace_only(client, auth_headers):
+    """Test receipt submission fails when receipt_text is whitespace only."""
+    request_data = {
+        "receipt_text": "   \n\t   "
+    }
+
+    response = client.post(
+        "/receipts",
+        json=request_data,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422
+
+
+def test_submit_receipt_too_short(client, auth_headers):
+    """Test receipt submission fails when receipt_text is too short (< 10 chars)."""
+    request_data = {
+        "receipt_text": "short"
+    }
+
+    response = client.post(
+        "/receipts",
+        json=request_data,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422
+
+
+def test_submit_receipt_too_long(client, auth_headers):
+    """Test receipt submission fails when receipt_text exceeds max length."""
+    request_data = {
+        "receipt_text": "X" * 50001  # Exceeds max_length=50000
+    }
+
+    response = client.post(
+        "/receipts",
+        json=request_data,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422
+
+
+def test_submit_receipt_empty_store_name(client, auth_headers):
+    """Test receipt submission fails when store_name is empty string."""
+    request_data = {
+        "receipt_text": "COSTCO WHOLESALE\n04/01/2026\nBananas 3.99",
+        "store_name": ""
+    }
+
+    response = client.post(
+        "/receipts",
+        json=request_data,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422
+
+
+def test_submit_receipt_whitespace_store_name(client, auth_headers):
+    """Test receipt submission fails when store_name is whitespace only."""
+    request_data = {
+        "receipt_text": "COSTCO WHOLESALE\n04/01/2026\nBananas 3.99",
+        "store_name": "   "
+    }
+
+    response = client.post(
+        "/receipts",
+        json=request_data,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422
+
+
+# --- Receipt Confirmation Tests ---
 
 # --- Success Cases ---
 

--- a/tests/routers/test_receipts.py
+++ b/tests/routers/test_receipts.py
@@ -10,11 +10,12 @@ Tests cover:
 - Input validation: empty items, invalid enums, receipt text length, etc.
 """
 
+import json
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from uuid import uuid4
+from uuid import uuid4, UUID
 from datetime import datetime, timezone
 
 from src.db.database import Base, get_db
@@ -220,7 +221,6 @@ def test_submit_receipt_success(client, db_session, test_user, auth_headers):
 
     # Verify task exists in database
     # Convert string UUID from JSON response to UUID object for database query
-    from uuid import UUID
     task_id = UUID(data["task_id"])
     task = db_session.query(ProcessingTask).filter(
         ProcessingTask.id == task_id
@@ -231,7 +231,6 @@ def test_submit_receipt_success(client, db_session, test_user, auth_headers):
     assert task.status == TaskStatus.pending.value
 
     # Verify input_reference contains JSON with receipt_text and store_name
-    import json
     input_data = json.loads(task.input_reference)
     assert input_data["receipt_text"] == request_data["receipt_text"]
     assert input_data["store_name"] == request_data["store_name"]
@@ -256,12 +255,10 @@ def test_submit_receipt_without_store_name(client, db_session, test_user, auth_h
 
     # Verify task exists with null store_name
     # Convert string UUID from JSON response to UUID object for database query
-    from uuid import UUID
     task_id = UUID(data["task_id"])
     task = db_session.query(ProcessingTask).filter(
         ProcessingTask.id == task_id
     ).first()
-    import json
     input_data = json.loads(task.input_reference)
     assert input_data["receipt_text"] == request_data["receipt_text"]
     assert input_data["store_name"] is None


### PR DESCRIPTION
## Work in Progress

Closes #435

[Phase 4A] Add receipt submission endpoint

**Description**:
Create POST /receipts endpoint that accepts receipt text, creates a ProcessingTask for async LLM parsing, and returns 202 Accepted with task ID. Users can then poll task status to retrieve parsed results. This is text-only input for digital receipts (Costco copy-paste).

**Claude Context**:
Files to Read:
- src/routers/grocery.py (router pattern with service layer delegation)
- src/services/grocery_service.py (service layer pattern)
- src/db/models/processing_task.py (ProcessingTask model)
- src/schemas/task.py (existing ProcessingTaskResponse schema)

Files to Modify:
- src/routers/__init__.py (register receipts_router)
- src/routers/receipts.py (create)
- src/services/receipt_service.py (create)
- src/main.py (include receipts_router)
- tests/routers/test_receipts.py (create)

**Acceptance Criteria**:
- [ ] POST /receipts accepts JSON body: `{"receipt_text": "...", "store_name": "Costco"}`
- [ ] store_name is optional, defaults to null
- [ ] Endpoint creates ProcessingTask with task_type="receipt_parse"
- [ ] task.input_reference stores JSON with receipt_text and store_name (matching task worker expectation from Issue #1)
- [ ] Returns 202 Accepted with `{"task_id": "uuid", "status": "pending", "message": "Receipt submitted for processing"}`
- [ ] Receipt text min_length=10, max_length=50000 (reasonable bounds for receipt content)
- [ ] Returns 401 if not authenticated
- [ ] Returns 422 if receipt_text is empty or too short
- [ ] Service layer (receipt_service.py) handles ProcessingTask creation
- [ ] Tests cover: success case, validation errors, auth errors

**Verification Commands**:
```bash
pytest tests/routers/test_receipts.py -v
# Manual test with server running
curl -X POST http://localhost:8000/receipts \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"receipt_text": "COSTCO WHOLESALE\n04/01/2026\nBananas 3.99", "store_name": "Costco"}'
```

**Done Definition**: Done when POST /receipts creates a ProcessingTask and returns 202 with task_id.

**Scope Boundary**:
- DO: Create receipts router with POST endpoint
- DO: Create receipt_service.py with submit_receipt function
- DO: Store input as JSON with receipt_text and store_name fields
- DO: Register router in main.py
- DO NOT: Implement file upload (Phase 4B)
- DO NOT: Implement task status polling (Issue #3)
- DO NOT: Implement result parsing or confirmation (Issues #4, #5)

**Dependencies**: After #1 (task worker expects JSON input format defined in #1)

**Time Estimate**: 1hr

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**4** files, **2** commits (+0 added, ~4 modified, -0 deleted)
- `M` src/routers/receipts.py
- `M` src/schemas/receipt.py
- `M` src/services/receipt_service.py
- `M` tests/routers/test_receipts.py

### Commits
- 6c5190b feat: [Phase 4A] Add receipt submission endpoint
- 34aed6d chore: initialize work on #435 [Phase 4A] Add receipt submission endpoint
<!-- /sharkrite-changes-summary -->