### PR TITLE
Fix: clean up orphaned MinIO objects on upload failure

### DIFF
--- a/src/routers/receipts.py
+++ b/src/routers/receipts.py
@@ -61,6 +61,24 @@ def _detect_image_type(image_bytes: bytes) -> Optional[str]:
     return None
 
 
+def _cleanup_minio_object(s3_client, settings, minio_path: Optional[str], user_id) -> None:
+    """Delete an uploaded MinIO object after a subsequent failure.
+
+    Safe to call when no upload occurred (minio_path is None) — will no-op.
+    Logs but does not raise on cleanup failure to avoid masking the original error.
+    """
+    if not minio_path or not s3_client or not settings:
+        return
+    try:
+        s3_client.delete_object(Bucket=settings.minio_bucket, Key=minio_path)
+        logger.info(f"Cleaned up orphaned MinIO object: user_id={user_id}, path={minio_path}")
+    except Exception as cleanup_err:
+        logger.warning(
+            f"Failed to clean up MinIO object after error: user_id={user_id}, "
+            f"path={minio_path}, cleanup_error={cleanup_err}"
+        )
+
+
 @router.post(
     "",
     response_model=ReceiptSubmitResponse,
@@ -170,6 +188,10 @@ def upload_receipt_image(
             detail=f"Invalid file type. Only JPEG and PNG images are supported."
         )
 
+    minio_path = None
+    s3_client = None
+    settings = None
+
     try:
         # Read image bytes from upload
         image_bytes = file.file.read()
@@ -271,10 +293,12 @@ def upload_receipt_image(
         )
 
     except HTTPException:
-        # Re-raise HTTPExceptions (e.g., validation errors) without modification
+        # Clean up MinIO object if it was uploaded before the error
+        _cleanup_minio_object(s3_client, settings, minio_path, current_user.id)
         raise
     except OCRError as e:
         # OCR processing failed (corrupt image, tesseract error, etc.)
+        _cleanup_minio_object(s3_client, settings, minio_path, current_user.id)
         logger.error(
             f"OCR error during receipt upload: user_id={current_user.id}, "
             f"filename={file.filename}"
@@ -285,9 +309,10 @@ def upload_receipt_image(
             detail="Failed to process image. The image may be corrupt or unreadable."
         )
     except DomainException as e:
-        # Convert domain exceptions to HTTPException
+        _cleanup_minio_object(s3_client, settings, minio_path, current_user.id)
         raise HTTPException(status_code=e.http_status_code, detail=e.message)
     except Exception as e:
+        _cleanup_minio_object(s3_client, settings, minio_path, current_user.id)
         # Catch S3/MinIO errors and other unexpected errors
         logger.error(
             f"Error during receipt image upload: user_id={current_user.id}, "

--- a/tests/routers/test_receipts.py
+++ b/tests/routers/test_receipts.py
@@ -678,7 +678,7 @@ def test_upload_receipt_image_exceeds_size_limit(client, auth_headers):
 
 
 def test_upload_receipt_image_ocr_error(client, auth_headers):
-    """Test receipt upload handles OCR processing errors."""
+    """Test receipt upload handles OCR processing errors and cleans up MinIO."""
     # Create a mock JPEG with valid magic bytes but corrupt data for OCR
     image_content = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01corrupt-image-data"
     image_file = ("receipt.jpg", io.BytesIO(image_content), "image/jpeg")
@@ -698,10 +698,12 @@ def test_upload_receipt_image_ocr_error(client, auth_headers):
 
     assert response.status_code == 500
     assert "failed to process image" in response.json()["detail"].lower()
+    # Verify MinIO object was cleaned up after OCR failure
+    mock_s3_client.delete_object.assert_called_once()
 
 
 def test_upload_receipt_image_insufficient_ocr_text(client, auth_headers):
-    """Test receipt upload rejects images with insufficient OCR text."""
+    """Test receipt upload rejects images with insufficient OCR text and cleans up MinIO."""
     # Create a mock JPEG with valid magic bytes
     image_content = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01blank-image-data"
     image_file = ("receipt.jpg", io.BytesIO(image_content), "image/jpeg")
@@ -722,10 +724,12 @@ def test_upload_receipt_image_insufficient_ocr_text(client, auth_headers):
 
     assert response.status_code == 400
     assert "unable to extract" in response.json()["detail"].lower()
+    # Verify MinIO object was cleaned up after insufficient OCR text
+    mock_s3_client.delete_object.assert_called_once()
 
 
 def test_upload_receipt_image_empty_ocr_text(client, auth_headers):
-    """Test receipt upload rejects images with empty OCR text."""
+    """Test receipt upload rejects images with empty OCR text and cleans up MinIO."""
     # Create a mock JPEG with valid magic bytes
     image_content = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01blank-image-data"
     image_file = ("receipt.jpg", io.BytesIO(image_content), "image/jpeg")
@@ -746,6 +750,28 @@ def test_upload_receipt_image_empty_ocr_text(client, auth_headers):
 
     assert response.status_code == 400
     assert "unable to extract" in response.json()["detail"].lower()
+    # Verify MinIO object was cleaned up after empty OCR text
+    mock_s3_client.delete_object.assert_called_once()
+
+
+def test_upload_receipt_image_no_cleanup_before_upload(client, auth_headers):
+    """Test that validation failures before MinIO upload don't attempt cleanup."""
+    # Invalid file type — fails before upload, no cleanup needed
+    image_content = b"not-an-image"
+    image_file = ("receipt.txt", io.BytesIO(image_content), "text/plain")
+
+    with patch("src.routers.receipts.get_storage_client") as mock_storage:
+        mock_s3_client = MagicMock()
+        mock_storage.return_value = mock_s3_client
+
+        response = client.post(
+            "/receipts/upload",
+            files={"file": image_file},
+            headers=auth_headers,
+        )
+
+    assert response.status_code == 400
+    mock_s3_client.delete_object.assert_not_called()
 
 
 # --- Error Cases: Authentication ---


### PR DESCRIPTION
## Summary
Closes #466

- Adds `_cleanup_minio_object()` helper that deletes uploaded MinIO objects when subsequent steps (OCR, task creation, db commit) fail
- Cleanup is best-effort: failures are logged as warnings but don't mask the original error
- `minio_path`, `s3_client`, and `settings` are initialized to `None` before the try block so cleanup knows whether an upload occurred

## Test plan
- [x] `test_upload_receipt_image_ocr_error` — verifies `delete_object` called after OCR failure
- [x] `test_upload_receipt_image_insufficient_ocr_text` — verifies cleanup after short OCR text
- [x] `test_upload_receipt_image_empty_ocr_text` — verifies cleanup after empty OCR text
- [x] `test_upload_receipt_image_no_cleanup_before_upload` — verifies no cleanup attempt when failure occurs before MinIO upload
- [x] All 51 receipt router tests pass