### PR TITLE
[Phase 4B] Seed store parsing profiles

### DIFF
--- a/alembic/versions/nh9iocxw7qtv_update_store_parsing_profiles_phase4b.py
+++ b/alembic/versions/nh9iocxw7qtv_update_store_parsing_profiles_phase4b.py
@@ -1,0 +1,116 @@
+"""update store parsing profiles phase4b
+
+Revision ID: nh9iocxw7qtv
+Revises: mg8hnbcw6psr
+Create Date: 2026-04-06 16:00:00.000000
+
+"""
+from typing import Sequence, Union
+import json
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'nh9iocxw7qtv'
+down_revision: Union[str, None] = 'mg8hnbcw6psr'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Deterministic UUID for Generic store
+GENERIC_STORE_ID = "f9e8d7c6-b5a4-4321-9876-543210fedcba"
+
+
+def upgrade() -> None:
+    """
+    Update Costco store parsing profile and add Generic store with standardized schema.
+
+    Standardizes parsing profiles to use consistent schema:
+    - header_patterns: Store-specific header text patterns
+    - abbreviations: Common abbreviations mapped to full terms
+    - date_formats: Date format strings for parsing
+    - category_hints: Common product category names
+
+    Updates existing Costco store and adds new Generic fallback store.
+    """
+    # Updated Costco parsing profile with standardized schema
+    costco_profile = {
+        "header_patterns": ["COSTCO WHOLESALE", "WAREHOUSE"],
+        "abbreviations": {
+            "MBR": "Member",
+            "QTY": "Quantity",
+            "WT": "Weight",
+            "EA": "Each",
+            "LB": "Pound"
+        },
+        "date_formats": ["%m/%d/%y", "%m/%d/%Y"],
+        "category_hints": ["GROCERY", "PRODUCE", "MEAT", "BAKERY", "DELI", "FROZEN"]
+    }
+
+    # Generic parsing profile for fallback/unknown stores
+    generic_profile = {
+        "header_patterns": [],
+        "abbreviations": {
+            "EA": "Each",
+            "LB": "Pound",
+            "OZ": "Ounce",
+            "QTY": "Quantity"
+        },
+        "date_formats": ["%m/%d/%Y", "%m/%d/%y", "%Y-%m-%d", "%d/%m/%Y"],
+        "category_hints": ["GROCERY", "PRODUCE", "MEAT", "DAIRY", "FROZEN", "BAKERY"]
+    }
+
+    # Update Costco store parsing profile (using name since ID may vary)
+    op.execute(
+        sa.text(
+            """
+            UPDATE stores
+            SET parsing_profile = :parsing_profile
+            WHERE name = :name
+            """
+        ).bindparams(
+            name="Costco",
+            parsing_profile=json.dumps(costco_profile)
+        )
+    )
+
+    # Insert Generic store with parsing profile
+    # Using INSERT OR IGNORE for SQLite compatibility
+    op.execute(
+        sa.text(
+            """
+            INSERT OR IGNORE INTO stores (id, name, has_digital_receipts, parsing_profile)
+            VALUES (:id, :name, :has_digital_receipts, :parsing_profile)
+            """
+        ).bindparams(
+            id=GENERIC_STORE_ID,
+            name="Generic",
+            has_digital_receipts=False,
+            parsing_profile=json.dumps(generic_profile)
+        )
+    )
+
+
+def downgrade() -> None:
+    """
+    Revert Costco parsing profile and remove Generic store.
+
+    Note: This reverts to NULL parsing_profile for Costco rather than
+    the previous schema, as the old schema is deprecated.
+    """
+    # Revert Costco parsing profile to NULL
+    op.execute(
+        sa.text(
+            """
+            UPDATE stores
+            SET parsing_profile = NULL
+            WHERE name = :name
+            """
+        ).bindparams(name="Costco")
+    )
+
+    # Remove Generic store
+    op.execute(
+        sa.text("DELETE FROM stores WHERE id = :id").bindparams(id=GENERIC_STORE_ID)
+    )

