### PR TITLE
Integrate store profiles into receipt pipeline

### DIFF
--- a/src/services/task_worker.py
+++ b/src/services/task_worker.py
@@ -60,6 +60,11 @@ async def process_receipt_task(
         input_reference can be either:
         1. Plain text (legacy format): "Costco\\n2024-03-29\\nBananas $3.99"
         2. JSON (new format): {"receipt_text": "...", "store_name": "Costco"}
+
+        Store hint sources (in priority order):
+        1. task.task_metadata['store_hint'] (preferred, most flexible)
+        2. input_reference JSON 'store_name' field (backward compatible)
+        3. None (falls back to generic parsing prompt)
     """
     # Parse input_reference to extract receipt text and optional store name
     receipt_text = None
@@ -89,6 +94,17 @@ async def process_receipt_task(
             "Task input is plain text (not JSON), using generic prompt",
             extra={"task_id": str(task.id)}
         )
+
+    # Check task metadata for store hint (preferred source, takes precedence)
+    # Metadata approach is newer and more flexible than embedding in input_reference
+    if task.task_metadata and "store_hint" in task.task_metadata:
+        metadata_store_hint = task.task_metadata.get("store_hint")
+        if metadata_store_hint:
+            store_name = metadata_store_hint
+            logger.debug(
+                "Using store hint from task metadata",
+                extra={"task_id": str(task.id), "store_hint": store_name}
+            )
 
     # Look up store parsing profile if store_name provided
     store_hints = None

--- a/src/services/task_worker.py
+++ b/src/services/task_worker.py
@@ -99,11 +99,21 @@ async def process_receipt_task(
     # Metadata approach is newer and more flexible than embedding in input_reference
     if task.task_metadata and "store_hint" in task.task_metadata:
         metadata_store_hint = task.task_metadata.get("store_hint")
-        if metadata_store_hint:
+        # Validate store_hint is a string before using it
+        if metadata_store_hint and isinstance(metadata_store_hint, str):
             store_name = metadata_store_hint
             logger.debug(
                 "Using store hint from task metadata",
                 extra={"task_id": str(task.id), "store_hint": store_name}
+            )
+        elif metadata_store_hint:
+            # Store hint present but invalid type - log warning and ignore
+            logger.warning(
+                "Task metadata contains store_hint with invalid type (expected string)",
+                extra={
+                    "task_id": str(task.id),
+                    "store_hint_type": type(metadata_store_hint).__name__
+                }
             )
 
     # Look up store parsing profile if store_name provided

--- a/tests/unit/services/test_task_worker.py
+++ b/tests/unit/services/test_task_worker.py
@@ -987,6 +987,8 @@ async def test_process_receipt_task_metadata_takes_precedence_over_json(
     sample_receipt_result
 ):
     """Test that task_metadata store_hint takes precedence over input_reference JSON."""
+    from src.db.models.store import Store
+
     # Create task with BOTH JSON store_name AND metadata store_hint (different stores)
     task = MagicMock(spec=ProcessingTask)
     task.id = uuid4()
@@ -1003,19 +1005,36 @@ async def test_process_receipt_task_metadata_takes_precedence_over_json(
     # Configure mock to return valid result
     mock_ollama_client.complete.return_value = sample_receipt_result
 
-    # Mock database query - will be called with "Costco" not "WrongStore"
+    # Create a mock store with Costco-specific parsing profile
+    # This will only be returned if the query uses "Costco", not "WrongStore"
+    costco_store = MagicMock(spec=Store)
+    costco_store.id = uuid4()
+    costco_store.name = "Costco"
+    costco_store.parsing_profile = {
+        "item_name_patterns": ["Kirkland Signature"],
+        "common_abbreviations": {"KS": "Kirkland Signature"}
+    }
+
+    # Mock database query - return Costco store (proves metadata was used)
     mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = None  # Store not found, but that's ok
+    mock_result.scalar_one_or_none.return_value = costco_store
     mock_session.execute.return_value = mock_result
 
     # Process the task
     await process_receipt_task(task, mock_session, mock_ollama_client)
 
-    # Verify store lookup was performed with "Costco" (from metadata, not JSON)
+    # Verify store lookup was performed
     mock_session.execute.assert_called_once()
-    call_args = mock_session.execute.call_args[0][0]
-    # The query should contain func.lower comparison with "Costco"
-    # We can't easily inspect the SQLAlchemy query object, but we can verify the task completed
+
+    # Verify OllamaClient was called
+    mock_ollama_client.complete.assert_called_once()
+    call_args = mock_ollama_client.complete.call_args[1]
+
+    # CRITICAL: Verify that Costco's parsing profile was used in the prompt
+    # This proves metadata store_hint ("Costco") took precedence over JSON store_name ("WrongStore")
+    # If "WrongStore" was used, the store lookup would fail and no hints would appear
+    assert "Store-specific parsing hints:" in call_args["prompt"]
+    assert "Kirkland Signature" in call_args["prompt"]
 
     # Verify task completed successfully
     assert task.status == TaskStatus.completed.value

--- a/tests/unit/services/test_task_worker.py
+++ b/tests/unit/services/test_task_worker.py
@@ -1193,3 +1193,50 @@ async def test_process_receipt_task_case_insensitive_store_lookup(
     # Verify prompt includes store-specific hints (case-insensitive match worked)
     call_args = mock_ollama_client.complete.call_args[1]
     assert "Store-specific parsing hints:" in call_args["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_process_receipt_task_with_invalid_store_hint_type(
+    mock_session,
+    mock_ollama_client,
+    sample_receipt_result
+):
+    """Test that non-string store_hint in metadata is ignored with warning."""
+    # Create task with non-string store_hint (e.g., dict instead of string)
+    task = MagicMock(spec=ProcessingTask)
+    task.id = uuid4()
+    task.task_type = TaskType.receipt_parse.value
+    task.status = TaskStatus.pending.value
+    task.input_reference = "Costco\n2024-03-29\nBananas $3.99"  # Plain text
+    task.task_metadata = {"store_hint": {"name": "Costco"}}  # Invalid: dict instead of string
+    task.result_reference = None
+    task.error_message = None
+    task.created_at = datetime.now(timezone.utc)
+    task.completed_at = None
+    task.retry_count = 0
+
+    # Configure mock to return valid result
+    mock_ollama_client.complete.return_value = sample_receipt_result
+    mock_session.commit = MagicMock()
+
+    # Process the task - should log warning and continue without store hints
+    await process_receipt_task(task, mock_session, mock_ollama_client)
+
+    # Verify NO store lookup was attempted (invalid type ignored)
+    mock_session.execute.assert_not_called()
+
+    # Verify OllamaClient was called
+    mock_ollama_client.complete.assert_called_once()
+    call_args = mock_ollama_client.complete.call_args[1]
+
+    # Verify prompt does NOT include store-specific hints (invalid type ignored)
+    assert "Store-specific parsing hints:" not in call_args["prompt"]
+
+    # Verify prompt includes receipt text
+    assert "Costco" in call_args["prompt"]
+    assert "Bananas $3.99" in call_args["prompt"]
+
+    # Verify task completed successfully (invalid type doesn't cause failure)
+    assert task.status == TaskStatus.completed.value
+    assert task.result_reference is not None
+    assert task.completed_at is not None

--- a/tests/unit/services/test_task_worker.py
+++ b/tests/unit/services/test_task_worker.py
@@ -924,6 +924,104 @@ async def test_process_receipt_task_with_json_input_null_parsing_profile(
 
 
 @pytest.mark.asyncio
+async def test_process_receipt_task_with_metadata_store_hint(
+    mock_session,
+    mock_ollama_client,
+    mock_store,
+    sample_receipt_result
+):
+    """Test processing task with store hint from task_metadata (preferred source)."""
+    # Create task with plain text input but metadata containing store_hint
+    task = MagicMock(spec=ProcessingTask)
+    task.id = uuid4()
+    task.task_type = TaskType.receipt_parse.value
+    task.status = TaskStatus.pending.value
+    task.input_reference = "Costco\n2024-03-29\nBananas $3.99"  # Plain text, no JSON
+    task.task_metadata = {"store_hint": "Costco", "source": "image"}  # Store hint in metadata
+    task.result_reference = None
+    task.error_message = None
+    task.created_at = datetime.now(timezone.utc)
+    task.completed_at = None
+    task.retry_count = 0
+
+    # Configure mock to return valid result
+    mock_ollama_client.complete.return_value = sample_receipt_result
+
+    # Mock database query to return store with parsing_profile
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = mock_store
+    mock_session.execute.return_value = mock_result
+
+    # Process the task
+    await process_receipt_task(task, mock_session, mock_ollama_client)
+
+    # Verify store lookup was performed
+    mock_session.execute.assert_called_once()
+
+    # Verify OllamaClient was called
+    mock_ollama_client.complete.assert_called_once()
+    call_args = mock_ollama_client.complete.call_args[1]
+
+    # Verify prompt includes receipt text
+    assert "Costco" in call_args["prompt"]
+    assert "Bananas $3.99" in call_args["prompt"]
+
+    # Verify prompt includes store-specific hints (from metadata lookup)
+    assert "Store-specific parsing hints:" in call_args["prompt"]
+    assert "Kirkland Signature" in call_args["prompt"]
+    assert "ORG=Organic" in call_args["prompt"]
+
+    # Verify task was updated correctly
+    assert task.status == TaskStatus.completed.value
+    assert task.result_reference is not None
+    assert task.completed_at is not None
+
+    # Verify session commit was called
+    mock_session.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_process_receipt_task_metadata_takes_precedence_over_json(
+    mock_session,
+    mock_ollama_client,
+    sample_receipt_result
+):
+    """Test that task_metadata store_hint takes precedence over input_reference JSON."""
+    # Create task with BOTH JSON store_name AND metadata store_hint (different stores)
+    task = MagicMock(spec=ProcessingTask)
+    task.id = uuid4()
+    task.task_type = TaskType.receipt_parse.value
+    task.status = TaskStatus.pending.value
+    task.input_reference = '{"receipt_text": "Receipt text", "store_name": "WrongStore"}'
+    task.task_metadata = {"store_hint": "Costco"}  # Metadata takes precedence
+    task.result_reference = None
+    task.error_message = None
+    task.created_at = datetime.now(timezone.utc)
+    task.completed_at = None
+    task.retry_count = 0
+
+    # Configure mock to return valid result
+    mock_ollama_client.complete.return_value = sample_receipt_result
+
+    # Mock database query - will be called with "Costco" not "WrongStore"
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None  # Store not found, but that's ok
+    mock_session.execute.return_value = mock_result
+
+    # Process the task
+    await process_receipt_task(task, mock_session, mock_ollama_client)
+
+    # Verify store lookup was performed with "Costco" (from metadata, not JSON)
+    mock_session.execute.assert_called_once()
+    call_args = mock_session.execute.call_args[0][0]
+    # The query should contain func.lower comparison with "Costco"
+    # We can't easily inspect the SQLAlchemy query object, but we can verify the task completed
+
+    # Verify task completed successfully
+    assert task.status == TaskStatus.completed.value
+
+
+@pytest.mark.asyncio
 async def test_process_receipt_task_with_plain_text_input(
     mock_task,
     mock_session,
@@ -931,13 +1029,16 @@ async def test_process_receipt_task_with_plain_text_input(
     sample_receipt_result
 ):
     """Test backward compatibility with plain text input (legacy format)."""
+    # Ensure mock_task has no metadata (legacy behavior)
+    mock_task.task_metadata = None
+
     # Configure mock to return valid result
     mock_ollama_client.complete.return_value = sample_receipt_result
 
     # Process the task with plain text input_reference
     await process_receipt_task(mock_task, mock_session, mock_ollama_client)
 
-    # Verify NO store lookup was attempted (plain text has no store_name)
+    # Verify NO store lookup was attempted (plain text has no store_name, no metadata)
     mock_session.execute.assert_not_called()
 
     # Verify OllamaClient was called


### PR DESCRIPTION
## Work in Progress

Closes #458

Integrate store profiles into receipt pipeline

**Time Estimate**: 1hr

**Description**:
Extend the receipt parsing pipeline to use store-specific parsing profiles. This bridges three components: (1) task metadata stores the store hint, (2) create_user_prompt accepts store hints, (3) task_worker fetches and passes profiles to prompts.

**Claude Context**:
Files to Read:
- src/db/models/processing_task.py (ProcessingTask with metadata field from #1)
- src/db/models/store.py (Store with parsing_profile)
- src/services/task_worker.py (process_receipt_task function)
- src/services/llm/prompts/receipt.py (create_user_prompt function)

Files to Modify:
- src/services/llm/prompts/receipt.py (extend create_user_prompt signature)
- src/services/task_worker.py (fetch store profile, pass to prompt)
- tests/unit/services/test_task_worker.py (update tests)
- tests/unit/services/llm/test_receipt_prompts.py (add store hints tests)

Related Issues: #1 (provides metadata field)

**Acceptance Criteria**:
- [ ] `create_user_prompt(receipt_text: str, store_hints: Optional[dict] = None) -> str` signature
- [ ] When store_hints provided, prompt includes section: "Store context: {formatted hints}"
- [ ] When store_hints is None, prompt unchanged from current behavior
- [ ] task_worker reads `task.metadata.get('store_hint')` if metadata exists
- [ ] task_worker queries Store by name to get parsing_profile
- [ ] task_worker passes parsing_profile to create_user_prompt as store_hints
- [ ] Graceful fallback: if store not found or no profile, proceeds without hints
- [ ] Unit tests verify prompt includes hints when provided
- [ ] Unit tests verify task_worker fetches and passes store profile

**Verification Commands**:
```bash
pytest tests/unit/services/llm/test_receipt_prompts.py -v
pytest tests/unit/services/test_task_worker.py -v
```

**Done Definition**: Done when task_worker fetches store profiles from metadata and passes them to the LLM prompt.

**Scope Boundary**:
- DO: Extend create_user_prompt to accept optional store_hints
- DO: Update task_worker to read metadata and fetch Store.parsing_profile
- DO: Add unit tests for both components
- DO NOT: Create receipts router (Issue #5)
- DO NOT: Modify the system prompt (only the user prompt)

**Dependencies**: After #1 (needs: metadata field on ProcessingTask model)

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **5** commits (+0 added, ~2 modified, -0 deleted)
- `M` src/services/task_worker.py
- `M` tests/unit/services/test_task_worker.py

### Commits
- bfe234f feat: Integrate store profiles into receipt pipeline
- 05efc34 Merge remote-tracking branch 'origin/main' into feat/integrate-store-profiles-into-receipt-pipeline
- b1d0cca Merge remote-tracking branch 'origin/main' into feat/integrate-store-profiles-into-receipt-pipeline
- 087fa76 Merge remote-tracking branch 'origin/main' into feat/integrate-store-profiles-into-receipt-pipeline
- 92c0d04 chore: initialize work on #458 Integrate store profiles into receipt pipeline
<!-- /sharkrite-changes-summary -->