### PR TITLE
[Phase 4B] Implement Tesseract OCR service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
+    tesseract-ocr \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user for security

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ recipe-scrapers==15.4.0
 requests==2.32.3
 defusedxml==0.7.1
 pytest-timeout==2.3.1
+pytesseract==0.3.13
+Pillow==11.0.0

--- a/src/services/ocr_service.py
+++ b/src/services/ocr_service.py
@@ -1,0 +1,60 @@
+"""
+OCR service for extracting text from receipt images using Tesseract.
+
+This service provides the first step in the paper receipt pipeline:
+image → OCR text → LLM parsing.
+"""
+
+from io import BytesIO
+from PIL import Image
+import pytesseract
+
+
+class OCRError(Exception):
+    """Raised when OCR processing fails due to corrupt or unreadable images."""
+    pass
+
+
+class OCRService:
+    """Service for extracting text from images using Tesseract OCR."""
+
+    @staticmethod
+    def extract_text(image_bytes: bytes) -> str:
+        """
+        Extract text from an image using Tesseract OCR.
+
+        Args:
+            image_bytes: Raw bytes of the image file (JPEG, PNG, etc.)
+
+        Returns:
+            Extracted text string. May be empty for blank images.
+
+        Raises:
+            OCRError: If the image is corrupt or unreadable.
+
+        Example:
+            >>> with open("receipt.jpg", "rb") as f:
+            ...     image_bytes = f.read()
+            >>> text = OCRService.extract_text(image_bytes)
+            >>> print(text)
+            'COSTCO WHOLESALE\\nTOTAL: $142.37\\n...'
+        """
+        try:
+            # Open image from bytes using Pillow
+            image = Image.open(BytesIO(image_bytes))
+
+            # Extract text using Tesseract with default config
+            # No PSM mode tuning or preprocessing per scope boundary
+            text = pytesseract.image_to_string(image)
+
+            return text
+
+        except (OSError, IOError) as e:
+            # Pillow raises OSError/IOError for corrupt/invalid image files
+            raise OCRError(f"Failed to read image: {str(e)}") from e
+        except pytesseract.TesseractError as e:
+            # Tesseract-specific errors during OCR processing
+            raise OCRError(f"Tesseract OCR failed: {str(e)}") from e
+        except Exception as e:
+            # Catch-all for unexpected errors (e.g., out of memory, etc.)
+            raise OCRError(f"Unexpected error during OCR: {str(e)}") from e

--- a/src/services/ocr_service.py
+++ b/src/services/ocr_service.py
@@ -56,5 +56,9 @@ class OCRService:
             # Tesseract-specific errors during OCR processing
             raise OCRError(f"Tesseract OCR failed: {str(e)}") from e
         except Exception as e:
-            # Catch-all for unexpected errors (e.g., out of memory, etc.)
+            # Catch remaining exceptions at service boundary and wrap in OCRError.
+            # Note: KeyboardInterrupt and SystemExit do NOT inherit from Exception
+            # in Python 3, so they will not be caught here and will propagate normally.
+            # This catch-all handles unexpected errors (e.g., MemoryError) to provide
+            # consistent error handling at the service API boundary.
             raise OCRError(f"Unexpected error during OCR: {str(e)}") from e

