### PR TITLE
[Phase 4A] Add task status polling endpoint

### DIFF
--- a/src/routers/receipts.py
+++ b/src/routers/receipts.py
@@ -25,7 +25,6 @@ from src.schemas.receipt import (
     ReceiptSubmitResponse,
     ReceiptConfirmRequest,
     ReceiptConfirmResponse,
-    ReceiptTaskStatusResponse,
 )
 from src.schemas.inventory import InventoryItemResponse
 from src.services.receipt_service import submit_receipt, confirm_receipt_items, get_receipt_task_status

--- a/src/routers/receipts.py
+++ b/src/routers/receipts.py
@@ -27,7 +27,7 @@ from src.schemas.receipt import (
     ReceiptConfirmResponse,
 )
 from src.schemas.inventory import InventoryItemResponse
-from src.services.receipt_service import submit_receipt, confirm_receipt_items, get_receipt_task_status
+from src.services.receipt_service import submit_receipt, confirm_receipt_items
 from src.middleware.auth import get_current_user
 
 logger = logging.getLogger(__name__)

--- a/src/routers/receipts.py
+++ b/src/routers/receipts.py
@@ -25,9 +25,10 @@ from src.schemas.receipt import (
     ReceiptSubmitResponse,
     ReceiptConfirmRequest,
     ReceiptConfirmResponse,
+    ReceiptTaskStatusResponse,
 )
 from src.schemas.inventory import InventoryItemResponse
-from src.services.receipt_service import submit_receipt, confirm_receipt_items
+from src.services.receipt_service import submit_receipt, confirm_receipt_items, get_receipt_task_status
 from src.middleware.auth import get_current_user
 
 logger = logging.getLogger(__name__)

--- a/src/routers/tasks.py
+++ b/src/routers/tasks.py
@@ -7,14 +7,18 @@ to check task completion.
 """
 
 import logging
+from typing import Union
 from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from src.db.database import get_db
 from src.db.models.user import User
+from src.db.models.processing_task import TaskType
 from src.schemas.task import ProcessingTaskResponse
+from src.schemas.receipt import ReceiptTaskStatusResponse
 from src.services.task_service import get_task_by_id
+from src.services.receipt_service import get_receipt_task_status
 from src.middleware.auth import get_current_user
 
 logger = logging.getLogger(__name__)
@@ -22,7 +26,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 
 
-@router.get("/{task_id}", response_model=ProcessingTaskResponse, status_code=status.HTTP_200_OK)
+@router.get("/{task_id}", response_model=Union[ReceiptTaskStatusResponse, ProcessingTaskResponse], status_code=status.HTTP_200_OK)
 def get_task_status(
     task_id: UUID,
     current_user: User = Depends(get_current_user),
@@ -32,6 +36,7 @@ def get_task_status(
     Get the status of a processing task.
 
     Returns the current status of a task and its result (if completed) or error (if failed).
+    For receipt parsing tasks, includes parsed ReceiptParseResult when status is 'completed'.
     Requires authentication. Users can only access their own tasks.
 
     Args:
@@ -40,11 +45,13 @@ def get_task_status(
         db: Database session
 
     Returns:
-        ProcessingTaskResponse with task status, metadata, and result/error if applicable
+        ReceiptTaskStatusResponse (for receipt tasks) or ProcessingTaskResponse (for other tasks)
+        with task status, metadata, and result/error if applicable
 
     Raises:
         HTTPException 404: Task not found or not owned by current user
         HTTPException 401: Unauthorized (no valid token)
+        HTTPException 500: If result parsing fails for receipt tasks
     """
     # Service layer enforces user_id filtering for defense-in-depth
     task = get_task_by_id(task_id, current_user.id, db)
@@ -56,4 +63,13 @@ def get_task_status(
             detail=f"Task with id {task_id} not found"
         )
 
+    # For receipt parsing tasks, return parsed result when completed
+    if task.task_type == TaskType.receipt_parse.value:
+        receipt_status = get_receipt_task_status(task_id, current_user.id, db)
+        if receipt_status:
+            return receipt_status
+        # Fallback to generic response if parsing fails (shouldn't happen)
+        return ProcessingTaskResponse.model_validate(task)
+
+    # For other task types, return generic response
     return ProcessingTaskResponse.model_validate(task)