--- a/alembic/versions/nh9iocxw7qtv_update_store_parsing_profiles_phase4b.py
+++ b/alembic/versions/nh9iocxw7qtv_update_store_parsing_profiles_phase4b.py
@@ -76,20 +76,39 @@ def upgrade() -> None:
     )
 
     # Insert Generic store with parsing profile
-    # Using INSERT OR IGNORE for SQLite compatibility
-    op.execute(
-        sa.text(
-            """
-            INSERT OR IGNORE INTO stores (id, name, has_digital_receipts, parsing_profile)
-            VALUES (:id, :name, :has_digital_receipts, :parsing_profile)
-            """
-        ).bindparams(
-            id=GENERIC_STORE_ID,
-            name="Generic",
-            has_digital_receipts=False,
-            parsing_profile=json.dumps(generic_profile)
+    # Use database-specific syntax for INSERT ... ON CONFLICT (PostgreSQL) / INSERT OR IGNORE (SQLite)
+    bind = op.get_bind()
+    if bind.dialect.name == 'postgresql':
+        # PostgreSQL syntax
+        op.execute(
+            sa.text(
+                """
+                INSERT INTO stores (id, name, has_digital_receipts, parsing_profile)
+                VALUES (:id, :name, :has_digital_receipts, :parsing_profile)
+                ON CONFLICT (id) DO NOTHING
+                """
+            ).bindparams(
+                id=GENERIC_STORE_ID,
+                name="Generic",
+                has_digital_receipts=False,
+                parsing_profile=json.dumps(generic_profile)
+            )
         )
-    )
+    else:
+        # SQLite syntax
+        op.execute(
+            sa.text(
+                """
+                INSERT OR IGNORE INTO stores (id, name, has_digital_receipts, parsing_profile)
+                VALUES (:id, :name, :has_digital_receipts, :parsing_profile)
+                """
+            ).bindparams(
+                id=GENERIC_STORE_ID,
+                name="Generic",
+                has_digital_receipts=False,
+                parsing_profile=json.dumps(generic_profile)
+            )
+        )
 
 
 def downgrade() -> None:

--- a/src/db/seed.py
+++ b/src/db/seed.py
@@ -15,10 +15,40 @@ from src.services.auth_service import hash_password
 
 
 STORES = [
-    {"name": "Costco", "has_digital_receipts": True},
+    {
+        "name": "Costco",
+        "has_digital_receipts": True,
+        "parsing_profile": {
+            "header_patterns": ["COSTCO WHOLESALE", "WAREHOUSE"],
+            "abbreviations": {
+                "MBR": "Member",
+                "QTY": "Quantity",
+                "WT": "Weight",
+                "EA": "Each",
+                "LB": "Pound"
+            },
+            "date_formats": ["%m/%d/%y", "%m/%d/%Y"],
+            "category_hints": ["GROCERY", "PRODUCE", "MEAT", "BAKERY", "DELI", "FROZEN"]
+        }
+    },
     {"name": "Save-A-Lot", "has_digital_receipts": False},
     {"name": "King Soopers", "has_digital_receipts": False},
     {"name": "Walmart", "has_digital_receipts": False},
+    {
+        "name": "Generic",
+        "has_digital_receipts": False,
+        "parsing_profile": {
+            "header_patterns": [],
+            "abbreviations": {
+                "EA": "Each",
+                "LB": "Pound",
+                "OZ": "Ounce",
+                "QTY": "Quantity"
+            },
+            "date_formats": ["%m/%d/%Y", "%m/%d/%y", "%Y-%m-%d", "%d/%m/%Y"],
+            "category_hints": ["GROCERY", "PRODUCE", "MEAT", "DAIRY", "FROZEN", "BAKERY"]
+        }
+    },
 ]
 
 SEED_USERS = [
@@ -45,7 +75,7 @@ def seed() -> None:
     session_factory = get_session_factory()
 
     with session_factory() as session:
-        # Seed stores
+        # Seed stores - create or update with parsing profiles
         for store_data in STORES:
             exists = session.execute(
                 select(Store).where(Store.name == store_data["name"])
@@ -54,7 +84,12 @@ def seed() -> None:
                 session.add(Store(id=uuid4(), **store_data))
                 print(f"  Added store: {store_data['name']}")
             else:
-                print(f"  Store already exists: {store_data['name']}")
+                # Update existing store with parsing profile if provided
+                if "parsing_profile" in store_data and exists.parsing_profile != store_data["parsing_profile"]:
+                    exists.parsing_profile = store_data["parsing_profile"]
+                    print(f"  Updated parsing profile for: {store_data['name']}")
+                else:
+                    print(f"  Store already exists: {store_data['name']}")
 
         # Seed users
         for user_data in SEED_USERS:

--- a/tests/db/__init__.py
+++ b/tests/db/__init__.py
@@ -1,0 +1,1 @@
+"""Database tests package."""

--- a/tests/db/test_seed.py
+++ b/tests/db/test_seed.py
@@ -1,0 +1,245 @@
+"""
+Tests for database seed data functionality.
+
+Tests cover:
+- Seed script creates stores with parsing profiles
+- Costco store has correct parsing profile schema
+- Generic store has correct parsing profile schema
+- Parsing profiles are queryable
+- Seed script is idempotent (safe to run multiple times)
+"""
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from src.db.database import Base
+from src.db import models
+from src.db.models.store import Store
+
+
+# Create an in-memory SQLite database for testing
+TEST_DATABASE_URL = "sqlite:///:memory:"
+
+
+@pytest.fixture(autouse=True)
+def setup_test_env(monkeypatch):
+    """Set up test environment variables."""
+    from src.config import get_settings
+    get_settings.cache_clear()
+
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars")
+    monkeypatch.setenv("JWT_ALGORITHM", "HS256")
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    monkeypatch.setenv("ACCESS_TOKEN_EXPIRE_MINUTES", "43200")
+
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def db_session():
+    """Create a fresh database session for each test."""
+    from sqlalchemy.pool import StaticPool
+
+    # Import models to ensure all SQLAlchemy model classes are registered
+    _ = models
+
+    engine = create_engine(
+        TEST_DATABASE_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+def test_seed_stores_have_parsing_profiles(db_session):
+    """Test that seed data includes parsing profiles for Costco and Generic stores."""
+    from src.db.seed import STORES
+
+    # Verify STORES constant has parsing profiles
+    costco_store = next((s for s in STORES if s["name"] == "Costco"), None)
+    generic_store = next((s for s in STORES if s["name"] == "Generic"), None)
+
+    assert costco_store is not None, "Costco store not found in STORES"
+    assert generic_store is not None, "Generic store not found in STORES"
+
+    assert "parsing_profile" in costco_store, "Costco store missing parsing_profile"
+    assert "parsing_profile" in generic_store, "Generic store missing parsing_profile"
+
+
+def test_costco_parsing_profile_schema(db_session):
+    """Test that Costco parsing profile follows the required schema."""
+    from src.db.seed import STORES
+
+    costco_store = next((s for s in STORES if s["name"] == "Costco"), None)
+    profile = costco_store["parsing_profile"]
+
+    # Verify required schema fields
+    assert "header_patterns" in profile, "Missing header_patterns"
+    assert "abbreviations" in profile, "Missing abbreviations"
+    assert "date_formats" in profile, "Missing date_formats"
+    assert "category_hints" in profile, "Missing category_hints"
+
+    # Verify types
+    assert isinstance(profile["header_patterns"], list), "header_patterns should be list"
+    assert isinstance(profile["abbreviations"], dict), "abbreviations should be dict"
+    assert isinstance(profile["date_formats"], list), "date_formats should be list"
+    assert isinstance(profile["category_hints"], list), "category_hints should be list"
+
+    # Verify non-empty
+    assert len(profile["header_patterns"]) > 0, "header_patterns should not be empty"
+    assert len(profile["abbreviations"]) > 0, "abbreviations should not be empty"
+    assert len(profile["date_formats"]) > 0, "date_formats should not be empty"
+    assert len(profile["category_hints"]) > 0, "category_hints should not be empty"
+
+
+def test_generic_parsing_profile_schema(db_session):
+    """Test that Generic parsing profile follows the required schema."""
+    from src.db.seed import STORES
+
+    generic_store = next((s for s in STORES if s["name"] == "Generic"), None)
+    profile = generic_store["parsing_profile"]
+
+    # Verify required schema fields
+    assert "header_patterns" in profile, "Missing header_patterns"
+    assert "abbreviations" in profile, "Missing abbreviations"
+    assert "date_formats" in profile, "Missing date_formats"
+    assert "category_hints" in profile, "Missing category_hints"
+
+    # Verify types
+    assert isinstance(profile["header_patterns"], list), "header_patterns should be list"
+    assert isinstance(profile["abbreviations"], dict), "abbreviations should be dict"
+    assert isinstance(profile["date_formats"], list), "date_formats should be list"
+    assert isinstance(profile["category_hints"], list), "category_hints should be list"
+
+    # Generic should have empty or minimal header_patterns (fallback)
+    assert isinstance(profile["header_patterns"], list), "header_patterns should be list"
+
+
+def test_seed_creates_stores_in_database(db_session, monkeypatch):
+    """Test that running seed script creates stores with parsing profiles in database."""
+    # Override database URL to use test session
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+
+    from src.config import get_settings
+    get_settings.cache_clear()
+
+    # Mock the engine and session factory to use our test db_session
+    from src.db import seed
+    from unittest.mock import patch
+
+    def mock_session_factory():
+        class MockSessionContext:
+            def __enter__(self):
+                return db_session
+            def __exit__(self, *args):
+                pass
+        return MockSessionContext()
+
+    with patch.object(seed, 'init_engine'), \
+         patch.object(seed, 'get_session_factory', return_value=mock_session_factory):
+        seed.seed()
+
+    # Query Costco store
+    costco = db_session.execute(
+        select(Store).where(Store.name == "Costco")
+    ).scalar_one_or_none()
+
+    assert costco is not None, "Costco store not created"
+    assert costco.parsing_profile is not None, "Costco parsing_profile is None"
+    assert "header_patterns" in costco.parsing_profile, "Costco missing header_patterns"
+
+    # Query Generic store
+    generic = db_session.execute(
+        select(Store).where(Store.name == "Generic")
+    ).scalar_one_or_none()
+
+    assert generic is not None, "Generic store not created"
+    assert generic.parsing_profile is not None, "Generic parsing_profile is None"
+    assert "header_patterns" in generic.parsing_profile, "Generic missing header_patterns"
+
+
+def test_seed_is_idempotent(db_session, monkeypatch):
+    """Test that running seed script multiple times doesn't create duplicates."""
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+
+    from src.config import get_settings
+    get_settings.cache_clear()
+
+    from src.db import seed
+    from unittest.mock import patch
+
+    def mock_session_factory():
+        class MockSessionContext:
+            def __enter__(self):
+                return db_session
+            def __exit__(self, *args):
+                pass
+        return MockSessionContext()
+
+    with patch.object(seed, 'init_engine'), \
+         patch.object(seed, 'get_session_factory', return_value=mock_session_factory):
+        # Run seed twice
+        seed.seed()
+        seed.seed()
+
+    # Count stores
+    stores = db_session.execute(select(Store)).scalars().all()
+    store_names = [s.name for s in stores]
+
+    # Each store should appear exactly once
+    assert store_names.count("Costco") == 1, "Costco store duplicated"
+    assert store_names.count("Generic") == 1, "Generic store duplicated"
+
+
+def test_seed_updates_existing_store_profile(db_session, monkeypatch):
+    """Test that seed script updates parsing profile on existing stores."""
+    from uuid import uuid4
+
+    # Create a Costco store without parsing profile
+    costco = Store(
+        id=uuid4(),
+        name="Costco",
+        has_digital_receipts=True,
+        parsing_profile=None
+    )
+    db_session.add(costco)
+    db_session.commit()
+
+    # Verify it has no profile
+    assert costco.parsing_profile is None
+
+    # Run seed
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+    from src.config import get_settings
+    get_settings.cache_clear()
+
+    from src.db import seed
+    from unittest.mock import patch
+
+    def mock_session_factory():
+        class MockSessionContext:
+            def __enter__(self):
+                return db_session
+            def __exit__(self, *args):
+                pass
+        return MockSessionContext()
+
+    with patch.object(seed, 'init_engine'), \
+         patch.object(seed, 'get_session_factory', return_value=mock_session_factory):
+        seed.seed()
+
+    # Refresh and verify profile was added
+    db_session.refresh(costco)
+    assert costco.parsing_profile is not None, "Parsing profile not updated"
+    assert "header_patterns" in costco.parsing_profile, "Missing header_patterns after update"


### PR DESCRIPTION
## Work in Progress

Closes #457

[Phase 4B] Seed store parsing profiles

**Time Estimate**: 30min

**Description**:
Seed the database with parsing profiles for Costco and a generic fallback. These JSON profiles provide store-specific hints to improve LLM receipt parsing accuracy.

**Claude Context**:
Files to Read:
- src/db/models/store.py (Store model with parsing_profile field)
- alembic/versions/eb9402f07ab3_initial_schema.py (store table structure)

Files to Modify:
- src/db/seed_data.py (add parsing profiles to store seeds, or create if needed)
- alembic/versions/ (data migration for existing stores)

**Acceptance Criteria**:
- [ ] Costco store has parsing_profile JSON with: expected_header_format, common_abbreviations dict, date_format_hints, typical_categories list
- [ ] Generic store profile created for fallback (name: "Generic" or "Other") with broad hints
- [ ] Parsing profiles follow consistent schema: `{"header_patterns": [...], "abbreviations": {...}, "date_formats": [...], "category_hints": [...]}`
- [ ] Seed data or migration updates existing Costco record (don't create duplicate)
- [ ] Tests verify profiles are queryable: `pytest tests/ -k "store" -v`

**Verification Commands**:
```bash
alembic upgrade head
python -c "from src.db.database import get_session_factory; from src.db.models.store import Store; s=get_session_factory()(); print(s.query(Store).filter(Store.name=='Costco').first().parsing_profile)"
```

**Done Definition**: Done when Costco and generic parsing profiles exist in the database and are queryable.

**Scope Boundary**:
- DO: Create Costco and generic parsing profiles
- DO: Update seed data or create data migration
- DO NOT: Add profiles for Save-A-Lot, King Soopers (Phase 4B follow-up)
- DO NOT: Modify Store model (parsing_profile field already exists)

**Dependencies**: None (can run in parallel with #1, #2)

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**10** files, **3** commits (+3 added, ~4 modified, -3 deleted)
- `M` Dockerfile
- `M` alembic/versions/mg8hnbcw6psr_seed_costco_store_parsing_profile.py
- `A` alembic/versions/nh9iocxw7qtv_update_store_parsing_profiles_phase4b.py
- `M` requirements.txt
- `M` src/db/seed.py
- `D` src/services/ocr_service.py
- `A` tests/db/__init__.py
- `A` tests/db/test_seed.py
- `D` tests/test_migrations.py
- `D` tests/unit/services/test_ocr_service.py

### Commits
- c074d72 fix: address review findings from PR automated review
- 5ab5968 feat: [Phase 4B] Seed store parsing profiles
- 3beeedd chore: initialize work on #457 [Phase 4B] Seed store parsing profiles
<!-- /sharkrite-changes-summary -->