--- a/tests/unit/services/test_ocr_service.py
+++ b/tests/unit/services/test_ocr_service.py
@@ -1,0 +1,192 @@
+"""
+Unit tests for OCR service.
+
+Tests cover:
+- Successful text extraction from valid image
+- Corrupt/invalid image file handling
+- Empty text result from blank image
+- Tesseract processing errors
+
+All tests mock pytesseract and Pillow - no real OCR processing is performed.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock, Mock
+from io import BytesIO
+from PIL import Image
+import pytesseract
+
+from src.services.ocr_service import OCRService, OCRError
+
+
+@pytest.fixture
+def mock_image():
+    """Create a mock PIL Image object."""
+    mock = MagicMock(spec=Image.Image)
+    return mock
+
+
+@pytest.fixture
+def valid_image_bytes():
+    """Create valid image bytes for testing."""
+    # Create a simple 1x1 pixel image in memory
+    img = Image.new('RGB', (1, 1), color='white')
+    buffer = BytesIO()
+    img.save(buffer, format='PNG')
+    return buffer.getvalue()
+
+
+def test_extract_text_success(mock_image):
+    """Test successful text extraction from valid image."""
+    # Mock image bytes
+    image_bytes = b"fake-image-data"
+
+    # Mock Pillow Image.open to return our mock image
+    with patch('src.services.ocr_service.Image.open') as mock_open:
+        mock_open.return_value = mock_image
+
+        # Mock pytesseract to return sample receipt text
+        with patch('src.services.ocr_service.pytesseract.image_to_string') as mock_tesseract:
+            expected_text = "COSTCO WHOLESALE\nTOTAL: $142.37\nTHANK YOU"
+            mock_tesseract.return_value = expected_text
+
+            # Execute
+            result = OCRService.extract_text(image_bytes)
+
+            # Verify
+            assert result == expected_text
+            mock_open.assert_called_once()
+            mock_tesseract.assert_called_once_with(mock_image)
+
+            # Verify Image.open was called with BytesIO containing our bytes
+            call_args = mock_open.call_args[0][0]
+            assert isinstance(call_args, BytesIO)
+
+
+def test_extract_text_empty_result(mock_image):
+    """Test extraction from blank image returns empty string."""
+    image_bytes = b"fake-blank-image-data"
+
+    with patch('src.services.ocr_service.Image.open') as mock_open:
+        mock_open.return_value = mock_image
+
+        with patch('src.services.ocr_service.pytesseract.image_to_string') as mock_tesseract:
+            # Tesseract returns empty string for blank images
+            mock_tesseract.return_value = ""
+
+            result = OCRService.extract_text(image_bytes)
+
+            assert result == ""
+            mock_tesseract.assert_called_once_with(mock_image)
+
+
+def test_extract_text_corrupt_image_oserror():
+    """Test handling of corrupt image that raises OSError."""
+    corrupt_bytes = b"not-a-valid-image-file"
+
+    with patch('src.services.ocr_service.Image.open') as mock_open:
+        # Pillow raises OSError for corrupt image files
+        mock_open.side_effect = OSError("cannot identify image file")
+
+        with pytest.raises(OCRError) as exc_info:
+            OCRService.extract_text(corrupt_bytes)
+
+        # Verify error message
+        assert "Failed to read image" in str(exc_info.value)
+        assert "cannot identify image file" in str(exc_info.value)
+
+        # Verify the original exception is chained
+        assert isinstance(exc_info.value.__cause__, OSError)
+
+
+def test_extract_text_corrupt_image_ioerror():
+    """Test handling of corrupt image that raises IOError."""
+    corrupt_bytes = b"not-a-valid-image-file"
+
+    with patch('src.services.ocr_service.Image.open') as mock_open:
+        # Pillow may also raise IOError for I/O issues
+        mock_open.side_effect = IOError("I/O error reading image")
+
+        with pytest.raises(OCRError) as exc_info:
+            OCRService.extract_text(corrupt_bytes)
+
+        assert "Failed to read image" in str(exc_info.value)
+        assert isinstance(exc_info.value.__cause__, IOError)
+
+
+def test_extract_text_tesseract_error(mock_image):
+    """Test handling of Tesseract processing errors."""
+    image_bytes = b"fake-image-data"
+
+    with patch('src.services.ocr_service.Image.open') as mock_open:
+        mock_open.return_value = mock_image
+
+        with patch('src.services.ocr_service.pytesseract.image_to_string') as mock_tesseract:
+            # Tesseract raises TesseractError for OCR processing failures
+            mock_tesseract.side_effect = pytesseract.TesseractError(
+                status=1,
+                message="Tesseract processing failed"
+            )
+
+            with pytest.raises(OCRError) as exc_info:
+                OCRService.extract_text(image_bytes)
+
+            assert "Tesseract OCR failed" in str(exc_info.value)
+            assert isinstance(exc_info.value.__cause__, pytesseract.TesseractError)
+
+
+def test_extract_text_unexpected_error(mock_image):
+    """Test handling of unexpected errors during OCR."""
+    image_bytes = b"fake-image-data"
+
+    with patch('src.services.ocr_service.Image.open') as mock_open:
+        mock_open.return_value = mock_image
+
+        with patch('src.services.ocr_service.pytesseract.image_to_string') as mock_tesseract:
+            # Simulate unexpected error (e.g., out of memory)
+            mock_tesseract.side_effect = RuntimeError("Out of memory")
+
+            with pytest.raises(OCRError) as exc_info:
+                OCRService.extract_text(image_bytes)
+
+            assert "Unexpected error during OCR" in str(exc_info.value)
+            assert "Out of memory" in str(exc_info.value)
+            assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+
+def test_extract_text_with_real_image_bytes(valid_image_bytes):
+    """Test extraction with actual image bytes (still mocking pytesseract)."""
+    # This test uses real image bytes to verify BytesIO handling
+    # but still mocks pytesseract to avoid external dependencies
+
+    with patch('src.services.ocr_service.pytesseract.image_to_string') as mock_tesseract:
+        expected_text = "Sample receipt text"
+        mock_tesseract.return_value = expected_text
+
+        result = OCRService.extract_text(valid_image_bytes)
+
+        # Verify result
+        assert result == expected_text
+
+        # Verify pytesseract was called with a PIL Image
+        mock_tesseract.assert_called_once()
+        called_image = mock_tesseract.call_args[0][0]
+        assert isinstance(called_image, Image.Image)
+
+
+def test_extract_text_whitespace_handling(mock_image):
+    """Test that whitespace in OCR results is preserved."""
+    image_bytes = b"fake-image-data"
+
+    with patch('src.services.ocr_service.Image.open') as mock_open:
+        mock_open.return_value = mock_image
+
+        with patch('src.services.ocr_service.pytesseract.image_to_string') as mock_tesseract:
+            # Tesseract often returns text with extra whitespace/newlines
+            text_with_whitespace = "\n  STORE NAME  \n\n  Item 1    $5.99\n  \n"
+            mock_tesseract.return_value = text_with_whitespace
+
+            result = OCRService.extract_text(image_bytes)
+
+            # Verify whitespace is preserved (no automatic stripping)
+            assert result == text_with_whitespace

--- a/tests/unit/services/test_ocr_service.py
+++ b/tests/unit/services/test_ocr_service.py
@@ -11,7 +11,7 @@ All tests mock pytesseract and Pillow - no real OCR processing is performed.
 """
 
 import pytest
