### PR TITLE
Use database-agnostic SQL syntax

### DIFF
--- a/alembic/versions/mg8hnbcw6psr_seed_costco_store_parsing_profile.py
+++ b/alembic/versions/mg8hnbcw6psr_seed_costco_store_parsing_profile.py
@@ -86,19 +86,26 @@ def upgrade() -> None:
     # Reflect the stores table from the current database schema
     stores_table = Table('stores', metadata, autoload_with=connection)
 
-    # Check if Costco store already exists (idempotency check)
-    exists_query = sa.select(stores_table.c.id).where(stores_table.c.id == COSTCO_STORE_ID)
-    result = connection.execute(exists_query).first()
+    # Use try-except to handle race condition: if multiple processes check simultaneously
+    # and both try to insert, the database will reject the duplicate via unique constraint
+    try:
+        # Check if Costco store already exists (idempotency check)
+        exists_query = sa.select(stores_table.c.id).where(stores_table.c.id == COSTCO_STORE_ID)
+        result = connection.execute(exists_query).first()
 
-    # Only insert if the store doesn't already exist (prevents duplicate key errors)
-    if not result:
-        insert_stmt = stores_table.insert().values(
-            id=COSTCO_STORE_ID,
-            name="Costco",
-            has_digital_receipts=False,
-            parsing_profile=costco_profile  # SQLAlchemy handles JSON serialization
-        )
-        connection.execute(insert_stmt)
+        # Only insert if the store doesn't already exist (prevents duplicate key errors)
+        if not result:
+            insert_stmt = stores_table.insert().values(
+                id=COSTCO_STORE_ID,
+                name="Costco",
+                has_digital_receipts=False,
+                parsing_profile=costco_profile  # SQLAlchemy handles JSON serialization
+            )
+            connection.execute(insert_stmt)
+    except sa.exc.IntegrityError:
+        # Race condition: another process inserted between our check and insert
+        # This is safe to ignore - the store exists, which is our goal
+        pass
 
 
 def downgrade() -> None:

--- a/alembic/versions/mg8hnbcw6psr_seed_costco_store_parsing_profile.py
+++ b/alembic/versions/mg8hnbcw6psr_seed_costco_store_parsing_profile.py
@@ -6,10 +6,10 @@ Create Date: 2026-04-04 17:00:00.000000
 
 """
 from typing import Sequence, Union
-import json
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy import Table, MetaData
 
 
 # revision identifiers, used by Alembic.
@@ -32,7 +32,7 @@ def upgrade() -> None:
     - price_format_hints: Price per unit displays (e.g., "$/oz", "$/lb")
     - common_abbreviations: Costco-specific abbreviations (e.g., "ORG", "KS")
 
-    Uses INSERT OR IGNORE for idempotency (safe to run multiple times).
+    Uses database-agnostic check-then-insert pattern for idempotency (safe to run multiple times).
     """
     # Costco parsing profile with store-specific hints
     costco_profile = {
@@ -77,21 +77,28 @@ def upgrade() -> None:
         }
     }
 
