### PR TITLE
Standardize exception handling in get_accessible

### DIFF
--- a/src/routers/prepared_foods.py
+++ b/src/routers/prepared_foods.py
@@ -44,6 +44,7 @@ from src.routers.prepared_foods_helpers import (
 from src.services.prepared_foods_service import (
     create_prepared_food,
     consume_prepared_food,
+    get_accessible_prepared_food,
     transfer_prepared_food,
     freeze_prepared_food,
     thaw_prepared_food,
@@ -53,53 +54,6 @@ from src.exceptions import DomainException
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/prepared-foods", tags=["prepared-foods"])
-
-
-def get_accessible_prepared_food(
-    item_id: UUID,
-    current_user: User,
-    db: Session,
-) -> PreparedFood:
-    """
-    Retrieve a prepared food item with shareability-aware access control.
-
-    Implements the authorization pattern where:
-    - Shared items are accessible to all authenticated users
-    - Personal/reserved items are only accessible to their owner
-
-    This helper consolidates the authorization logic used across multiple
-    action endpoints (consume, transfer, freeze, thaw).
-
-    Args:
-        item_id: UUID of the prepared food item to retrieve
-        current_user: Authenticated user attempting to access the item
-        db: Database session
-
-    Returns:
-        PreparedFood: The requested item if accessible
-
-    Raises:
-        HTTPException(404): If item doesn't exist or is not accessible to current user
-    """
-    item = (
-        db.query(PreparedFood)
-        .filter(
-            PreparedFood.id == item_id,
-            or_(
-                PreparedFood.shareability == Shareability.shared.value,
-                PreparedFood.prepared_by == current_user.id
-            )
-        )
-        .first()
-    )
-
-    if not item:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Prepared food item not found"
-        )
-
-    return item
 
 
 @router.post("", response_model=PreparedFoodResponse, status_code=status.HTTP_201_CREATED)
@@ -502,9 +456,8 @@ def transfer_prepared_food_endpoint(
         HTTPException(422): If storage_location is invalid
     """
     try:
-        # Use helper function for shareability-aware access control
+        # Use service function for shareability-aware access control
         item = get_accessible_prepared_food(item_id, current_user, db)
-
         return transfer_prepared_food(item, transfer_data.storage_location, current_user, db)
     except DomainException as e:
         raise HTTPException(status_code=e.http_status_code, detail=e.message)
@@ -543,9 +496,8 @@ def freeze_prepared_food_endpoint(
         HTTPException(404): If item doesn't exist or is not accessible to current user
     """
     try:
-        # Use helper function for shareability-aware access control
+        # Use service function for shareability-aware access control
         item = get_accessible_prepared_food(item_id, current_user, db)
-
         return freeze_prepared_food(item, current_user, db)
     except DomainException as e:
         raise HTTPException(status_code=e.http_status_code, detail=e.message)
@@ -584,9 +536,8 @@ def thaw_prepared_food_endpoint(
         HTTPException(404): If item doesn't exist or is not accessible to current user
     """
     try:
-        # Use helper function for shareability-aware access control
+        # Use service function for shareability-aware access control
         item = get_accessible_prepared_food(item_id, current_user, db)
-
         return thaw_prepared_food(item, current_user, db)
     except DomainException as e:
         raise HTTPException(status_code=e.http_status_code, detail=e.message)

--- a/src/services/prepared_foods_service.py
+++ b/src/services/prepared_foods_service.py
@@ -23,6 +23,50 @@ from src.exceptions import ValidationError, NotFoundError
 logger = logging.getLogger(__name__)
 
 
+def get_accessible_prepared_food(
+    item_id: UUID,
+    current_user: User,
+    db: Session,
+) -> PreparedFood:
+    """
+    Retrieve a prepared food item with shareability-aware access control.
+
+    Implements the authorization pattern where:
+    - Shared items are accessible to all authenticated users
+    - Personal/reserved items are only accessible to their owner
+
+    This helper consolidates the authorization logic used across multiple
+    action endpoints (consume, transfer, freeze, thaw).
+
+    Args:
+        item_id: UUID of the prepared food item to retrieve
+        current_user: Authenticated user attempting to access the item
+        db: Database session
+
+    Returns:
+        PreparedFood: The requested item if accessible
+
+    Raises:
+        NotFoundError: If item doesn't exist or is not accessible to current user
+    """
+    item = (
+        db.query(PreparedFood)
+        .filter(
+            PreparedFood.id == item_id,
+            or_(
+                PreparedFood.shareability == Shareability.shared.value,
+                PreparedFood.prepared_by == current_user.id
+            )
+        )
+        .first()
+    )
+
+    if not item:
+        raise NotFoundError("Prepared food item not found")
+
+    return item
+
+
 def create_prepared_food(
     item_data: PreparedFoodCreate,
     current_user: User,


### PR DESCRIPTION
## Work in Progress

Closes #450

Standardize exception handling in get_accessible

<!-- sharkrite-source-issue:439 -->## From PR #448 Assessment

**Severity:** MEDIUM
**Category:** ScopeCreep

## Issue
The helper function still raises HTTPException directly instead of domain exceptions, creating inconsistency with the new pattern. However, this function was not modified as part of this PR and updating it requires changes across multiple endpoints that use it.

## Context
While this is a valid inconsistency, it's in a helper function that predates this PR's changes. Updating it requires touching multiple call sites and testing across different endpoints.

## Defer Reason
Scope exceeds time budget - requires updating helper and all call sites with corresponding tests

---
_Created by Sharkrite assessment on 2026-04-05T00:59:01Z_
_Parent PR: #448_

---

## Additional Assessment (PR #448)

**Severity:** MEDIUM
**Reasoning:** The PR scope focuses on decoupling HTTPException from service layer functions that were modified. Endpoints that were not modified in this PR (get_prepared_foods, get_prepared_food, update_prepared_food, delete_prepared_food) represent pre-existing code without the new exception handling pattern.
**Context:** 
**Defer Reason:** Scope exceeds time budget - completing migration across all router endpoints requires updating multiple functions that weren't part of the original change set

_Added by Sharkrite on 2026-04-05T01:02:08Z_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+0 added, ~2 modified, -0 deleted)
- `M` src/routers/prepared_foods.py
- `M` src/services/prepared_foods_service.py

### Commits
- bb0b6ee feat: Standardize exception handling in get_accessible
- d07615b chore: initialize work on #450 Standardize exception handling in get_accessible
<!-- /sharkrite-changes-summary -->