### PR TITLE
Add image upload endpoint to receipts router

### DIFF
--- a/src/routers/receipts.py
+++ b/src/routers/receipts.py
@@ -12,7 +12,6 @@ Logging Policy:
     user privacy per OWASP recommendations.
 """
 
-import io
 import logging
 from uuid import UUID, uuid4
 from typing import Optional
@@ -20,6 +19,7 @@ from fastapi import APIRouter, Depends, HTTPException, status, UploadFile, File,
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError, IntegrityError
 
+from src.config import get_settings
 from src.db.database import get_db
 from src.db.models.user import User
 from src.schemas.receipt import (
@@ -135,6 +135,7 @@ def upload_receipt_image(
     Raises:
         HTTPException(401): If Authorization header is missing or token is invalid
         HTTPException(400): If file is not a valid image type (JPEG/PNG)
+        HTTPException(413): If file size exceeds 10MB limit
         HTTPException(500): If OCR, MinIO storage, or database error occurs
     """
     # Validate file type (accept only JPEG and PNG images)
@@ -152,6 +153,17 @@ def upload_receipt_image(
         # Read image bytes from upload
         image_bytes = file.file.read()
 
+        # Validate file size (max 10MB to prevent memory exhaustion attacks)
+        max_size_bytes = 10 * 1024 * 1024  # 10MB
+        if len(image_bytes) > max_size_bytes:
+            logger.warning(
+                f"Oversized file upload attempt by user {current_user.id}: {len(image_bytes)} bytes"
+            )
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail=f"File size exceeds maximum allowed size of 10MB."
+            )
+
         # Generate unique filename with original extension
         # UUID prevents conflicts and path traversal attacks
         file_ext = "jpg" if file.content_type == "image/jpeg" else "png"
