### PR TITLE
Update scrapers for browse-then-persist flow

### DIFF
--- a/alembic/versions/pi1jpdky8rus_add_is_persisted_to_recipes.py
+++ b/alembic/versions/pi1jpdky8rus_add_is_persisted_to_recipes.py
@@ -1,0 +1,49 @@
+"""add is_persisted to recipes
+
+Revision ID: pi1jpdky8rus
+Revises: nh9iocxw7qtv
+Create Date: 2026-05-03 17:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'pi1jpdky8rus'
+down_revision: Union[str, None] = 'nh9iocxw7qtv'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """
+    Add is_persisted column to recipes table.
+
+    This field tracks whether a recipe should be kept permanently (True) or is
+    eligible for cleanup as part of the browse cache (False). Scraped recipes
+    start as non-persisted and become persisted through user interaction
+    (bookmarking, cooking, rating, adding to menu, etc.).
+
+    Backfills existing recipes with is_persisted=True since they were created
+    before the browse-then-persist flow was implemented.
+    """
+    with op.batch_alter_table('recipes', schema=None) as batch_op:
+        # Add column with default False for new rows
+        batch_op.add_column(
+            sa.Column('is_persisted', sa.Boolean(), nullable=False, server_default=sa.false())
+        )
+
+    # Backfill existing recipes as persisted
+    # (they exist in production, so should be kept)
+    op.execute(
+        sa.text("UPDATE recipes SET is_persisted = true WHERE is_persisted = false")
+    )
+
+
+def downgrade() -> None:
+    """Remove is_persisted column from recipes table."""
+    with op.batch_alter_table('recipes', schema=None) as batch_op:
+        batch_op.drop_column('is_persisted')

--- a/alembic/versions/pi1jpdky8rus_add_is_persisted_to_recipes.py
+++ b/alembic/versions/pi1jpdky8rus_add_is_persisted_to_recipes.py
@@ -39,7 +39,7 @@ def upgrade() -> None:
     # Backfill existing recipes as persisted
     # (they exist in production, so should be kept)
     op.execute(
-        sa.text("UPDATE recipes SET is_persisted = true WHERE is_persisted = false")
+        sa.text("UPDATE recipes SET is_persisted = true")
     )
 
 

--- a/src/db/models/recipe.py
+++ b/src/db/models/recipe.py
@@ -5,7 +5,7 @@ from uuid import UUID, uuid4
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import String, Integer, JSON, ForeignKey, DateTime, func
+from sqlalchemy import String, Integer, JSON, ForeignKey, DateTime, Boolean, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.db.database import Base
@@ -37,6 +37,7 @@ class Recipe(Base):
     tags: Mapped[list] = mapped_column(JSON, default=list)
     nutritional_info: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
     times_cooked: Mapped[int] = mapped_column(Integer, default=0)
+    is_persisted: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     created_by: Mapped[Optional[UUID]] = mapped_column(ForeignKey("users.id"), nullable=True)
     notes: Mapped[Optional[str]] = mapped_column(String(10000), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())

--- a/src/services/import_service.py
+++ b/src/services/import_service.py
@@ -4,6 +4,11 @@ Recipe import orchestration service for FreshUp.
 Coordinates scraping, parsing, deduplication, and database persistence for
 recipe imports from external URLs. Supports both single URL and batch imports
 with rate limiting.
+
+Browse-then-Persist Flow:
+Newly scraped recipes are created with is_persisted=False, making them eligible
+for cleanup by the browse cache cleanup job. Recipes become persisted (is_persisted=True)
+through user interactions like bookmarking, cooking, rating, or adding to menus.
 """
 
 import logging
@@ -213,6 +218,7 @@ def import_recipe_from_url(url: str, db: Session) -> ImportResult:
             steps=scraped_data.instructions,
             tags=scraped_data.tags,
             nutritional_info=scraped_data.nutrients,
+            is_persisted=False,  # Scraped recipes start as non-persisted (browse cache)
             created_by=None,  # System-imported recipe, no owner
         )
 

--- a/tests/services/test_import_service.py
+++ b/tests/services/test_import_service.py
@@ -343,6 +343,105 @@ class TestImportRecipeFromUrl:
         assert created_recipe.created_by is None  # System-imported
 
     @patch('src.services.import_service.scrape_recipe')