-    # Insert Costco store with parsing profile
-    # Using raw SQL with INSERT OR IGNORE for SQLite compatibility
-    op.execute(
-        sa.text(
-            """
-            INSERT OR IGNORE INTO stores (id, name, has_digital_receipts, parsing_profile)
-            VALUES (:id, :name, :has_digital_receipts, :parsing_profile)
-            """
-        ).bindparams(
+    # Database-agnostic insert: check if store exists, then insert only if not present
+    # This pattern works across SQLite, PostgreSQL, MySQL, and other databases
+    # Uses check-then-insert pattern instead of database-specific upsert syntax
+    connection = op.get_bind()
+    metadata = MetaData()
+
+    # Reflect the stores table from the current database schema
+    stores_table = Table('stores', metadata, autoload_with=connection)
+
+    # Check if Costco store already exists (idempotency check)
+    exists_query = sa.select(stores_table.c.id).where(stores_table.c.id == COSTCO_STORE_ID)
+    result = connection.execute(exists_query).first()
+
+    # Only insert if the store doesn't already exist (prevents duplicate key errors)
+    if not result:
+        insert_stmt = stores_table.insert().values(
             id=COSTCO_STORE_ID,
             name="Costco",
             has_digital_receipts=False,
-            parsing_profile=json.dumps(costco_profile)
+            parsing_profile=costco_profile  # SQLAlchemy handles JSON serialization
         )
-    )
+        connection.execute(insert_stmt)
 
 
 def downgrade() -> None:

--- a/src/routers/tasks.py
+++ b/src/routers/tasks.py
@@ -16,6 +16,7 @@ from src.db.models.user import User
 from src.schemas.receipt import ReceiptTaskStatusResponse
 from src.services.receipt_service import get_receipt_task_status
 from src.middleware.auth import get_current_user
+from src.exceptions import DomainException
 
 logger = logging.getLogger(__name__)
 
@@ -49,14 +50,22 @@ def get_task_status(
         HTTPException 401: Unauthorized (no valid token)
         HTTPException 500: If result parsing fails for completed task
     """
-    # Call receipt service which validates task type and ownership (defense-in-depth)
-    receipt_status = get_receipt_task_status(task_id, current_user.id, db)
+    try:
+        # Call receipt service which validates task type and ownership (defense-in-depth)
+        receipt_status = get_receipt_task_status(task_id, current_user.id, db)
 
-    if not receipt_status:
-        # Return 404 for both not-found and unauthorized to prevent information disclosure
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Task with id {task_id} not found"
-        )
+        if not receipt_status:
+            # Return 404 for both not-found and unauthorized to prevent information disclosure
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Task with id {task_id} not found"
+            )
 
-    return receipt_status
+        return receipt_status
+
+    except DomainException as e:
+        # Convert domain exceptions (ValidationError, NotFoundError, etc.) to HTTPException
+        raise HTTPException(status_code=e.http_status_code, detail=e.message)
+    except RuntimeError as e:
+        # Convert runtime errors (e.g., JSON parsing failures) to 500
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,161 @@
+"""
+Tests for Alembic migrations, particularly database-agnostic patterns.
+"""
+import ast
+import json
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from src.db.database import Base
+from src.db import models  # noqa: F401  — registers models with Base.metadata
+
+
+TEST_DATABASE_URL = "sqlite:///:memory:"
+
+
+@pytest.fixture
+def db_session():
+    """Create a fresh in-memory database with all tables via model metadata."""
+    engine = create_engine(
+        TEST_DATABASE_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+COSTCO_STORE_ID = "a1b2c3d4-e5f6-4789-0abc-def123456789"
+
+
+def _run_seed_insert(conn):
+    """Execute the same check-then-insert logic the migration uses."""
+    from sqlalchemy import MetaData, Table
+    import sqlalchemy as sa
+
+    metadata = MetaData()
+    stores_table = Table("stores", metadata, autoload_with=conn)
+    exists_query = sa.select(stores_table.c.id).where(
+        stores_table.c.id == COSTCO_STORE_ID
+    )
+    result = conn.execute(exists_query).first()
+    if not result:
+        costco_profile = {
+            "item_name_patterns": [
+                "Kirkland Signature", "KS ", "Organic", "ORG",
+                "Multi-pack", "Variety Pack",
+            ],
+            "quantity_patterns": [
+                "2-pack", "3-pack", "4-pack", "6-pack", "12-pack",
+                "24-pack", "ct", "count", "oz pack", "lb pack",
+            ],
+            "price_format_hints": [
+                "$/oz", "$/lb", "$/kg", "$/unit", "unit price", "price per",
+            ],
+            "common_abbreviations": {
+                "ORG": "Organic", "KS": "Kirkland Signature",
+                "LB": "Pound", "OZ": "Ounce", "CT": "Count",
+                "PK": "Pack", "EA": "Each", "GAL": "Gallon", "QT": "Quart",
+            },
+        }
+        conn.execute(
+            stores_table.insert().values(
+                id=COSTCO_STORE_ID,
+                name="Costco",
+                has_digital_receipts=False,
+                parsing_profile=costco_profile,
+            )
+        )
+        conn.commit()
+
+
+def test_costco_store_migration_idempotency(db_session):
+    """
+    Verify the check-then-insert seed logic is idempotent:
+    running twice produces exactly one Costco row.
+    """
+    conn = db_session.get_bind().connect()
+
+    # First insert
+    _run_seed_insert(conn)
+
+    row = conn.execute(
+        text("SELECT id, name, has_digital_receipts, parsing_profile "
+             "FROM stores WHERE id = :id"),
+        {"id": COSTCO_STORE_ID},
+    ).first()
+
+    assert row is not None, "Costco store should be inserted"
+    assert row.name == "Costco"
+    assert row.has_digital_receipts == False  # noqa: E712
+
+    parsing_profile = row.parsing_profile
+    if isinstance(parsing_profile, str):
+        parsing_profile = json.loads(parsing_profile)
+    assert "item_name_patterns" in parsing_profile
+    assert "Kirkland Signature" in parsing_profile["item_name_patterns"]
+
+    # Second insert — idempotency check
+    _run_seed_insert(conn)
+
+    count = conn.execute(
+        text("SELECT COUNT(*) FROM stores WHERE id = :id"),
+        {"id": COSTCO_STORE_ID},
+    ).scalar()
+    assert count == 1, "Idempotent insert should not duplicate the row"
+
+    conn.close()
+
+
+def test_migration_uses_database_agnostic_syntax():
+    """
+    Static check: the migration file must not contain database-specific
+    upsert syntax in executable code.
+    """
+    migration_path = (
+        "alembic/versions/mg8hnbcw6psr_seed_costco_store_parsing_profile.py"
+    )
+    with open(migration_path, "r") as f:
+        source = f.read()
+
+    # Parse the AST to extract only string literals and executable code,
+    # ignoring comments and docstrings.
+    tree = ast.parse(source)
+
+    # Collect all string literals that appear in expressions (e.g., op.execute(text("...")))
+    # but skip module/function/class docstrings.
+    code_strings = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+            # This is a standalone string expression (docstring) — skip it
+            continue
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            code_strings.append(node.value)
+
+    code_text = " ".join(code_strings)
+
+    db_specific_patterns = [
+        "INSERT OR IGNORE",   # SQLite
+        "INSERT IGNORE",      # MySQL
+        "ON CONFLICT DO NOTHING",  # PostgreSQL
+    ]
+    for pattern in db_specific_patterns:
+        assert pattern not in code_text, (
+            f"Migration executable code should not contain '{pattern}'"
+        )
+
+    # Verify database-agnostic patterns ARE present in the source
+    assert "Table" in source, "Should use SQLAlchemy Table construct"
+    assert "MetaData" in source, "Should use SQLAlchemy MetaData"
+    assert "if not result:" in source, (
+        "Should use check-then-insert pattern for idempotency"
+    )

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -44,38 +44,44 @@ def _run_seed_insert(conn):
 
     metadata = MetaData()
     stores_table = Table("stores", metadata, autoload_with=conn)
-    exists_query = sa.select(stores_table.c.id).where(
-        stores_table.c.id == COSTCO_STORE_ID
-    )
-    result = conn.execute(exists_query).first()
-    if not result:
-        costco_profile = {
-            "item_name_patterns": [
-                "Kirkland Signature", "KS ", "Organic", "ORG",
-                "Multi-pack", "Variety Pack",
-            ],
-            "quantity_patterns": [
-                "2-pack", "3-pack", "4-pack", "6-pack", "12-pack",
-                "24-pack", "ct", "count", "oz pack", "lb pack",
-            ],
-            "price_format_hints": [
-                "$/oz", "$/lb", "$/kg", "$/unit", "unit price", "price per",
-            ],
-            "common_abbreviations": {
-                "ORG": "Organic", "KS": "Kirkland Signature",
-                "LB": "Pound", "OZ": "Ounce", "CT": "Count",
-                "PK": "Pack", "EA": "Each", "GAL": "Gallon", "QT": "Quart",
-            },
-        }
-        conn.execute(
-            stores_table.insert().values(
-                id=COSTCO_STORE_ID,
-                name="Costco",
-                has_digital_receipts=False,
-                parsing_profile=costco_profile,
-            )
+
+    try:
+        exists_query = sa.select(stores_table.c.id).where(
+            stores_table.c.id == COSTCO_STORE_ID
         )
-        conn.commit()
+        result = conn.execute(exists_query).first()
+        if not result:
+            costco_profile = {
+                "item_name_patterns": [
+                    "Kirkland Signature", "KS ", "Organic", "ORG",
+                    "Multi-pack", "Variety Pack",
+                ],
+                "quantity_patterns": [
+                    "2-pack", "3-pack", "4-pack", "6-pack", "12-pack",
+                    "24-pack", "ct", "count", "oz pack", "lb pack",
+                ],
+                "price_format_hints": [
+                    "$/oz", "$/lb", "$/kg", "$/unit", "unit price", "price per",
+                ],
+                "common_abbreviations": {
+                    "ORG": "Organic", "KS": "Kirkland Signature",
+                    "LB": "Pound", "OZ": "Ounce", "CT": "Count",
+                    "PK": "Pack", "EA": "Each", "GAL": "Gallon", "QT": "Quart",
+                },
+            }
+            conn.execute(
+                stores_table.insert().values(
+                    id=COSTCO_STORE_ID,
+                    name="Costco",
+                    has_digital_receipts=False,
+                    parsing_profile=costco_profile,
+                )
+            )
+            conn.commit()
+    except sa.exc.IntegrityError:
+        # Race condition: another process inserted between our check and insert
+        # This is safe to ignore - the store exists, which is our goal
+        conn.rollback()
 
 
 def test_costco_store_migration_idempotency(db_session):
@@ -96,7 +102,7 @@ def test_costco_store_migration_idempotency(db_session):
 
     assert row is not None, "Costco store should be inserted"
     assert row.name == "Costco"
-    assert row.has_digital_receipts == False  # noqa: E712
+    assert not row.has_digital_receipts
 
     parsing_profile = row.parsing_profile
     if isinstance(parsing_profile, str):


### PR DESCRIPTION
## Work in Progress

Closes #441

Use database-agnostic SQL syntax

<!-- sharkrite-source-issue:434 -->## From PR #440 Assessment

**Severity:** HIGH
**Category:** CodeQuality

## Issue
The `INSERT OR IGNORE` syntax is SQLite-specific and would break on PostgreSQL/MySQL. However, this is a seed data migration for a feature that works correctly on the current database, and there's no indication the project is migrating databases soon.

## Context
The original issue scope is to create a Costco store parsing profile and seed it. The migration accomplishes this goal. Database portability is a valid concern but represents future-proofing rather than a bug in the current implementation.

## Defer Reason
Scope exceeds time budget — requires research on dialect-agnostic patterns and testing across multiple database backends

---
_Created by Sharkrite assessment on 2026-04-04T23:14:59Z_
_Parent PR: #440_

---

## Additional Assessment (PR #440)

**Severity:** HIGH
**Reasoning:** This was already classified as ACTIONABLE_LATER in prior assessment decisions. The file `alembic/versions/mg8hnbcw6psr_seed_costco_store_parsing_profile.py` is listed as changed since the prior decision, but reviewing the finding shows it addresses the same `INSERT OR IGNORE` syntax concern. The migration works correctly on the current SQLite database, and there's no indication of an imminent database migration.
**Context:** The original issue scope is to create a Costco store parsing profile with seed data. The migration accomplishes this goal. Database portability is a valid concern but exceeds the scope of this feature PR.
**Defer Reason:** Scope exceeds time budget - requires architectural decision on database strategy

_Added by Sharkrite on 2026-04-04T23:17:49Z_

---

## Additional Assessment (PR #440)

**Severity:** HIGH
**Reasoning:** This is the same finding as "SQLite-specific syntax in migration limits database portability" which was already classified as ACTIONABLE_LATER in prior assessment decisions. The file has changed but the finding is identical - addressing SQLite-specific syntax.
**Context:** Prior decision explicitly states: "The migration works correctly on the current SQLite database, and there's no indication of an imminent database migration." This remains true.
**Defer Reason:** Scope exceeds time budget - requires architectural decision on dialect-aware migrations

_Added by Sharkrite on 2026-04-04T23:20:50Z_

---

## Additional Assessment (PR #440)

**Severity:** MEDIUM
**Reasoning:** This is the same finding already classified as ACTIONABLE_LATER in prior assessment decisions. The migration file has changed but the concern (INSERT OR IGNORE being SQLite-specific) remains identical and was already deferred.
**Context:** The migration works correctly on the current SQLite database. Database portability is a valid concern but not blocking for this feature.
**Defer Reason:** Scope exceeds time budget

_Added by Sharkrite on 2026-04-04T23:23:49Z_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **3** commits (+1 added, ~1 modified, -0 deleted)
- `M` alembic/versions/mg8hnbcw6psr_seed_costco_store_parsing_profile.py
- `A` tests/test_migrations.py

### Commits
- 0690ff0 Merge remote-tracking branch 'origin/main' into feat/use-database-agnostic-sql-syntax
- bf411ac fix: use database-agnostic SQL syntax in Costco store migration (#441)
- 4709fc5 chore: initialize work on #441 Use database-agnostic SQL syntax
<!-- /sharkrite-changes-summary -->