### PR TITLE
[Phase 4B] Add metadata field to ProcessingTask

### DIFF
--- a/alembic/versions/nh0iocxw7qtr_add_metadata_to_processing_tasks.py
+++ b/alembic/versions/nh0iocxw7qtr_add_metadata_to_processing_tasks.py
@@ -1,0 +1,30 @@
+"""add_metadata_to_processing_tasks
+
+Revision ID: nh0iocxw7qtr
+Revises: 5238c466e2a3
+Create Date: 2026-04-06 22:58:47.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'nh0iocxw7qtr'
+down_revision: Union[str, None] = '5238c466e2a3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add task_metadata JSON column to processing_tasks table."""
+    with op.batch_alter_table('processing_tasks', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('task_metadata', sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    """Remove task_metadata column from processing_tasks table."""
+    with op.batch_alter_table('processing_tasks', schema=None) as batch_op:
+        batch_op.drop_column('task_metadata')

--- a/src/db/models/processing_task.py
+++ b/src/db/models/processing_task.py
@@ -12,7 +12,7 @@ from uuid import UUID, uuid4
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import String, Text, DateTime, Integer, func, Index, ForeignKey
+from sqlalchemy import String, Text, DateTime, Integer, JSON, func, Index, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column
 
 from src.db.database import Base
@@ -75,6 +75,9 @@ class ProcessingTask(Base):
     input_reference: Mapped[str] = mapped_column(Text, nullable=False)
     result_reference: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     error_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    # Contextual information for task processing (e.g., store hints for parsing)
+    task_metadata: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
 
     # Retry tracking for stale task recovery
     retry_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)

--- a/src/db/models/processing_task.py
+++ b/src/db/models/processing_task.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from enum import Enum as PyEnum
 from uuid import UUID, uuid4
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
 from sqlalchemy import String, Text, DateTime, Integer, JSON, func, Index, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column
@@ -77,7 +77,7 @@ class ProcessingTask(Base):
     error_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 
     # Contextual information for task processing (e.g., store hints for parsing)
-    task_metadata: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
+    task_metadata: Mapped[Optional[dict[str, Any]]] = mapped_column(JSON, nullable=True)
 
     # Retry tracking for stale task recovery
     retry_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)

--- a/tests/unit/services/test_task_service.py
+++ b/tests/unit/services/test_task_service.py
@@ -143,3 +143,40 @@ class TestGetTaskById:
         # User2 cannot access user1's task
         result4 = get_task_by_id(task1.id, other_user_id, db_session)
         assert result4 is None
+
+    def test_task_metadata_field_is_optional(self, db_session, user_id):
+        """Test that task_metadata field can be None and can store JSON data."""
+        # Create task without metadata
+        task_without_metadata = ProcessingTask(
+            id=uuid4(),
+            user_id=user_id,
+            task_type=TaskType.receipt_parse.value,
+            status=TaskStatus.pending.value,
+            input_reference="s3://bucket/receipts/no-metadata.jpg",
+        )
+        db_session.add(task_without_metadata)
+        db_session.commit()
+        db_session.refresh(task_without_metadata)
+
+        # Verify task_metadata is None by default
+        assert task_without_metadata.task_metadata is None
+
+        # Create task with metadata
+        metadata = {"store_hint": "Costco", "location": "Seattle"}
+        task_with_metadata = ProcessingTask(
+            id=uuid4(),
+            user_id=user_id,
+            task_type=TaskType.receipt_parse.value,
+            status=TaskStatus.pending.value,
+            input_reference="s3://bucket/receipts/with-metadata.jpg",
+            task_metadata=metadata,
+        )
+        db_session.add(task_with_metadata)
+        db_session.commit()
+        db_session.refresh(task_with_metadata)
+
+        # Verify task_metadata is stored correctly
+        assert task_with_metadata.task_metadata is not None
+        assert task_with_metadata.task_metadata == metadata
+        assert task_with_metadata.task_metadata["store_hint"] == "Costco"
+        assert task_with_metadata.task_metadata["location"] == "Seattle"


### PR DESCRIPTION
## Work in Progress

Closes #455

[Phase 4B] Add metadata field to ProcessingTask

**Time Estimate**: 30min

**Description**:
Add a nullable JSON metadata field to the ProcessingTask model to store contextual information like store hints. This enables the task worker to pass store-specific parsing profiles to the LLM prompt.

**Claude Context**:
Files to Read:
- src/db/models/processing_task.py (current model definition)
- alembic/versions/ic6ciyat2lmp_add_processing_tasks_table.py (existing migration for reference)

Files to Modify:
- src/db/models/processing_task.py
- alembic/versions/ (new migration)

**Acceptance Criteria**:
- [ ] ProcessingTask model has `metadata: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)` field
- [ ] New Alembic migration adds metadata column to processing_tasks table: `alembic revision --autogenerate -m "add_metadata_to_processing_tasks"`
- [ ] Migration runs cleanly: `alembic upgrade head`
- [ ] Migration is reversible: `alembic downgrade -1` removes the column

**Verification Commands**:
```bash
alembic upgrade head
alembic downgrade -1
alembic upgrade head
python -c "from src.db.models.processing_task import ProcessingTask; print(ProcessingTask.__table__.columns.keys())"
```

**Done Definition**: Done when the metadata JSON column exists on processing_tasks table and migrations pass up/down.

**Scope Boundary**:
- DO: Add metadata field and migration
- DO NOT: Update task_worker to use metadata (Phase 4B Issue #4)
- DO NOT: Add any other columns

**Dependencies**: None

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **2** commits (+1 added, ~2 modified, -0 deleted)
- `A` alembic/versions/nh0iocxw7qtr_add_metadata_to_processing_tasks.py
- `M` src/db/models/processing_task.py
- `M` tests/unit/services/test_task_service.py

### Commits
- 5c31b30 feat: [Phase 4B] Add metadata field to ProcessingTask
- 1020cf5 chore: initialize work on #455 [Phase 4B] Add metadata field to ProcessingTask
<!-- /sharkrite-changes-summary -->