--- a/src/routers/tasks.py
+++ b/src/routers/tasks.py
@@ -69,6 +69,10 @@ def get_task_status(
         if receipt_status:
             return receipt_status
         # Fallback to generic response if parsing fails (shouldn't happen)
+        logger.warning(
+            f"Receipt task {task_id} returned None from get_receipt_task_status, falling back to generic response. "
+            f"Task status: {task.status}, has result_reference: {task.result_reference is not None}"
+        )
         return ProcessingTaskResponse.model_validate(task)
 
     # For other task types, return generic response

--- a/src/schemas/receipt.py
+++ b/src/schemas/receipt.py
@@ -8,7 +8,7 @@ Per ADR Phase 4B: Receipt parsing handles messy OCR output from grocery receipts
 extracting store name, date, and line items with quantities and prices.
 """
 
-from datetime import date
+from datetime import date, datetime
 from typing import Optional
 from uuid import UUID
 from pydantic import BaseModel, Field, field_validator
@@ -320,4 +320,59 @@ class ReceiptSubmitResponse(BaseModel):
     message: str = Field(
         ...,
         description="Human-readable message"
+    )
+
+
+class ReceiptTaskStatusResponse(BaseModel):
+    """
+    Response body for receipt task status polling.
+
+    Returns task status with parsed receipt result when completed.
+    This schema extends ProcessingTaskResponse with parsed ReceiptParseResult
+    for client-side polling and result display.
+    """
+
+    id: UUID = Field(
+        ...,
+        description="Processing task ID"
+    )
+    task_type: str = Field(
+        ...,
+        description="Task type (receipt_parse)"
+    )
+    status: str = Field(
+        ...,
+        description="Task status: pending, processing, completed, or failed"
+    )
+    input_reference: str = Field(
+        ...,
+        description="Reference to input data"
+    )
+    result_reference: Optional[str] = Field(
+        default=None,
+        description="Reference to result data (raw JSON, use parsed_result for structured data)"
+    )
+    error_message: Optional[str] = Field(
+        default=None,
+        description="Error message if task failed (null otherwise)"
+    )
+    created_at: datetime = Field(
+        ...,
+        description="Task creation timestamp"
+    )
+    updated_at: datetime = Field(
+        ...,
+        description="Task last updated timestamp"
+    )
+    processing_started_at: Optional[datetime] = Field(
+        default=None,
+        description="Timestamp when processing started (null if not started)"
+    )
+    completed_at: Optional[datetime] = Field(
+        default=None,
+        description="Task completion timestamp (null if not completed)"
+    )
+    parsed_result: Optional[ReceiptParseResult] = Field(
+        default=None,
+        description="Parsed receipt data (only present when status is 'completed')"
     )

--- a/src/services/receipt_service.py
+++ b/src/services/receipt_service.py
@@ -208,7 +208,7 @@ def get_receipt_task_status(
             result_data = json.loads(task.result_reference)
             parsed_result = ReceiptParseResult.model_validate(result_data)
         except (json.JSONDecodeError, ValueError) as e:
-            # Log error but don't fail the request - return task status without parsed result
+            # Log error and fail the request - result_reference should always be valid for completed tasks
             logger.error(
                 f"Failed to parse result_reference for task {task_id}: {e}"
             )

--- a/src/services/receipt_service.py
+++ b/src/services/receipt_service.py
@@ -15,7 +15,7 @@ from sqlalchemy.exc import SQLAlchemyError, IntegrityError
 
 from src.db.models.processing_task import ProcessingTask, TaskStatus, TaskType
 from src.db.models.inventory_item import InventoryItem
-from src.schemas.receipt import ReceiptInventoryCandidate
+from src.schemas.receipt import ReceiptInventoryCandidate, ReceiptParseResult, ReceiptTaskStatusResponse
 from src.schemas.inventory import InventoryItemCreate
 from src.services.task_service import get_task_by_id
 from src.services.inventory_service import create_inventory_items_bulk
@@ -167,3 +167,68 @@ def confirm_receipt_items(
     )
 
     return created_items
+
+
+def get_receipt_task_status(
+    task_id: UUID,
+    user_id: UUID,
+    db: Session
+) -> Optional[ReceiptTaskStatusResponse]:
+    """
+    Get receipt task status with parsed result.
+
+    Retrieves a receipt parsing task and parses the result_reference JSON
+    into a ReceiptParseResult when the task status is 'completed'.
+
+    Multi-tenant isolation: Service layer validates task ownership to ensure
+    users can only access their own receipt parsing tasks.
+
+    Args:
+        task_id: ID of the receipt parsing task
+        user_id: ID of the authenticated user
+        db: Database session
+
+    Returns:
+        ReceiptTaskStatusResponse with parsed result if completed, None if task not found
+
+    Raises:
+        HTTPException(500): If result_reference JSON parsing fails for completed task
+    """
+    # Retrieve task with multi-tenant isolation
+    task = get_task_by_id(task_id, user_id, db)
+
+    if not task:
+        return None
+
+    # Parse result_reference into ReceiptParseResult if completed
+    parsed_result = None
+    if task.status == TaskStatus.completed.value and task.result_reference:
+        try:
+            # Parse JSON string into ReceiptParseResult schema
+            result_data = json.loads(task.result_reference)
+            parsed_result = ReceiptParseResult.model_validate(result_data)
+        except (json.JSONDecodeError, ValueError) as e:
+            # Log error but don't fail the request - return task status without parsed result
+            logger.error(
+                f"Failed to parse result_reference for task {task_id}: {e}"
+            )
+            logger.debug(f"Invalid result_reference content: {task.result_reference}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to parse receipt result"
+            )
+
+    # Build response
+    return ReceiptTaskStatusResponse(
+        id=task.id,
+        task_type=task.task_type,
+        status=task.status,
+        input_reference=task.input_reference,
+        result_reference=task.result_reference,
+        error_message=task.error_message,
+        created_at=task.created_at,
+        updated_at=task.updated_at,
+        processing_started_at=task.processing_started_at,
+        completed_at=task.completed_at,
+        parsed_result=parsed_result
+    )

--- a/tests/routers/test_receipts.py
+++ b/tests/routers/test_receipts.py
@@ -26,7 +26,7 @@ from src.db.models.processing_task import ProcessingTask, TaskStatus, TaskType
 from src.services.auth_service import hash_password, create_access_token
 
 from fastapi import FastAPI
-from src.routers import receipts_router
+from src.routers import receipts_router, tasks_router
 
 # Create a test app without lifespan
 app = FastAPI(
@@ -35,8 +35,9 @@ app = FastAPI(
     version="0.1.0",
 )
 
-# Register the receipts router
+# Register the receipts and tasks routers
 app.include_router(receipts_router)
+app.include_router(tasks_router)
 
 
 # Create an in-memory SQLite database for testing
@@ -838,3 +839,192 @@ def test_confirm_receipt_empty_name(client, completed_task, auth_headers):
     )
 
     assert response.status_code == 422
+
+
+# --- Receipt Task Status Polling Tests ---
+
+# --- Success Cases ---
+
+
+def test_get_task_status_pending(client, pending_task, auth_headers):
+    """Test retrieving pending receipt task status."""
+    response = client.get(
+        f"/tasks/{pending_task.id}",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == str(pending_task.id)
+    assert data["status"] == "pending"
+    assert data["parsed_result"] is None
+    assert data["error_message"] is None
+    assert data["completed_at"] is None
+    assert "created_at" in data
+
+
+def test_get_task_status_completed_with_result(client, db_session, test_user, auth_headers):
+    """Test retrieving completed receipt task with parsed result."""
+    # Create a completed task with valid ReceiptParseResult JSON
+    task = ProcessingTask(
+        id=uuid4(),
+        user_id=test_user.id,
+        task_type=TaskType.receipt_parse.value,
+        status=TaskStatus.completed.value,
+        input_reference='{"receipt_text": "test", "store_name": "Costco"}',
+        result_reference=json.dumps({
+            "store_name": "Costco Wholesale",
+            "receipt_date": "2026-04-01",
+            "line_items": [
+                {
+                    "item_name": "Bananas",
+                    "quantity": 3.0,
+                    "unit_price": 0.59,
+                    "total_price": 1.77,
+                    "category_guess": "produce"
+                },
+                {
+                    "item_name": "Milk 1 Gallon",
+                    "quantity": 2.0,
+                    "unit_price": 4.59,
+                    "total_price": 9.18,
+                    "category_guess": "dairy"
+                }
+            ]
+        }),
+        completed_at=datetime.now(timezone.utc),
+    )
+    db_session.add(task)
+    db_session.commit()
+    db_session.refresh(task)
+
+    response = client.get(
+        f"/tasks/{task.id}",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == str(task.id)
+    assert data["status"] == "completed"
+    assert data["error_message"] is None
+    assert data["completed_at"] is not None
+
+    # Verify parsed_result is present and correct
+    assert data["parsed_result"] is not None
+    parsed = data["parsed_result"]
+    assert parsed["store_name"] == "Costco Wholesale"
+    assert parsed["receipt_date"] == "2026-04-01"
+    assert len(parsed["line_items"]) == 2
+
+    # Verify first line item
+    item1 = parsed["line_items"][0]
+    assert item1["item_name"] == "Bananas"
+    assert item1["quantity"] == 3.0
+    assert item1["unit_price"] == 0.59
+    assert item1["total_price"] == 1.77
+    assert item1["category_guess"] == "produce"
+
+    # Verify second line item
+    item2 = parsed["line_items"][1]
+    assert item2["item_name"] == "Milk 1 Gallon"
+    assert item2["quantity"] == 2.0
+
+
+def test_get_task_status_processing(client, db_session, test_user, auth_headers):
+    """Test retrieving processing receipt task status."""
+    task = ProcessingTask(
+        id=uuid4(),
+        user_id=test_user.id,
+        task_type=TaskType.receipt_parse.value,
+        status=TaskStatus.processing.value,
+        input_reference='{"receipt_text": "test", "store_name": "Target"}',
+    )
+    db_session.add(task)
+    db_session.commit()
+    db_session.refresh(task)
+
+    response = client.get(
+        f"/tasks/{task.id}",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == str(task.id)
+    assert data["status"] == "processing"
+    assert data["parsed_result"] is None
+    assert data["error_message"] is None
+    assert data["completed_at"] is None
+
+
+def test_get_task_status_failed(client, db_session, test_user, auth_headers):
+    """Test retrieving failed receipt task with error message."""
+    task = ProcessingTask(
+        id=uuid4(),
+        user_id=test_user.id,
+        task_type=TaskType.receipt_parse.value,
+        status=TaskStatus.failed.value,
+        input_reference='{"receipt_text": "test", "store_name": "Walmart"}',
+        error_message="LLM service unavailable: connection timeout",
+    )
+    db_session.add(task)
+    db_session.commit()
+    db_session.refresh(task)
+
+    response = client.get(
+        f"/tasks/{task.id}",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == str(task.id)
+    assert data["status"] == "failed"
+    assert data["parsed_result"] is None
+    assert data["error_message"] == "LLM service unavailable: connection timeout"
+    assert data["completed_at"] is None
+
+
+# --- Error Cases ---
+
+
+def test_get_task_status_not_found(client, auth_headers):
+    """Test retrieving non-existent task returns 404."""
+    fake_task_id = uuid4()
+    response = client.get(
+        f"/tasks/{fake_task_id}",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+def test_get_task_status_no_auth(client, pending_task):
+    """Test retrieving task status requires authentication."""
+    response = client.get(f"/tasks/{pending_task.id}")
+
+    assert response.status_code == 401
+
+
+def test_get_task_status_invalid_token(client, pending_task):
+    """Test retrieving task status fails with invalid token."""
+    response = client.get(
+        f"/tasks/{pending_task.id}",
+        headers={"Authorization": "Bearer invalid-token"},
+    )
+
+    assert response.status_code == 401
+
+
+def test_get_task_status_other_user_task(client, other_user_task, auth_headers):
+    """Test users cannot access tasks owned by other users."""
+    response = client.get(
+        f"/tasks/{other_user_task.id}",
+        headers=auth_headers,
+    )
+
+    # Should return 404 to prevent information leakage
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()

--- a/tests/routers/test_receipts.py
+++ b/tests/routers/test_receipts.py
@@ -1028,3 +1028,29 @@ def test_get_task_status_other_user_task(client, other_user_task, auth_headers):
     # Should return 404 to prevent information leakage
     assert response.status_code == 404
     assert "not found" in response.json()["detail"].lower()
+
+
+def test_get_task_status_invalid_result_json(client, db_session, test_user, auth_headers):
+    """Test retrieving completed task with malformed JSON in result_reference returns 500."""
+    # Create a completed task with invalid JSON in result_reference
+    task = ProcessingTask(
+        id=uuid4(),
+        user_id=test_user.id,
+        task_type=TaskType.receipt_parse.value,
+        status=TaskStatus.completed.value,
+        input_reference='{"receipt_text": "test", "store_name": "Costco"}',
+        result_reference='{"invalid": "json", "missing_closing_brace":',  # Malformed JSON
+        completed_at=datetime.now(timezone.utc),
+    )
+    db_session.add(task)
+    db_session.commit()
+    db_session.refresh(task)
+
+    response = client.get(
+        f"/tasks/{task.id}",
+        headers=auth_headers,
+    )
+
+    # Should return 500 because result_reference should always be valid for completed tasks
+    assert response.status_code == 500
+    assert "failed to parse" in response.json()["detail"].lower()

--- a/tests/unit/routers/test_tasks.py
+++ b/tests/unit/routers/test_tasks.py
@@ -135,7 +135,7 @@ def completed_task(db_session, test_user):
         task_type=TaskType.receipt_parse.value,
         status=TaskStatus.completed.value,
         input_reference="s3://bucket/receipts/completed-receipt.jpg",
-        result_reference='{"store_name": "Whole Foods", "total": 45.67, "items": []}',
+        result_reference='{"store_name": "Whole Foods", "receipt_date": null, "line_items": [{"item_name": "Test Item"}]}',
         completed_at=datetime.now(timezone.utc),
     )
     db_session.add(task)

--- a/tests/unit/routers/test_tasks.py
+++ b/tests/unit/routers/test_tasks.py
@@ -135,7 +135,7 @@ def completed_task(db_session, test_user):
         task_type=TaskType.receipt_parse.value,
         status=TaskStatus.completed.value,
         input_reference="s3://bucket/receipts/completed-receipt.jpg",
-        result_reference='{"store_name": "Whole Foods", "receipt_date": null, "line_items": [{"item_name": "Test Item"}]}',
+        result_reference='{"store_name": "Whole Foods", "receipt_date": null, "line_items": [{"item_name": "Test Item", "quantity": null, "unit_price": null, "total_price": null, "category_guess": null}]}',
         completed_at=datetime.now(timezone.utc),
     )
     db_session.add(task)
@@ -275,7 +275,7 @@ class TestGetTaskStatus:
             task_type=TaskType.receipt_parse.value,
             status=TaskStatus.completed.value,
             input_reference="s3://bucket/receipts/other-user-receipt.jpg",
-            result_reference='{"store_name": "Target", "total": 100.00, "items": []}',
+            result_reference='{"store_name": "Target", "receipt_date": null, "line_items": [{"item_name": "Milk", "quantity": null, "unit_price": null, "total_price": null, "category_guess": null}]}',
         )
         db_session.add(other_task)
         db_session.commit()


### PR DESCRIPTION
## Work in Progress

Closes #436

[Phase 4A] Add task status polling endpoint

**Description**:
Create GET /tasks/{task_id} endpoint for polling ProcessingTask status and retrieving parsed results. When status=completed, include the parsed ReceiptParseResult in the response. This allows clients to poll until parsing completes.

**Claude Context**:
Files to Read:
- src/db/models/processing_task.py (ProcessingTask model, status enum)
- src/schemas/task.py (ProcessingTaskResponse schema)
- src/schemas/receipt.py (ReceiptParseResult schema)
- src/routers/receipts.py (existing receipts router from Issue #2)

Files to Modify:
- src/routers/receipts.py (add GET endpoint)
- src/services/receipt_service.py (add get_task_status function)
- src/schemas/receipt.py (add ReceiptTaskStatusResponse)
- tests/routers/test_receipts.py (extend)

**Acceptance Criteria**:
- [ ] GET /tasks/{task_id} returns task status with appropriate response shape
- [ ] Response includes: task_id, status, created_at, completed_at (nullable), error_message (nullable)
- [ ] When status="completed", response includes parsed_result field containing ReceiptParseResult
- [ ] When status="pending" or "processing", parsed_result is null
- [ ] When status="failed", error_message contains failure details
- [ ] Returns 404 if task_id doesn't exist
- [ ] Returns 401 if not authenticated
- [ ] Tests cover: pending task, completed task with result, failed task, not found

**Verification Commands**:
```bash
pytest tests/routers/test_receipts.py::test_get_task_status -v
# Manual test
curl -X GET http://localhost:8000/tasks/{task_id} \
  -H "Authorization: Bearer $TOKEN"
```

**Done Definition**: Done when GET /tasks/{task_id} returns status and includes parsed_result when completed.

**Scope Boundary**:
- DO: Add GET /tasks/{task_id} endpoint to receipts router
- DO: Parse result_reference JSON into ReceiptParseResult when completed
- DO: Create ReceiptTaskStatusResponse schema
- DO NOT: Implement task cancellation
- DO NOT: Implement task listing (not needed for MVP)
- DO NOT: Implement receipt confirmation (Issue #5)

**Dependencies**: After #2 (can run in parallel with #4)

**Time Estimate**: 45min

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**5** files, **4** commits (+0 added, ~5 modified, -0 deleted)
- `M` src/routers/tasks.py
- `M` src/schemas/receipt.py
- `M` src/services/receipt_service.py
- `M` tests/routers/test_receipts.py
- `M` tests/unit/routers/test_tasks.py

### Commits
- 6825dae wip: auto-commit relevant changes for issue #436 (2026-04-04)
- d5319c1 fix: address review findings from PR automated review
- f38222c feat: [Phase 4A] Add task status polling endpoint
- ddbe0f1 chore: initialize work on #436 [Phase 4A] Add task status polling endpoint
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-04-05T00:17:52Z:**
- Created: #444 
- Updated: none