### PR TITLE
[Phase 2.5B] Implement persistence trigger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ dist/
 build/
 .eggs/
 venv/
-.venv/
+.venv
 
 # Database
 *.db
@@ -40,3 +40,4 @@ backend/node_modules
 .sharkrite-scratchpad.md
 .rite-scratchpad.md
 .scratchpad.md
+backend/.venv

--- a/src/routers/recipes.py
+++ b/src/routers/recipes.py
@@ -845,19 +845,7 @@ def rate_recipe(
             f"recipe_id={recipe_id}, rating_id={existing_rating.id}"
         )
 
-        # Trigger persistence if user bookmarked/liked the recipe
-        # Phase 2.5B: bookmarking/liking makes recipes permanent
-        # This prevents cleanup of recipes users have shown interest in
-        if rating_data.is_favorite:
-            try:
-                trigger_persistence(recipe, db)
-            except SQLAlchemyError as e:
-                logger.error(f"Failed to trigger persistence for recipe {recipe_id}")
-                logger.debug(f"Persistence trigger error: {e}")
-                # Don't fail the rating operation if persistence fails
-                # The rating was already saved successfully
-
-        return existing_rating
+        rating_result = existing_rating
     else:
         # Create new rating
         new_rating = UserRecipeRating(
@@ -892,19 +880,20 @@ def rate_recipe(
             f"recipe_id={recipe_id}, rating_id={new_rating.id}"
         )
 
-        # Trigger persistence if user bookmarked/liked the recipe
-        # Phase 2.5B: bookmarking/liking makes recipes permanent
-        # This prevents cleanup of recipes users have shown interest in
-        if rating_data.is_favorite:
-            try:
-                trigger_persistence(recipe, db)
-            except SQLAlchemyError as e:
-                logger.error(f"Failed to trigger persistence for recipe {recipe_id}")
-                logger.debug(f"Persistence trigger error: {e}")
-                # Don't fail the rating operation if persistence fails
-                # The rating was already saved successfully
+        rating_result = new_rating
 
-        return new_rating
+    # Trigger persistence if user bookmarked/liked the recipe
+    # Phase 2.5B: bookmarking/liking makes recipes permanent
+    # This prevents cleanup of recipes users have shown interest in
+    if rating_data.is_favorite:
+        try:
+            trigger_persistence(recipe, db)
+        except SQLAlchemyError as e:
+            logger.error(f"Failed to trigger persistence for recipe {recipe_id}", exc_info=e)
+            # Don't fail the rating operation if persistence fails
+            # The rating was already saved successfully
+
+    return rating_result
 
 
 @router.get("/{recipe_id}/my-rating", response_model=UserRecipeRatingResponse)

--- a/src/routers/recipes.py
+++ b/src/routers/recipes.py
@@ -44,6 +44,7 @@ from src.routers.recipe_helpers import (
     verify_recipe_ownership_with_system_check,
     validate_step_index,
 )
+from src.services.recipe_service import trigger_persistence
 
 logger = logging.getLogger(__name__)
 
@@ -843,6 +844,19 @@ def rate_recipe(
             f"Recipe rating updated: user_id={current_user.id}, "
             f"recipe_id={recipe_id}, rating_id={existing_rating.id}"
         )
+
+        # Trigger persistence if user bookmarked/liked the recipe
+        # Phase 2.5B: bookmarking/liking makes recipes permanent
+        # This prevents cleanup of recipes users have shown interest in
+        if rating_data.is_favorite:
+            try:
+                trigger_persistence(recipe, db)
+            except SQLAlchemyError as e:
+                logger.error(f"Failed to trigger persistence for recipe {recipe_id}")
+                logger.debug(f"Persistence trigger error: {e}")
+                # Don't fail the rating operation if persistence fails
+                # The rating was already saved successfully
+
         return existing_rating
     else:
         # Create new rating
@@ -877,6 +891,19 @@ def rate_recipe(
             f"Recipe rating created: user_id={current_user.id}, "
             f"recipe_id={recipe_id}, rating_id={new_rating.id}"
         )
+
+        # Trigger persistence if user bookmarked/liked the recipe
+        # Phase 2.5B: bookmarking/liking makes recipes permanent
+        # This prevents cleanup of recipes users have shown interest in
+        if rating_data.is_favorite:
+            try:
+                trigger_persistence(recipe, db)
+            except SQLAlchemyError as e:
+                logger.error(f"Failed to trigger persistence for recipe {recipe_id}")
+                logger.debug(f"Persistence trigger error: {e}")
+                # Don't fail the rating operation if persistence fails
+                # The rating was already saved successfully
+
         return new_rating
 
 

--- a/src/services/recipe_service.py
+++ b/src/services/recipe_service.py
@@ -1,0 +1,56 @@
+"""
+Recipe business logic service.
+
+Provides core recipe operations that are used across multiple endpoints.
+"""
+
+import logging
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError
+
+from src.db.models.recipe import Recipe
+
+logger = logging.getLogger(__name__)
+
+
+def trigger_persistence(recipe: Recipe, db: Session) -> bool:
+    """
+    Set a recipe's is_persisted flag to True if not already set.
+
+    When a user bookmarks, likes, or adds a recipe to their meal plan,
+    the recipe should become permanent (is_persisted=True). This function
+    handles that transition idempotently.
+
+    Background: Recipes start as non-persisted when imported via scrapers
+    (browse flow). They only become permanent when a user explicitly
+    interacts with them (bookmark, like, meal plan). This prevents
+    the database from filling with unbrowsed recipes.
+
+    Args:
+        recipe: The Recipe object to persist
+        db: Database session
+
+    Returns:
+        bool: True if the recipe was persisted (state changed), False if already persisted
+
+    Raises:
+        SQLAlchemyError: If database operation fails (caller should handle)
+    """
+    # No-op if already persisted (idempotent behavior)
+    # This ensures safe repeated calls without side effects
+    if recipe.is_persisted:
+        logger.debug(f"Recipe {recipe.id} already persisted, skipping")
+        return False
+
+    # Set persistence flag (one-way operation - never reverses)
+    recipe.is_persisted = True
+
+    try:
+        db.commit()
+        db.refresh(recipe)
+        logger.info(f"Recipe {recipe.id} persisted via user interaction")
+        return True
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Failed to persist recipe {recipe.id}: {e}")
+        raise

--- a/tests/routers/test_recipes.py
+++ b/tests/routers/test_recipes.py
@@ -2942,3 +2942,56 @@ class TestPersistenceTrigger:
         # Verify recipe remains persisted (persistence is one-way)
         db_session.refresh(recipe)
         assert recipe.is_persisted is True
+
+    def test_rating_succeeds_even_if_persistence_trigger_fails(self, client, auth_headers, test_user, db_session, monkeypatch):
+        """Test that rating operation succeeds even if persistence trigger fails."""
+        from src.db.models.user_recipe import UserRecipeRating
+        from sqlalchemy.exc import SQLAlchemyError
+
+        # Create a non-persisted recipe
+        recipe = Recipe(
+            id=uuid4(),
+            name="Test Recipe",
+            source_type="manual",
+            is_persisted=False,
+            created_by=test_user.id,
+        )
+        db_session.add(recipe)
+        db_session.commit()
+
+        # Mock trigger_persistence to raise an exception
+        def mock_trigger_persistence(recipe, db):
+            raise SQLAlchemyError("Simulated persistence failure")
+
+        import src.routers.recipes
+        monkeypatch.setattr(src.routers.recipes, "trigger_persistence", mock_trigger_persistence)
+
+        # Create a rating with is_favorite=True
+        rating_data = {
+            "is_favorite": True,
+            "rating": 5.0,
+        }
+
+        response = client.post(
+            f"/recipes/{recipe.id}/rate",
+            json=rating_data,
+            headers=auth_headers
+        )
+
+        # The rating operation should succeed despite persistence failure
+        assert response.status_code == 200
+        assert response.json()["is_favorite"] is True
+        assert response.json()["rating"] == 5.0
+
+        # Verify the rating was saved to the database
+        saved_rating = db_session.query(UserRecipeRating).filter(
+            UserRecipeRating.user_id == test_user.id,
+            UserRecipeRating.recipe_id == recipe.id,
+        ).first()
+        assert saved_rating is not None
+        assert saved_rating.is_favorite is True
+        assert saved_rating.rating == 5.0
+
+        # Verify recipe was NOT persisted (due to simulated failure)
+        db_session.refresh(recipe)
+        assert recipe.is_persisted is False

--- a/tests/routers/test_recipes.py
+++ b/tests/routers/test_recipes.py
@@ -2716,3 +2716,229 @@ class TestRecipeIngredientStepIndex:
         detail = response.json()["detail"]
         assert "step_index 5 is out of bounds" in detail
         assert "Recipe has 1 step" in detail
+
+
+class TestPersistenceTrigger:
+    """Test persistence trigger when users bookmark/like recipes."""
+
+    def test_bookmark_non_persisted_recipe_triggers_persistence(self, client, auth_headers, test_user, db_session):
+        """Test that bookmarking a non-persisted recipe sets is_persisted=True."""
+        # Create a non-persisted recipe
+        recipe = Recipe(
+            id=uuid4(),
+            name="Test Recipe",
+            source_type="manual",
+            is_persisted=False,
+            created_by=test_user.id,
+        )
+        db_session.add(recipe)
+        db_session.commit()
+        db_session.refresh(recipe)
+
+        # Verify recipe starts as non-persisted
+        assert recipe.is_persisted is False
+
+        # Bookmark the recipe (is_favorite=True)
+        rating_data = {
+            "is_favorite": True,
+            "rating": None,  # User can bookmark without rating
+        }
+
+        response = client.post(
+            f"/recipes/{recipe.id}/rate",
+            json=rating_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+
+        # Verify recipe is now persisted
+        db_session.refresh(recipe)
+        assert recipe.is_persisted is True
+
+    def test_like_with_rating_triggers_persistence(self, client, auth_headers, test_user, db_session):
+        """Test that liking a recipe with a rating triggers persistence."""
+        # Create a non-persisted recipe
+        recipe = Recipe(
+            id=uuid4(),
+            name="Test Recipe",
+            source_type="manual",
+            is_persisted=False,
+            created_by=test_user.id,
+        )
+        db_session.add(recipe)
+        db_session.commit()
+        db_session.refresh(recipe)
+
+        # Rate and like the recipe
+        rating_data = {
+            "is_favorite": True,
+            "rating": 4.5,
+        }
+
+        response = client.post(
+            f"/recipes/{recipe.id}/rate",
+            json=rating_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+
+        # Verify recipe is now persisted
+        db_session.refresh(recipe)
+        assert recipe.is_persisted is True
+
+    def test_rate_without_favorite_does_not_trigger_persistence(self, client, auth_headers, test_user, db_session):
+        """Test that rating without favoriting does not trigger persistence."""
+        # Create a non-persisted recipe
+        recipe = Recipe(
+            id=uuid4(),
+            name="Test Recipe",
+            source_type="manual",
+            is_persisted=False,
+            created_by=test_user.id,
+        )
+        db_session.add(recipe)
+        db_session.commit()
+        db_session.refresh(recipe)
+
+        # Rate without favoriting
+        rating_data = {
+            "is_favorite": False,
+            "rating": 3.0,
+        }
+
+        response = client.post(
+            f"/recipes/{recipe.id}/rate",
+            json=rating_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+
+        # Verify recipe remains non-persisted
+        db_session.refresh(recipe)
+        assert recipe.is_persisted is False
+
+    def test_bookmark_already_persisted_recipe_is_idempotent(self, client, auth_headers, test_user, db_session):
+        """Test that bookmarking an already-persisted recipe has no side effects."""
+        # Create a pre-persisted recipe
+        recipe = Recipe(
+            id=uuid4(),
+            name="Test Recipe",
+            source_type="manual",
+            is_persisted=True,  # Already persisted
+            created_by=test_user.id,
+        )
+        db_session.add(recipe)
+        db_session.commit()
+        db_session.refresh(recipe)
+
+        # Bookmark the recipe
+        rating_data = {
+            "is_favorite": True,
+            "rating": None,
+        }
+
+        response = client.post(
+            f"/recipes/{recipe.id}/rate",
+            json=rating_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+
+        # Verify recipe remains persisted (idempotent)
+        db_session.refresh(recipe)
+        assert recipe.is_persisted is True
+
+    def test_update_rating_to_favorite_triggers_persistence(self, client, auth_headers, test_user, db_session):
+        """Test that updating an existing rating to is_favorite=True triggers persistence."""
+        from src.db.models.user_recipe import UserRecipeRating
+
+        # Create a non-persisted recipe
+        recipe = Recipe(
+            id=uuid4(),
+            name="Test Recipe",
+            source_type="manual",
+            is_persisted=False,
+            created_by=test_user.id,
+        )
+        db_session.add(recipe)
+        db_session.commit()
+
+        # Create an initial rating without favoriting
+        initial_rating = UserRecipeRating(
+            user_id=test_user.id,
+            recipe_id=recipe.id,
+            rating=3.0,
+            is_favorite=False,
+        )
+        db_session.add(initial_rating)
+        db_session.commit()
+        db_session.refresh(recipe)
+
+        # Verify recipe is not persisted yet
+        assert recipe.is_persisted is False
+
+        # Update rating to favorite
+        update_data = {
+            "is_favorite": True,
+            "rating": 4.0,
+        }
+
+        response = client.post(
+            f"/recipes/{recipe.id}/rate",
+            json=update_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+
+        # Verify recipe is now persisted
+        db_session.refresh(recipe)
+        assert recipe.is_persisted is True
+
+    def test_update_rating_to_unfavorite_does_not_unpersist(self, client, auth_headers, test_user, db_session):
+        """Test that un-favoriting does not reverse persistence (one-way operation)."""
+        from src.db.models.user_recipe import UserRecipeRating
+
+        # Create a persisted recipe
+        recipe = Recipe(
+            id=uuid4(),
+            name="Test Recipe",
+            source_type="manual",
+            is_persisted=True,
+            created_by=test_user.id,
+        )
+        db_session.add(recipe)
+        db_session.commit()
+
+        # Create a favorited rating
+        initial_rating = UserRecipeRating(
+            user_id=test_user.id,
+            recipe_id=recipe.id,
+            rating=4.0,
+            is_favorite=True,
+        )
+        db_session.add(initial_rating)
+        db_session.commit()
+        db_session.refresh(recipe)
+
+        # Update rating to un-favorite
+        update_data = {
+            "is_favorite": False,
+            "rating": 4.0,
+        }
+
+        response = client.post(
+            f"/recipes/{recipe.id}/rate",
+            json=update_data,
+            headers=auth_headers
+        )
+
+        assert response.status_code == 200
+
+        # Verify recipe remains persisted (persistence is one-way)
+        db_session.refresh(recipe)
+        assert recipe.is_persisted is True


### PR DESCRIPTION
## Work in Progress

Closes #475

[Phase 2.5B] Implement persistence trigger

**Time Estimate**: 45min

**Description**:
Implement persistence trigger: when a user bookmarks, likes, or adds a non-persisted recipe to a meal plan, set `is_persisted=True`. This makes the recipe permanent.

**Claude Context**:
Files to Read:
- src/routers/recipes.py (bookmark/like endpoints after #6)
- src/db/models/recipe.py (is_persisted field after #2)
- src/db/models/meal_plan.py (MealPlanEntry model)

Files to Modify:
- src/routers/recipes.py (add persistence check to bookmark/like)
- src/services/recipe_service.py (create new file with trigger_persistence function)
- tests/routers/test_recipes.py (add persistence trigger tests)

Related Issues: #2 (is_persisted field), #6 (bookmark/like endpoints)

**Acceptance Criteria**:
- [ ] Create `src/services/recipe_service.py` with `trigger_persistence(recipe: Recipe, db: Session)` function
- [ ] Bookmark endpoint calls trigger_persistence when creating/updating relation
- [ ] Like endpoint calls trigger_persistence when creating/updating relation
- [ ] Trigger sets `is_persisted=True` only if currently `False` (no-op otherwise)
- [ ] Tests: bookmark non-persisted recipe → becomes persisted
- [ ] Tests: like non-persisted recipe → becomes persisted
- [ ] Tests: bookmark already-persisted recipe → no change
- [ ] Tests pass: `.venv/bin/python -m pytest tests/routers/test_recipes.py::test_persist -x -q`

**Verification Commands**:
```bash
.venv/bin/python -m pytest tests/routers/test_recipes.py -x -q
```

**Done Definition**: Done when bookmark/like on non-persisted recipe sets is_persisted=True.

**Scope Boundary**:
- DO: Implement trigger in bookmark/like endpoints
- DO NOT: Add trigger to meal plan add (deferred until meal plan endpoints built in 2.5E)

**Dependencies**: After #2 (needs: is_persisted field), After #6 (needs: bookmark/like endpoints)

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **2** commits (+1 added, ~2 modified, -0 deleted)
- `M` src/routers/recipes.py
- `A` src/services/recipe_service.py
- `M` tests/routers/test_recipes.py

### Commits
- 0db1f78 feat: [Phase 2.5B] Implement persistence trigger
- 5f8bb74 chore: initialize work on #475 [Phase 2.5B] Implement persistence trigger
<!-- /sharkrite-changes-summary -->