-from unittest.mock import patch, MagicMock, Mock
+from unittest.mock import patch, MagicMock
 from io import BytesIO
 from PIL import Image
 import pytesseract


### PR DESCRIPTION
## Work in Progress

Closes #456

[Phase 4B] Implement Tesseract OCR service

**Time Estimate**: 1hr

**Description**:
Create an OCR service that uses Tesseract to extract text from receipt images. This is the first step in the paper receipt pipeline: image → OCR text → LLM parsing.

**Claude Context**:
Files to Read:
- src/services/storage_service.py (MinIO client pattern)
- src/config.py (settings pattern)

Files to Modify:
- requirements.txt (add pytesseract, Pillow)
- src/services/ocr_service.py (create)
- tests/unit/services/test_ocr_service.py (create)
- Dockerfile (add tesseract-ocr apt package if not present)

**Acceptance Criteria**:
- [ ] pytesseract and Pillow added to requirements.txt
- [ ] Dockerfile installs tesseract-ocr via apt-get (in apt install layer)
- [ ] `OCRService` class with `extract_text(image_bytes: bytes) -> str` method
- [ ] Service uses Pillow to open image from bytes
- [ ] Service calls pytesseract.image_to_string() with default config
- [ ] Returns extracted text string (may be empty for blank images)
- [ ] Raises `OCRError` for corrupt/unreadable image files
- [ ] Unit tests mock pytesseract and verify correct image handling
- [ ] Tests cover: valid image, corrupt image, empty result

**Verification Commands**:
```bash
pip install -r requirements.txt
pytest tests/unit/services/test_ocr_service.py -v
```

**Done Definition**: Done when OCRService extracts text from image bytes and tests pass.

**Scope Boundary**:
- DO: Implement OCR text extraction with Tesseract
- DO: Add dependencies and Dockerfile apt package
- DO: Create unit tests with mocked pytesseract
- DO NOT: Implement PSM mode tuning or image preprocessing (Phase 4B follow-up)
- DO NOT: Integrate with receipts router (Issue #5)

**Dependencies**: None (can run in parallel with #1)

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**4** files, **2** commits (+2 added, ~2 modified, -0 deleted)
- `M` Dockerfile
- `M` requirements.txt
- `A` src/services/ocr_service.py
- `A` tests/unit/services/test_ocr_service.py

### Commits
- f340929 feat: [Phase 4B] Implement Tesseract OCR service
- 694baec chore: initialize work on #456 [Phase 4B] Implement Tesseract OCR service
<!-- /sharkrite-changes-summary -->