+    @patch('src.services.import_service.parse_ingredient')
+    def test_imported_recipe_is_not_persisted(self, mock_parse_ingredient, mock_scrape_recipe):
+        """Test that newly imported recipes have is_persisted=False."""
+        # Mock database session
+        mock_db = Mock()
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        # Mock scraper response
+        mock_scrape_recipe.return_value = ScrapedRecipeData(
+            source_url="https://example.com/recipe",
+            source_type="url_import",
+            title="Test Recipe",
+            servings=4,
+            ingredients=["1 cup flour"],
+            instructions=["Mix it"],
+        )
+
+        # Mock ingredient parser
+        mock_parse_ingredient.return_value = {
+            'quantity': 1.0,
+            'unit': 'cup',
+            'ingredient_name': 'flour',
+            'preparation': '',
+            'is_optional': False,
+            'raw_text': '1 cup flour',
+        }
+
+        # Mock recipe creation
+        created_recipe = None
+        def capture_recipe(obj):
+            nonlocal created_recipe
+            if isinstance(obj, Recipe):
+                created_recipe = obj
+                created_recipe.id = uuid4()
+
+        mock_db.add.side_effect = capture_recipe
+        mock_db.flush = Mock()
+        mock_db.commit = Mock()
+        mock_db.refresh = Mock()
+
+        # Execute import
+        result = import_recipe_from_url("https://example.com/recipe", mock_db)
+
+        # Assertions
+        assert result.status == ImportStatus.success
+        assert created_recipe is not None
+        assert created_recipe.is_persisted is False  # Newly scraped recipes are non-persisted
+
+    @patch('src.services.import_service.scrape_recipe')
+    def test_dedup_against_persisted_recipe(self, mock_scrape_recipe):
+        """Test that deduplication works for persisted recipes."""
+        # Mock database session with existing persisted recipe
+        existing_recipe_id = uuid4()
+        mock_existing = Mock()
+        mock_existing.id = existing_recipe_id
+        mock_existing.is_persisted = True  # Existing recipe is persisted
+
+        mock_db = Mock()
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_existing
+
+        # Execute import
+        result = import_recipe_from_url("https://example.com/recipe", mock_db)
+
+        # Assertions
+        assert result.status == ImportStatus.duplicate
+        assert result.recipe_id == existing_recipe_id
+        assert result.error_message is None
+
+        # Verify scraper was NOT called (dedup happened before scraping)
+        mock_scrape_recipe.assert_not_called()
+
+    @patch('src.services.import_service.scrape_recipe')
+    def test_dedup_against_non_persisted_recipe(self, mock_scrape_recipe):
+        """Test that deduplication works for non-persisted recipes.
+
+        Even if a non-persisted recipe exists, we should NOT re-scrape.
+        This prevents unnecessary load on source websites.
+        """
+        # Mock database session with existing non-persisted recipe
+        existing_recipe_id = uuid4()
+        mock_existing = Mock()
+        mock_existing.id = existing_recipe_id
+        mock_existing.is_persisted = False  # Existing recipe is non-persisted (browse cache)
+
+        mock_db = Mock()
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_existing
+
+        # Execute import
+        result = import_recipe_from_url("https://example.com/recipe", mock_db)
+
+        # Assertions
+        assert result.status == ImportStatus.duplicate
+        assert result.recipe_id == existing_recipe_id
+        assert result.error_message is None
+
+        # Verify scraper was NOT called (dedup happened before scraping)
+        mock_scrape_recipe.assert_not_called()
+
+    @patch('src.services.import_service.scrape_recipe')
     def test_url_normalization_in_deduplication_end_to_end(self, mock_scrape_recipe):
         """Test that URL normalization works end-to-end for deduplication.
 


### PR DESCRIPTION
## Work in Progress

Closes #474

Update scrapers for browse-then-persist flow

**Time Estimate**: 1hr

**Description**:
Create the UserCookEvent model to track when users cook recipes. Add `POST /recipes/{id}/cook` and `GET /recipes/{id}/cook-history` endpoints. Cook events are required for rating gating.

**Claude Context**:
Files to Read:
- src/db/models/user_recipe.py (relationship patterns)
- src/db/models/meal_plan.py (meal_plan_entry_id FK reference)
- src/routers/recipes.py
- src/services/recipes_service.py (create — router delegates to service) (endpoint patterns)

Files to Modify:
- src/db/models/user_cook_event.py (create new file)
- src/db/models/__init__.py (add export)
- src/schemas/recipe.py (add CookEventCreate, CookEventResponse)
- src/routers/recipes.py
- src/services/recipes_service.py (create — router delegates to service) (add cook and cook-history endpoints)
- alembic/versions/ (new migration file)
- tests/routers/test_recipes.py (add cook event tests)

**Acceptance Criteria**:
- [ ] UserCookEvent model created with fields: id (UUID PK), user_id (FK users), recipe_id (FK recipes), cooked_at (datetime), meal_plan_entry_id (FK meal_plan_entries nullable), notes (varchar 500 nullable)
- [ ] Model exported from `src/db/models/__init__.py`
- [ ] `POST /recipes/{id}/cook` creates cook event for current user, returns CookEventResponse
- [ ] `GET /recipes/{id}/cook-history` returns list of user's cook events for recipe
- [ ] Increments Recipe.times_cooked on cook event creation
- [ ] Tests cover: create cook event, get history, multiple cooks, recipe not found
- [ ] Migration applies cleanly: `alembic upgrade head`
- [ ] Tests pass: `.venv/bin/python -m pytest tests/routers/test_recipes.py::test_cook -x -q`

**Verification Commands**:
```bash
alembic upgrade head
.venv/bin/python -m pytest tests/routers/test_recipes.py -x -q
```

**Done Definition**: Done when cook endpoint creates events, history returns them, and times_cooked is incremented.

**Scope Boundary**:
- DO: Create model, endpoints, tests, increment times_cooked
- DO NOT: Integrate with MealPlanEntry status transitions (Phase 3)
- DO NOT: Update rating endpoint to gate on cook events (Issue "[Phase 2.5A] Update rating endpoint with cook gate")

**Dependencies**: None (can run in parallel with #1, #2)

---END------ISSUE---

**Description**:
Create the UserRecipeView model for tracking recipe detail views. Add `POST /recipes/{id}/view` endpoint (fire-and-forget). Views are a feed signal for "viewed but not cooked" detection.

**Claude Context**:
Files to Read:
- src/db/models/user_cook_event.py (similar model pattern, created by #4)
- src/routers/recipes.py
- src/services/recipes_service.py (create — router delegates to service) (endpoint patterns)

Files to Modify:
- src/db/models/user_recipe_view.py (create new file)
- src/db/models/__init__.py (add export)
- src/schemas/recipe.py (add ViewEventCreate)
- src/routers/recipes.py
- src/services/recipes_service.py (create — router delegates to service) (add view endpoint)
- alembic/versions/ (new migration file)
- tests/routers/test_recipes.py (add view tests)

Related Issues: #4 (similar pattern)

**Acceptance Criteria**:
- [ ] UserRecipeView model created with fields: id (UUID PK), user_id (FK users), recipe_id (FK recipes), viewed_at (datetime), source (varchar 50 nullable)
- [ ] No unique constraint (multiple views per user per recipe allowed)
- [ ] Model exported from `src/db/models/__init__.py`
- [ ] `POST /recipes/{id}/view` creates view event, returns 204 No Content (fire-and-forget)
- [ ] View endpoint accepts optional `source` body param (browse, detail, search, feed, menu)
- [ ] Tests cover: create view, multiple views same recipe, optional source param
- [ ] Migration applies cleanly: `alembic upgrade head`

**Verification Commands**:
```bash
alembic upgrade head
.venv/bin/python -m pytest tests/routers/test_recipes.py::test_view -x -q
```

**Done Definition**: Done when view endpoint creates events and allows multiple views per user per recipe.

**Scope Boundary**:
- DO: Create model, endpoint, tests
- DO NOT: Implement feed scoring using views (Issue "[Phase 2.5C] Create feed service with core queries")

**Dependencies**: None (can run in parallel with #1, #2, #4)

---END------ISSUE---

**Description**:
Add `POST/DELETE /recipes/{id}/bookmark` and `POST/DELETE /recipes/{id}/like` endpoints. These toggle the `is_bookmarked` and `is_liked` flags on UserRecipeRelation, creating the relation row if it doesn't exist.

**Claude Context**:
Files to Read:
- src/routers/recipes.py
- src/services/recipes_service.py (create — router delegates to service) (existing rating endpoints as pattern)
- src/db/models/user_recipe.py (UserRecipeRelation model after #1)
- src/schemas/recipe.py (UserRecipeRelationResponse after #1)

Files to Modify:
- src/routers/recipes.py
- src/services/recipes_service.py (create — router delegates to service) (add 4 endpoints)
- src/schemas/recipe.py (add BookmarkRequest with optional menu_id)
- tests/routers/test_recipes.py (add bookmark/like tests)

Related Issues: #1 (needs UserRecipeRelation model)

**Acceptance Criteria**:
- [ ] `POST /recipes/{id}/bookmark` creates/updates relation with `is_bookmarked=true`, accepts optional `menu_id`
- [ ] `DELETE /recipes/{id}/bookmark` sets `is_bookmarked=false`
- [ ] `POST /recipes/{id}/like` creates/updates relation with `is_liked=true`
- [ ] `DELETE /recipes/{id}/like` sets `is_liked=false`
- [ ] All endpoints return UserRecipeRelationResponse
- [ ] Recipe not found returns 404
- [ ] Tests cover: bookmark, unbookmark, like, unlike, bookmark with menu_id, toggle states independently
- [ ] Tests pass: `.venv/bin/python -m pytest tests/routers/test_recipes.py::test_bookmark -x -q`

**Verification Commands**:
```bash
.venv/bin/python -m pytest tests/routers/test_recipes.py -x -q
```

**Done Definition**: Done when all 4 endpoints work and bookmark/like states are independent of each other.

**Scope Boundary**:
- DO: Implement toggle endpoints, handle relation creation if not exists
- DO NOT: Implement persistence trigger (Issue "[Phase 2.5B] Implement persistence trigger")

**Dependencies**: After #1 (needs: UserRecipeRelation model with is_bookmarked, is_liked fields)

---END------ISSUE---

**Description**:
Update `POST /recipes/{id}/rate` to require at least one cook event before accepting ratings. Add support for `rating_photos` and `rating_comment` fields. Update aggregate endpoint to include bookmark_count and like_count.

**Claude Context**:
Files to Read:
- src/routers/recipes.py
- src/services/recipes_service.py (create — router delegates to service) (rate_recipe and get_recipe_ratings functions)
- src/db/models/user_cook_event.py (cook event model after #4)
- src/db/models/user_recipe.py (UserRecipeRelation after #1)

Files to Modify:
- src/schemas/recipe.py (update UserRecipeRelationCreate to accept rating_photos, rating_comment)
- src/routers/recipes.py
- src/services/recipes_service.py (create — router delegates to service) (add cook gate check, update aggregate query)
- tests/routers/test_recipes.py (add cook gate tests)

Related Issues: #1 (UserRecipeRelation schema), #4 (UserCookEvent model)

**Acceptance Criteria**:
- [ ] `POST /recipes/{id}/rate` returns 403 "Rate after cooking" if user has no cook events for this recipe
- [ ] Rating endpoint accepts `rating_photos` (JSON array of MinIO keys) and `rating_comment` (string max 2000)
- [ ] `GET /recipes/{id}/ratings` returns `bookmark_count` and `like_count` alongside existing fields
- [ ] `favorite_count` remains in response (deprecated alias for `like_count`) per backwards compat
- [ ] Tests cover: rate without cooking (403), rate after cooking (success), rating with photos/comment
- [ ] Tests pass: `.venv/bin/python -m pytest tests/routers/test_recipes.py::test_rate -x -q`

**Verification Commands**:
```bash
.venv/bin/python -m pytest tests/routers/test_recipes.py -x -q
```

**Done Definition**: Done when rating requires prior cook event and aggregate includes bookmark/like counts.

**Scope Boundary**:
- DO: Add cook gate, new fields, update aggregate query
- DO NOT: Validate MinIO keys exist (frontend responsibility)

**Dependencies**: After #1 (needs: UserRecipeRelation with new fields), After #4 (needs: UserCookEvent model)

---END------ISSUE---

**Description**:
Update scrapers and import_service to set `is_persisted=False` on newly scraped recipes. Update dedup logic to account for persistence status: skip if persisted recipe exists, recreate if non-persisted was pruned.

**Claude Context**:
Files to Read:
- src/services/import_service.py (import_recipe_from_url function)
- src/services/crawlers/hellofresh_crawler.py (crawler pattern)
- src/services/crawlers/kitchen_sanctuary_crawler.py (crawler pattern)
- src/routers/scraper.py (scraper endpoints)

Files to Modify:
- src/services/import_service.py (set is_persisted=False, update dedup logic)
- src/routers/scraper.py (ensure is_persisted=False on scraper endpoints)
- tests/services/test_import_service.py (add is_persisted tests)

Related Issues: #2 (needs is_persisted field on Recipe)

**Acceptance Criteria**:
- [ ] `import_recipe_from_url` creates recipes with `is_persisted=False`
- [ ] Dedup logic: if persisted recipe exists with same URL, return duplicate status
- [ ] Dedup logic: if only non-persisted recipe exists with same URL, still return duplicate (don't re-scrape)
- [ ] Scraper router endpoints create non-persisted recipes
- [ ] Tests cover: new import is non-persisted, dedup against persisted recipe, dedup against non-persisted
- [ ] Tests pass: `.venv/bin/python -m pytest tests/services/test_import_service.py -x -q`

**Verification Commands**:
```bash
.venv/bin/python -m pytest tests/services/test_import_service.py -x -q
```

**Done Definition**: Done when scraped recipes enter as non-persisted and dedup logic works correctly.

**Scope Boundary**:
- DO: Update import_service, scraper router, dedup logic
- DO NOT: Implement cleanup job (Issue "[Phase 2.5B] Implement browse cache cleanup job")

**Dependencies**: After #2 (needs: is_persisted field on Recipe model)

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**4** files, **2** commits (+1 added, ~3 modified, -0 deleted)
- `A` alembic/versions/pi1jpdky8rus_add_is_persisted_to_recipes.py
- `M` src/db/models/recipe.py
- `M` src/services/import_service.py
- `M` tests/services/test_import_service.py

### Commits
- 1e779b7 feat: Update scrapers for browse-then-persist flow
- 96cd3e4 chore: initialize work on #474 Update scrapers for browse-then-persist flow
<!-- /sharkrite-changes-summary -->