@@ -161,7 +173,6 @@ def upload_receipt_image(
         minio_path = f"receipts/{current_user.id}/{filename}"
 
         # Store image in MinIO before OCR to preserve original for debugging
-        from src.config import get_settings
         settings = get_settings()
         s3_client = get_storage_client()
 

--- a/src/routers/receipts.py
+++ b/src/routers/receipts.py
@@ -40,6 +40,27 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/receipts", tags=["receipts"])
 
 
+def _detect_image_type(image_bytes: bytes) -> Optional[str]:
+    """
+    Detect image type from magic bytes.
+
+    Returns 'jpeg' for JPEG images, 'png' for PNG images, or None for other types.
+    This defends against Content-Type header spoofing by validating actual file content.
+    """
+    if not image_bytes:
+        return None
+
+    # JPEG magic bytes: FF D8 FF
+    if image_bytes[:3] == b'\xff\xd8\xff':
+        return 'jpeg'
+
+    # PNG magic bytes: 89 50 4E 47 0D 0A 1A 0A
+    if image_bytes[:8] == b'\x89\x50\x4e\x47\x0d\x0a\x1a\x0a':
+        return 'png'
+
+    return None
+
+
 @router.post(
     "",
     response_model=ReceiptSubmitResponse,
@@ -154,6 +175,18 @@ def upload_receipt_image(
         image_bytes = file.file.read()
         # Ensure file handle is closed to prevent descriptor exhaustion
         file.file.close()
+
+        # Validate actual file type using magic bytes (defense against Content-Type spoofing)
+        detected_type = _detect_image_type(image_bytes)
+        if detected_type not in {"jpeg", "png"}:
+            logger.warning(
+                f"Magic byte validation failed for user {current_user.id}: "
+                f"Content-Type={file.content_type}, detected={detected_type}"
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid file type. Only JPEG and PNG images are supported."
+            )
 
         # Validate file size (max 10MB to prevent memory exhaustion attacks)
         max_size_bytes = 10 * 1024 * 1024  # 10MB

--- a/src/routers/receipts.py
+++ b/src/routers/receipts.py
@@ -152,6 +152,8 @@ def upload_receipt_image(
     try:
         # Read image bytes from upload
         image_bytes = file.file.read()
+        # Ensure file handle is closed to prevent descriptor exhaustion
+        file.file.close()
 
         # Validate file size (max 10MB to prevent memory exhaustion attacks)
         max_size_bytes = 10 * 1024 * 1024  # 10MB

--- a/src/routers/receipts.py
+++ b/src/routers/receipts.py
@@ -12,9 +12,11 @@ Logging Policy:
     user privacy per OWASP recommendations.
 """
 
+import io
 import logging
-from uuid import UUID
-from fastapi import APIRouter, Depends, HTTPException, status
+from uuid import UUID, uuid4
+from typing import Optional
+from fastapi import APIRouter, Depends, HTTPException, status, UploadFile, File, Query
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError, IntegrityError
 
@@ -28,6 +30,8 @@ from src.schemas.receipt import (
 )
 from src.schemas.inventory import InventoryItemResponse
 from src.services.receipt_service import submit_receipt, confirm_receipt_items
+from src.services.ocr_service import OCRService, OCRError
+from src.services.storage_service import get_storage_client
 from src.middleware.auth import get_current_user
 from src.exceptions import DomainException
 
@@ -94,6 +98,160 @@ def submit_receipt_for_processing(
         logger.error(f"Runtime error in submit_receipt_for_processing: user_id={current_user.id}")
         logger.debug(f"RuntimeError details: {e}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
+
+
+@router.post(
+    "/upload",
+    response_model=ReceiptSubmitResponse,
+    status_code=status.HTTP_202_ACCEPTED
+)
+def upload_receipt_image(
+    file: UploadFile = File(...),
+    store_hint: Optional[str] = Query(None, max_length=255),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Upload receipt image for OCR extraction and async LLM parsing.
+
+    Accepts a multipart form upload with an image file (JPEG or PNG), stores
+    the image in MinIO, extracts text via Tesseract OCR, creates a ProcessingTask
+    for background LLM parsing, and returns 202 Accepted with task ID for polling.
+
+    This endpoint handles paper receipt photos. For digital receipt text, use
+    POST /receipts instead.
+
+    Multi-tenant isolation: Image stored under user's directory, task owned by user.
+
+    Args:
+        file: Uploaded image file (JPEG or PNG, max 10MB via FastAPI defaults)
+        store_hint: Optional store name hint for parsing (e.g., 'Costco')
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        ReceiptSubmitResponse with task_id, status='pending', and message
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(400): If file is not a valid image type (JPEG/PNG)
+        HTTPException(500): If OCR, MinIO storage, or database error occurs
+    """
+    # Validate file type (accept only JPEG and PNG images)
+    allowed_types = {"image/jpeg", "image/png"}
+    if file.content_type not in allowed_types:
+        logger.warning(
+            f"Invalid file type upload attempt by user {current_user.id}: {file.content_type}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid file type. Only JPEG and PNG images are supported."
+        )
+
+    try:
+        # Read image bytes from upload
+        image_bytes = file.file.read()
+
+        # Generate unique filename with original extension
+        # UUID prevents conflicts and path traversal attacks
+        file_ext = "jpg" if file.content_type == "image/jpeg" else "png"
+        file_uuid = uuid4()
+        filename = f"{file_uuid}.{file_ext}"
+        # Store under user-specific directory for multi-tenant isolation
+        minio_path = f"receipts/{current_user.id}/{filename}"
+
+        # Store image in MinIO before OCR to preserve original for debugging
+        from src.config import get_settings
+        settings = get_settings()
+        s3_client = get_storage_client()
+
+        s3_client.put_object(
+            Bucket=settings.minio_bucket,
+            Key=minio_path,
+            Body=image_bytes,
+            ContentType=file.content_type,
+        )
+
+        logger.info(
+            f"Uploaded receipt image to MinIO: user_id={current_user.id}, "
+            f"path={minio_path}"
+        )
+
+        # Extract text from image using OCR service
+        ocr_text = OCRService.extract_text(image_bytes)
+
+        # Validate OCR extracted at least some text
+        if not ocr_text or len(ocr_text.strip()) < 10:
+            logger.warning(
+                f"OCR extracted insufficient text from image: user_id={current_user.id}, "
+                f"path={minio_path}, text_length={len(ocr_text.strip())}"
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Unable to extract readable text from image. Please ensure the image is clear and readable."
+            )
+
+        logger.debug(
+            f"OCR extracted text from image: user_id={current_user.id}, "
+            f"text_length={len(ocr_text)}"
+        )
+
+        # Submit receipt via service layer (creates ProcessingTask)
+        # OCR text goes into input_reference (same format as text submission)
+        task = submit_receipt(
+            receipt_text=ocr_text,
+            user_id=current_user.id,
+            db=db,
+            store_name=store_hint,
+        )
+
+        # Update task metadata to track image source and MinIO path
+        # This allows:
+        # 1. Future filtering/analytics (e.g., "image vs text receipt success rate")
+        # 2. Linking task back to original image for debugging OCR issues
+        # 3. Potential re-processing with different OCR settings in Phase 4B
+        task.task_metadata = {
+            "source": "image",
+            "minio_path": minio_path,
+            "store_hint": store_hint,
+        }
+        db.commit()
+        db.refresh(task)
+
+        return ReceiptSubmitResponse(
+            task_id=task.id,
+            status=task.status,
+            message="Receipt image uploaded and submitted for processing"
+        )
+
+    except HTTPException:
+        # Re-raise HTTPExceptions (e.g., validation errors) without modification
+        raise
+    except OCRError as e:
+        # OCR processing failed (corrupt image, tesseract error, etc.)
+        logger.error(
+            f"OCR error during receipt upload: user_id={current_user.id}, "
+            f"filename={file.filename}"
+        )
+        logger.debug(f"OCR error details: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to process image. The image may be corrupt or unreadable."
+        )
+    except DomainException as e:
+        # Convert domain exceptions to HTTPException
+        raise HTTPException(status_code=e.http_status_code, detail=e.message)
+    except Exception as e:
+        # Catch S3/MinIO errors and other unexpected errors
+        logger.error(
+            f"Error during receipt image upload: user_id={current_user.id}, "
+            f"filename={file.filename}"
+        )
+        logger.debug(f"Upload error details: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while uploading the receipt image"
+        )
 
 
 @router.post(

--- a/tests/routers/test_receipts.py
+++ b/tests/routers/test_receipts.py
@@ -3,6 +3,7 @@ Integration tests for receipt endpoints.
 
 Tests cover:
 - POST /receipts: submit receipt text for async LLM parsing
+- POST /receipts/upload: upload receipt image for OCR and LLM parsing
 - POST /receipts/{task_id}/confirm: confirm receipt items and create inventory
 - Task validation: existence, status, ownership
 - Multi-tenant isolation: users can only confirm their own tasks
@@ -10,8 +11,10 @@ Tests cover:
 - Input validation: empty items, invalid enums, receipt text length, etc.
 """
 
+import io
 import json
 import pytest
+from unittest.mock import Mock, patch, MagicMock
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -24,6 +27,7 @@ from src.db.models.user import User, UserRole
 from src.db.models.inventory_item import InventoryItem, Category, UnitType, StorageLocation
 from src.db.models.processing_task import ProcessingTask, TaskStatus, TaskType
 from src.services.auth_service import hash_password, create_access_token
+from src.services.ocr_service import OCRError
 
 from fastapi import FastAPI
 from src.routers import receipts_router, tasks_router
@@ -433,6 +437,298 @@ def test_submit_receipt_whitespace_store_name(client, auth_headers):
     )
 
     assert response.status_code == 422
+
+
+# --- Receipt Image Upload Tests ---
+
+# --- Success Cases ---
+
+
+def test_upload_receipt_image_jpeg_success(client, db_session, test_user, auth_headers):
+    """Test successful JPEG receipt image upload with OCR extraction."""
+    # Create a mock JPEG image file
+    image_content = b"fake-jpeg-image-data"
+    image_file = ("receipt.jpg", io.BytesIO(image_content), "image/jpeg")
+
+    mock_ocr_text = "COSTCO WHOLESALE\n04/01/2026\nBananas 3.99\nMilk 4.59\nTotal: $8.58"
+
+    with patch("src.routers.receipts.OCRService.extract_text") as mock_ocr, \
+         patch("src.routers.receipts.get_storage_client") as mock_storage:
+
+        mock_ocr.return_value = mock_ocr_text
+        mock_s3_client = MagicMock()
+        mock_storage.return_value = mock_s3_client
+
+        response = client.post(
+            "/receipts/upload",
+            files={"file": image_file},
+            headers=auth_headers,
+        )
+
+    assert response.status_code == 202
+    data = response.json()
+    assert "task_id" in data
+    assert data["status"] == "pending"
+    assert "image uploaded" in data["message"].lower()
+
+    # Verify task exists in database with metadata
+    task_id = UUID(data["task_id"])
+    task = db_session.query(ProcessingTask).filter(
+        ProcessingTask.id == task_id
+    ).first()
+    assert task is not None
+    assert task.user_id == test_user.id
+    assert task.task_type == TaskType.receipt_parse.value
+    assert task.status == TaskStatus.pending.value
+
+    # Verify input_reference contains OCR text
+    input_data = json.loads(task.input_reference)
+    assert input_data["receipt_text"] == mock_ocr_text
+    assert input_data["store_name"] is None
+
+    # Verify task_metadata contains image source info
+    assert task.task_metadata is not None
+    assert task.task_metadata["source"] == "image"
+    assert "minio_path" in task.task_metadata
+    assert f"receipts/{test_user.id}/" in task.task_metadata["minio_path"]
+    assert task.task_metadata["minio_path"].endswith(".jpg")
+
+    # Verify OCR service was called with image bytes
+    mock_ocr.assert_called_once_with(image_content)
+
+    # Verify MinIO upload was called
+    mock_s3_client.put_object.assert_called_once()
+    call_args = mock_s3_client.put_object.call_args
+    assert call_args.kwargs["Body"] == image_content
+    assert call_args.kwargs["ContentType"] == "image/jpeg"
+
+
+def test_upload_receipt_image_png_success(client, db_session, test_user, auth_headers):
+    """Test successful PNG receipt image upload."""
+    # Create a mock PNG image file
+    image_content = b"fake-png-image-data"
+    image_file = ("receipt.png", io.BytesIO(image_content), "image/png")
+
+    mock_ocr_text = "TARGET\n04/05/2026\nApples 5.99\nBread 2.49\nTotal: $8.48"
+
+    with patch("src.routers.receipts.OCRService.extract_text") as mock_ocr, \
+         patch("src.routers.receipts.get_storage_client") as mock_storage:
+
+        mock_ocr.return_value = mock_ocr_text
+        mock_s3_client = MagicMock()
+        mock_storage.return_value = mock_s3_client
+
+        response = client.post(
+            "/receipts/upload",
+            files={"file": image_file},
+            headers=auth_headers,
+        )
+
+    assert response.status_code == 202
+    data = response.json()
+    assert "task_id" in data
+
+    # Verify task metadata has .png extension
+    task_id = UUID(data["task_id"])
+    task = db_session.query(ProcessingTask).filter(
+        ProcessingTask.id == task_id
+    ).first()
+    assert task.task_metadata["minio_path"].endswith(".png")
+
+
+def test_upload_receipt_image_with_store_hint(client, db_session, test_user, auth_headers):
+    """Test receipt image upload with store_hint parameter."""
+    image_content = b"fake-jpeg-image-data"
+    image_file = ("receipt.jpg", io.BytesIO(image_content), "image/jpeg")
+
+    mock_ocr_text = "COSTCO WHOLESALE\n04/01/2026\nBananas 3.99"
+
+    with patch("src.routers.receipts.OCRService.extract_text") as mock_ocr, \
+         patch("src.routers.receipts.get_storage_client") as mock_storage:
+
+        mock_ocr.return_value = mock_ocr_text
+        mock_s3_client = MagicMock()
+        mock_storage.return_value = mock_s3_client
+
+        response = client.post(
+            "/receipts/upload?store_hint=Costco",
+            files={"file": image_file},
+            headers=auth_headers,
+        )
+
+    assert response.status_code == 202
+    data = response.json()
+
+    # Verify store_hint is stored in task metadata
+    task_id = UUID(data["task_id"])
+    task = db_session.query(ProcessingTask).filter(
+        ProcessingTask.id == task_id
+    ).first()
+    input_data = json.loads(task.input_reference)
+    assert input_data["store_name"] == "Costco"
+    assert task.task_metadata["store_hint"] == "Costco"
+
+
+# --- Error Cases: File Type Validation ---
+
+
+def test_upload_receipt_image_invalid_file_type(client, auth_headers):
+    """Test receipt upload rejects non-image file types."""
+    # Create a PDF file (invalid type)
+    pdf_content = b"%PDF-1.4 fake pdf content"
+    pdf_file = ("document.pdf", io.BytesIO(pdf_content), "application/pdf")
+
+    response = client.post(
+        "/receipts/upload",
+        files={"file": pdf_file},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 400
+    assert "invalid file type" in response.json()["detail"].lower()
+    assert "jpeg" in response.json()["detail"].lower() or "png" in response.json()["detail"].lower()
+
+
+def test_upload_receipt_image_text_file(client, auth_headers):
+    """Test receipt upload rejects text files."""
+    text_content = b"this is a text file"
+    text_file = ("receipt.txt", io.BytesIO(text_content), "text/plain")
+
+    response = client.post(
+        "/receipts/upload",
+        files={"file": text_file},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 400
+    assert "invalid file type" in response.json()["detail"].lower()
+
+
+# --- Error Cases: OCR Failures ---
+
+
+def test_upload_receipt_image_ocr_error(client, auth_headers):
+    """Test receipt upload handles OCR processing errors."""
+    image_content = b"corrupt-image-data"
+    image_file = ("receipt.jpg", io.BytesIO(image_content), "image/jpeg")
+
+    with patch("src.routers.receipts.OCRService.extract_text") as mock_ocr, \
+         patch("src.routers.receipts.get_storage_client") as mock_storage:
+
+        mock_ocr.side_effect = OCRError("Failed to read image: corrupt data")
+        mock_s3_client = MagicMock()
+        mock_storage.return_value = mock_s3_client
+
+        response = client.post(
+            "/receipts/upload",
+            files={"file": image_file},
+            headers=auth_headers,
+        )
+
+    assert response.status_code == 500
+    assert "failed to process image" in response.json()["detail"].lower()
+
+
+def test_upload_receipt_image_insufficient_ocr_text(client, auth_headers):
+    """Test receipt upload rejects images with insufficient OCR text."""
+    image_content = b"blank-image-data"
+    image_file = ("receipt.jpg", io.BytesIO(image_content), "image/jpeg")
+
+    with patch("src.routers.receipts.OCRService.extract_text") as mock_ocr, \
+         patch("src.routers.receipts.get_storage_client") as mock_storage:
+
+        # OCR returns very short text (less than 10 chars)
+        mock_ocr.return_value = "ABC"
+        mock_s3_client = MagicMock()
+        mock_storage.return_value = mock_s3_client
+
+        response = client.post(
+            "/receipts/upload",
+            files={"file": image_file},
+            headers=auth_headers,
+        )
+
+    assert response.status_code == 400
+    assert "unable to extract" in response.json()["detail"].lower()
+
+
+def test_upload_receipt_image_empty_ocr_text(client, auth_headers):
+    """Test receipt upload rejects images with empty OCR text."""
+    image_content = b"blank-image-data"
+    image_file = ("receipt.jpg", io.BytesIO(image_content), "image/jpeg")
+
+    with patch("src.routers.receipts.OCRService.extract_text") as mock_ocr, \
+         patch("src.routers.receipts.get_storage_client") as mock_storage:
+
+        # OCR returns empty text
+        mock_ocr.return_value = ""
+        mock_s3_client = MagicMock()
+        mock_storage.return_value = mock_s3_client
+
+        response = client.post(
+            "/receipts/upload",
+            files={"file": image_file},
+            headers=auth_headers,
+        )
+
+    assert response.status_code == 400
+    assert "unable to extract" in response.json()["detail"].lower()
+
+
+# --- Error Cases: Authentication ---
+
+
+def test_upload_receipt_image_no_auth(client):
+    """Test receipt image upload requires authentication."""
+    image_content = b"fake-jpeg-image-data"
+    image_file = ("receipt.jpg", io.BytesIO(image_content), "image/jpeg")
+
+    response = client.post(
+        "/receipts/upload",
+        files={"file": image_file},
+    )
+
+    assert response.status_code == 401
+
+
+def test_upload_receipt_image_invalid_token(client):
+    """Test receipt image upload fails with invalid token."""
+    image_content = b"fake-jpeg-image-data"
+    image_file = ("receipt.jpg", io.BytesIO(image_content), "image/jpeg")
+
+    response = client.post(
+        "/receipts/upload",
+        files={"file": image_file},
+        headers={"Authorization": "Bearer invalid-token"},
+    )
+
+    assert response.status_code == 401
+
+
+# --- Error Cases: MinIO Storage ---
+
+
+def test_upload_receipt_image_minio_error(client, auth_headers):
+    """Test receipt upload handles MinIO storage errors."""
+    image_content = b"fake-jpeg-image-data"
+    image_file = ("receipt.jpg", io.BytesIO(image_content), "image/jpeg")
+
+    with patch("src.routers.receipts.OCRService.extract_text") as mock_ocr, \
+         patch("src.routers.receipts.get_storage_client") as mock_storage:
+
+        mock_ocr.return_value = "COSTCO WHOLESALE\n04/01/2026\nBananas 3.99"
+        mock_s3_client = MagicMock()
+        mock_s3_client.put_object.side_effect = Exception("S3 connection failed")
+        mock_storage.return_value = mock_s3_client
+
+        response = client.post(
+            "/receipts/upload",
+            files={"file": image_file},
+            headers=auth_headers,
+        )
+
+    assert response.status_code == 500
+    assert "error occurred" in response.json()["detail"].lower()
 
 
 # --- Receipt Confirmation Tests ---

--- a/tests/routers/test_receipts.py
+++ b/tests/routers/test_receipts.py
@@ -604,6 +604,23 @@ def test_upload_receipt_image_text_file(client, auth_headers):
     assert "invalid file type" in response.json()["detail"].lower()
 
 
+def test_upload_receipt_image_exceeds_size_limit(client, auth_headers):
+    """Test receipt upload rejects files exceeding 10MB size limit."""
+    # Create a file larger than 10MB (10 * 1024 * 1024 bytes)
+    oversized_content = b"x" * (10 * 1024 * 1024 + 1)  # 10MB + 1 byte
+    oversized_file = ("receipt.jpg", io.BytesIO(oversized_content), "image/jpeg")
+
+    response = client.post(
+        "/receipts/upload",
+        files={"file": oversized_file},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 413
+    assert "file size" in response.json()["detail"].lower()
+    assert "10mb" in response.json()["detail"].lower()
+
+
 # --- Error Cases: OCR Failures ---
 
 

--- a/tests/routers/test_receipts.py
+++ b/tests/routers/test_receipts.py
@@ -446,8 +446,8 @@ def test_submit_receipt_whitespace_store_name(client, auth_headers):
 
 def test_upload_receipt_image_jpeg_success(client, db_session, test_user, auth_headers):
     """Test successful JPEG receipt image upload with OCR extraction."""
-    # Create a mock JPEG image file
-    image_content = b"fake-jpeg-image-data"
+    # Create a mock JPEG image file with valid JPEG magic bytes
+    image_content = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00fake-jpeg-data"
     image_file = ("receipt.jpg", io.BytesIO(image_content), "image/jpeg")
 
     mock_ocr_text = "COSTCO WHOLESALE\n04/01/2026\nBananas 3.99\nMilk 4.59\nTotal: $8.58"
@@ -505,8 +505,8 @@ def test_upload_receipt_image_jpeg_success(client, db_session, test_user, auth_h
 
 def test_upload_receipt_image_png_success(client, db_session, test_user, auth_headers):
     """Test successful PNG receipt image upload."""
-    # Create a mock PNG image file
-    image_content = b"fake-png-image-data"
+    # Create a mock PNG image file with valid PNG magic bytes
+    image_content = b"\x89\x50\x4e\x47\x0d\x0a\x1a\x0afake-png-data"
     image_file = ("receipt.png", io.BytesIO(image_content), "image/png")
 
     mock_ocr_text = "TARGET\n04/05/2026\nApples 5.99\nBread 2.49\nTotal: $8.48"
@@ -538,7 +538,8 @@ def test_upload_receipt_image_png_success(client, db_session, test_user, auth_he
 
 def test_upload_receipt_image_with_store_hint(client, db_session, test_user, auth_headers):
     """Test receipt image upload with store_hint parameter."""
-    image_content = b"fake-jpeg-image-data"
+    # Create a mock JPEG image file with valid JPEG magic bytes
+    image_content = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00fake-jpeg-data"
     image_file = ("receipt.jpg", io.BytesIO(image_content), "image/jpeg")
 
     mock_ocr_text = "COSTCO WHOLESALE\n04/01/2026\nBananas 3.99"
@@ -567,6 +568,58 @@ def test_upload_receipt_image_with_store_hint(client, db_session, test_user, aut
     input_data = json.loads(task.input_reference)
     assert input_data["store_name"] == "Costco"
     assert task.task_metadata["store_hint"] == "Costco"
+
+
+def test_upload_receipt_image_multi_tenant_isolation(client, db_session, test_user, other_user, auth_headers, other_auth_headers):
+    """Test that uploaded images are stored under the correct user's directory.
+
+    Multi-tenant isolation: Verify that when a user uploads a receipt image,
+    the MinIO storage path includes their user_id to prevent cross-user access.
+    Each user's images should be stored in their own isolated directory.
+    """
+    # Create a mock JPEG image file with valid JPEG magic bytes
+    image_content = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00fake-jpeg-data"
+    image_file = ("receipt.jpg", io.BytesIO(image_content), "image/jpeg")
+
+    mock_ocr_text = "TARGET\n04/01/2026\nApples 5.99\nBread 2.49\nTotal: $8.48"
+
+    with patch("src.routers.receipts.OCRService.extract_text") as mock_ocr, \
+         patch("src.routers.receipts.get_storage_client") as mock_storage:
+
+        mock_ocr.return_value = mock_ocr_text
+        mock_s3_client = MagicMock()
+        mock_storage.return_value = mock_s3_client
+
+        # Upload as test_user
+        response = client.post(
+            "/receipts/upload",
+            files={"file": image_file},
+            headers=auth_headers,
+        )
+
+    assert response.status_code == 202
+    data = response.json()
+    task_id = UUID(data["task_id"])
+
+    # Verify task exists and belongs to test_user
+    task = db_session.query(ProcessingTask).filter(
+        ProcessingTask.id == task_id
+    ).first()
+    assert task is not None
+    assert task.user_id == test_user.id
+
+    # Verify MinIO path includes test_user's ID for isolation
+    minio_path = task.task_metadata["minio_path"]
+    assert f"receipts/{test_user.id}/" in minio_path
+    assert minio_path.startswith(f"receipts/{test_user.id}/")
+
+    # Verify path does NOT include other_user's ID
+    assert str(other_user.id) not in minio_path
+
+    # Verify the MinIO upload was called with correct path
+    mock_s3_client.put_object.assert_called_once()
+    call_args = mock_s3_client.put_object.call_args
+    assert f"receipts/{test_user.id}/" in call_args.kwargs["Key"]
 
 
 # --- Error Cases: File Type Validation ---
@@ -606,8 +659,8 @@ def test_upload_receipt_image_text_file(client, auth_headers):
 
 def test_upload_receipt_image_exceeds_size_limit(client, auth_headers):
     """Test receipt upload rejects files exceeding 10MB size limit."""
-    # Create a file larger than 10MB (10 * 1024 * 1024 bytes)
-    oversized_content = b"x" * (10 * 1024 * 1024 + 1)  # 10MB + 1 byte
+    # Create a file larger than 10MB (10 * 1024 * 1024 bytes) with valid JPEG magic bytes
+    oversized_content = b"\xff\xd8\xff\xe0" + b"x" * (10 * 1024 * 1024)  # 10MB + magic bytes
     oversized_file = ("receipt.jpg", io.BytesIO(oversized_content), "image/jpeg")
 
     response = client.post(
@@ -626,7 +679,8 @@ def test_upload_receipt_image_exceeds_size_limit(client, auth_headers):
 
 def test_upload_receipt_image_ocr_error(client, auth_headers):
     """Test receipt upload handles OCR processing errors."""
-    image_content = b"corrupt-image-data"
+    # Create a mock JPEG with valid magic bytes but corrupt data for OCR
+    image_content = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01corrupt-image-data"
     image_file = ("receipt.jpg", io.BytesIO(image_content), "image/jpeg")
 
     with patch("src.routers.receipts.OCRService.extract_text") as mock_ocr, \
@@ -648,7 +702,8 @@ def test_upload_receipt_image_ocr_error(client, auth_headers):
 
 def test_upload_receipt_image_insufficient_ocr_text(client, auth_headers):
     """Test receipt upload rejects images with insufficient OCR text."""
-    image_content = b"blank-image-data"
+    # Create a mock JPEG with valid magic bytes
+    image_content = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01blank-image-data"
     image_file = ("receipt.jpg", io.BytesIO(image_content), "image/jpeg")
 
     with patch("src.routers.receipts.OCRService.extract_text") as mock_ocr, \
@@ -671,7 +726,8 @@ def test_upload_receipt_image_insufficient_ocr_text(client, auth_headers):
 
 def test_upload_receipt_image_empty_ocr_text(client, auth_headers):
     """Test receipt upload rejects images with empty OCR text."""
-    image_content = b"blank-image-data"
+    # Create a mock JPEG with valid magic bytes
+    image_content = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01blank-image-data"
     image_file = ("receipt.jpg", io.BytesIO(image_content), "image/jpeg")
 
     with patch("src.routers.receipts.OCRService.extract_text") as mock_ocr, \
@@ -697,7 +753,8 @@ def test_upload_receipt_image_empty_ocr_text(client, auth_headers):
 
 def test_upload_receipt_image_no_auth(client):
     """Test receipt image upload requires authentication."""
-    image_content = b"fake-jpeg-image-data"
+    # Create a mock JPEG with valid magic bytes
+    image_content = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01fake-jpeg-data"
     image_file = ("receipt.jpg", io.BytesIO(image_content), "image/jpeg")
 
     response = client.post(
@@ -710,7 +767,8 @@ def test_upload_receipt_image_no_auth(client):
 
 def test_upload_receipt_image_invalid_token(client):
     """Test receipt image upload fails with invalid token."""
-    image_content = b"fake-jpeg-image-data"
+    # Create a mock JPEG with valid magic bytes
+    image_content = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01fake-jpeg-data"
     image_file = ("receipt.jpg", io.BytesIO(image_content), "image/jpeg")
 
     response = client.post(
@@ -727,7 +785,8 @@ def test_upload_receipt_image_invalid_token(client):
 
 def test_upload_receipt_image_minio_error(client, auth_headers):
     """Test receipt upload handles MinIO storage errors."""
-    image_content = b"fake-jpeg-image-data"
+    # Create a mock JPEG with valid magic bytes
+    image_content = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01fake-jpeg-data"
     image_file = ("receipt.jpg", io.BytesIO(image_content), "image/jpeg")
 
     with patch("src.routers.receipts.OCRService.extract_text") as mock_ocr, \


### PR DESCRIPTION
## Work in Progress

Closes #459

Add image upload endpoint to receipts router

**Time Estimate**: 1hr

**Description**:
Extend the existing receipts router to accept image uploads for paper receipt processing. This endpoint receives a multipart form upload, stores the image in MinIO, extracts text via the OCR service, and creates a ProcessingTask for LLM parsing.

**Claude Context**:
Files to Read:
- src/routers/receipts.py (EXISTING router - must extend, not replace)
- src/services/ocr_service.py (OCRService from Issue #2)
- src/services/storage_service.py (MinIO client pattern)
- src/db/models/processing_task.py (ProcessingTask with metadata field)

Files to Modify:
- src/routers/receipts.py (add upload endpoint to existing router)
- src/schemas/receipt.py (add ReceiptUploadResponse if needed)
- tests/unit/routers/test_receipts.py (add upload endpoint tests)

**Acceptance Criteria**:
- [ ] `POST /receipts/upload` endpoint accepts multipart form data with `file` field
- [ ] Endpoint validates file is an image (JPEG, PNG) and rejects other types with 400
- [ ] Image stored in MinIO under `receipts/{user_id}/{uuid}.{ext}` path
- [ ] OCRService.extract_text() called on uploaded image bytes
- [ ] ProcessingTask created with: input_text=OCR result, metadata={"source": "image", "minio_path": path, "store_hint": optional_store_param}
- [ ] Returns 202 Accepted with task_id for polling (matches existing text submit pattern)
- [ ] Optional `store_hint` query param stored in task metadata
- [ ] Endpoint requires authentication (matches existing router auth pattern)
- [ ] Unit tests mock MinIO and OCR service, verify correct flow

**Verification Commands**:
```bash
pytest tests/unit/routers/test_receipts.py -v -k upload
```

**Done Definition**: Done when image upload endpoint exists on the receipts router, stores images in MinIO, extracts text via OCR, and creates ProcessingTask entries.

**Scope Boundary**:
- DO: Add upload endpoint to EXISTING receipts.py router
- DO: Integrate with OCRService and MinIO storage
- DO: Follow existing router patterns for auth and response format
- DO NOT: Create a new receipts.py file (router already exists from Phase 4A)
- DO NOT: Implement image preprocessing or PSM tuning (Phase 4B follow-up)
- DO NOT: Build frontend/UI for camera capture (frontend phase)

**Dependencies**: After #2 (needs: OCRService implementation)

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**6** files, **2** commits (+0 added, ~3 modified, -3 deleted)
- `D` alembic/versions/nh9iocxw7qtv_update_store_parsing_profiles_phase4b.py
- `M` src/db/seed.py
- `M` src/routers/receipts.py
- `D` tests/db/__init__.py
- `D` tests/db/test_seed.py
- `M` tests/routers/test_receipts.py

### Commits
- f2b22d6 feat: Add image upload endpoint to receipts router
- 54dd2d3 chore: initialize work on #459 Add image upload endpoint to receipts router
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-04-06T23:22:34Z:**
- Created: #466 
- Updated: none