### PR TITLE
[Phase 2.5B] Implement browse cache cleanup job

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -61,6 +61,10 @@ class Settings(BaseSettings):
     # Maximum retry count for stale task recovery before marking task as failed
     task_max_retry_count: int = Field(default=3, ge=0)
 
+    # Browse Cache Configuration
+    # TTL for non-persisted recipes (days) - recipes older than this are pruned
+    browse_cache_ttl_days: int = Field(default=7, gt=0)
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/src/main.py
+++ b/src/main.py
@@ -15,6 +15,7 @@ from src.db.database import Base, init_engine, get_engine, get_session_factory
 from src.routers import auth_router, users_router, substitutions_router, inventory_router, recipes_router, grocery_router, prepared_foods_router, scraper_router, tasks_router, receipts_router
 from src.middleware.rate_limit import limiter
 from src.services.task_worker import background_task_worker
+from src.services.cleanup_service import prune_unpersisted_recipes
 from src.services.llm.client import OllamaClient
 
 logger = logging.getLogger(__name__)
@@ -64,6 +65,17 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     init_engine(settings.database_url)
     _ensure_schema()
     _ensure_seed_data()
+
+    # Run browse cache cleanup on startup (Phase 2.5B)
+    # Prunes non-persisted recipes older than BROWSE_CACHE_TTL_DAYS
+    SessionFactory = get_session_factory()
+    with SessionFactory() as cleanup_session:
+        try:
+            pruned_count = prune_unpersisted_recipes(cleanup_session)
+            logger.info(f"Browse cache cleanup: pruned {pruned_count} recipe(s)")
+        except Exception as e:
+            logger.error(f"Browse cache cleanup failed: {e}", exc_info=True)
+            # Don't block startup if cleanup fails - log and continue
 
     # Start background task worker for processing async LLM tasks (Phase 2A)
     # Worker polls for pending tasks and processes them using OllamaClient

--- a/src/services/cleanup_service.py
+++ b/src/services/cleanup_service.py
@@ -1,0 +1,116 @@
+"""
+Browse cache cleanup service.
+
+Prunes non-persisted recipes older than the configured TTL and their
+associated UserRecipeRating records. This keeps the browse cache from
+growing indefinitely while preserving user-persisted recipes.
+
+Per ADR Section 2.5B: Browse-Then-Persist Flow
+- Only non-persisted recipes are pruned (is_persisted=False)
+- TTL is configurable via BROWSE_CACHE_TTL_DAYS env var (default 7 days)
+- Orphaned UserRecipeRating records are cascade deleted
+- Cleanup runs on application startup (MVP - no real-time scheduling)
+"""
+
+import logging
+from datetime import datetime, timezone, timedelta
+
+from sqlalchemy import select, delete
+from sqlalchemy.orm import Session
+
+from src.config import get_settings
+from src.db.models.recipe import Recipe
+from src.db.models.user_recipe import UserRecipeRating
+
+logger = logging.getLogger(__name__)
+
+
+def prune_unpersisted_recipes(db: Session) -> int:
+    """
+    Delete non-persisted recipes older than TTL and their orphaned UserRecipeRating records.
+
+    Queries for recipes where:
+    - is_persisted = False
+    - created_at < now() - BROWSE_CACHE_TTL_DAYS
+
+    First deletes associated UserRecipeRating records to avoid FK constraint violations,
+    then deletes the recipes themselves. All operations are performed in a single
+    transaction.
+
+    Args:
+        db: Database session for queries and deletes
+
+    Returns:
+        Number of recipes pruned
+
+    Example:
+        >>> with SessionFactory() as db:
+        >>>     pruned_count = prune_unpersisted_recipes(db)
+        >>>     logger.info(f"Pruned {pruned_count} recipes")
+    """
+    # Get settings inside function to allow test monkeypatching
+    settings = get_settings()
+
+    # Calculate cutoff date based on TTL
+    cutoff_date = datetime.now(timezone.utc) - timedelta(days=settings.browse_cache_ttl_days)
+
+    # Query for recipes to prune
+    stmt = (
+        select(Recipe.id)
+        .where(
+            Recipe.is_persisted == False,  # noqa: E712 - SQLAlchemy requires == for bool comparison
+            Recipe.created_at < cutoff_date
+        )
+    )
+    result = db.execute(stmt)
+    recipe_ids_to_prune = [row[0] for row in result.fetchall()]
+
+    if not recipe_ids_to_prune:
+        logger.debug(
+            "No non-persisted recipes to prune",
+            extra={"ttl_days": settings.browse_cache_ttl_days}
+        )
+        return 0
+
+    logger.info(
+        f"Pruning {len(recipe_ids_to_prune)} non-persisted recipe(s) older than {settings.browse_cache_ttl_days} days",
+        extra={
+            "recipe_count": len(recipe_ids_to_prune),
+            "ttl_days": settings.browse_cache_ttl_days,
+            "cutoff_date": cutoff_date.isoformat()
+        }
+    )
+
+    # Delete associated UserRecipeRating records first (avoid FK constraint violations)
+    rating_delete_stmt = (
+        delete(UserRecipeRating)
+        .where(UserRecipeRating.recipe_id.in_(recipe_ids_to_prune))
+    )
+    rating_result = db.execute(rating_delete_stmt)
+    deleted_ratings = rating_result.rowcount
+
+    logger.debug(
+        f"Deleted {deleted_ratings} orphaned UserRecipeRating record(s)",
+        extra={"deleted_count": deleted_ratings}
+    )
+
+    # Delete the recipes
+    recipe_delete_stmt = (
+        delete(Recipe)
+        .where(Recipe.id.in_(recipe_ids_to_prune))
+    )
+    recipe_result = db.execute(recipe_delete_stmt)
+    deleted_recipes = recipe_result.rowcount
+
+    # Commit the transaction
+    db.commit()
+
+    logger.info(
+        f"Pruned {deleted_recipes} recipe(s) and {deleted_ratings} rating(s)",
+        extra={
+            "pruned_recipes": deleted_recipes,
+            "pruned_ratings": deleted_ratings
+        }
+    )
+
+    return deleted_recipes

--- a/tests/services/test_cleanup_service.py
+++ b/tests/services/test_cleanup_service.py
@@ -1,0 +1,323 @@
+"""
+Unit tests for browse cache cleanup service.
+
+Tests cover:
+- Pruning non-persisted recipes older than TTL
+- Preserving persisted recipes
+- Preserving non-persisted recipes newer than TTL
+- Cascade deletion of UserRecipeRating records
+- Correct count of pruned recipes
+"""
+
+import pytest
+from datetime import datetime, timezone, timedelta
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from uuid import uuid4
+
+from src.db.database import Base
+from src.db import models  # Import all models to ensure Base.metadata has all tables
+from src.db.models.recipe import Recipe
+from src.db.models.user import User, UserRole
+from src.db.models.user_recipe import UserRecipeRating
+from src.services.cleanup_service import prune_unpersisted_recipes
+from src.services.auth_service import hash_password
+
+
+# Create an in-memory SQLite database for testing
+TEST_DATABASE_URL = "sqlite:///:memory:"
+
+
+@pytest.fixture(autouse=True)
+def setup_test_env(monkeypatch):
+    """
+    Set up test environment variables.
+
+    Uses monkeypatch to ensure clean setup/teardown and prevent test pollution.
+    autouse=True means this fixture runs automatically for all tests in this module.
+    """
+    # Clear the settings cache before setting environment variables
+    from src.config import get_settings
+    get_settings.cache_clear()
+
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars")
+    monkeypatch.setenv("JWT_ALGORITHM", "HS256")
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    monkeypatch.setenv("BROWSE_CACHE_TTL_DAYS", "7")  # Default TTL for most tests
+
+    # Clear the cache again to ensure fresh settings are loaded
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def db_session():
+    """Create a fresh database session for each test."""
+    # Ensure all models are imported by accessing them
+    _ = models  # This forces the import of all models
+
+    # Create a new engine with StaticPool to ensure all connections share the same in-memory database
+    engine = create_engine(
+        TEST_DATABASE_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,  # Critical for SQLite :memory: to work correctly
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+@pytest.fixture
+def test_user(db_session):
+    """Create a test user in the database."""
+    user = User(
+        id=uuid4(),
+        name="Test User",
+        email="test@example.com",
+        hashed_password=hash_password("testpassword123"),
+        role=UserRole.member.value,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+class TestPruneUnpersistedRecipes:
+    """Tests for the prune_unpersisted_recipes function."""
+
+    def test_prunes_old_unpersisted_recipe(self, db_session, test_user):
+        """Test that non-persisted recipe older than TTL is pruned."""
+        # Create a recipe that's 10 days old and not persisted
+        old_date = datetime.now(timezone.utc) - timedelta(days=10)
+        recipe_id = uuid4()
+        old_recipe = Recipe(
+            id=recipe_id,
+            name="Old Browse Recipe",
+            source_type="hellofresh_web",
+            is_persisted=False,
+            created_at=old_date,
+            created_by=test_user.id,
+        )
+        db_session.add(old_recipe)
+        db_session.commit()
+
+        # Run cleanup
+        pruned_count = prune_unpersisted_recipes(db_session)
+
+        # Verify recipe was pruned
+        assert pruned_count == 1
+        remaining = db_session.query(Recipe).filter_by(id=recipe_id).first()
+        assert remaining is None
+
+    def test_preserves_persisted_recipe(self, db_session, test_user):
+        """Test that persisted recipe is not pruned regardless of age."""
+        # Create a persisted recipe that's 10 days old
+        old_date = datetime.now(timezone.utc) - timedelta(days=10)
+        recipe_id = uuid4()
+        persisted_recipe = Recipe(
+            id=recipe_id,
+            name="Persisted Recipe",
+            source_type="manual",
+            is_persisted=True,
+            created_at=old_date,
+            created_by=test_user.id,
+        )
+        db_session.add(persisted_recipe)
+        db_session.commit()
+
+        # Run cleanup
+        pruned_count = prune_unpersisted_recipes(db_session)
+
+        # Verify recipe was NOT pruned
+        assert pruned_count == 0
+        remaining = db_session.query(Recipe).filter_by(id=recipe_id).first()
+        assert remaining is not None
+
+    def test_preserves_recent_unpersisted_recipe(self, db_session, test_user):
+        """Test that non-persisted recipe newer than TTL is not pruned."""
+        # Create a recipe that's 3 days old (within 7-day TTL)
+        recent_date = datetime.now(timezone.utc) - timedelta(days=3)
+        recipe_id = uuid4()
+        recent_recipe = Recipe(
+            id=recipe_id,
+            name="Recent Browse Recipe",
+            source_type="hellofresh_web",
+            is_persisted=False,
+            created_at=recent_date,
+            created_by=test_user.id,
+        )
+        db_session.add(recent_recipe)
+        db_session.commit()
+
+        # Run cleanup
+        pruned_count = prune_unpersisted_recipes(db_session)
+
+        # Verify recipe was NOT pruned
+        assert pruned_count == 0
+        remaining = db_session.query(Recipe).filter_by(id=recipe_id).first()
+        assert remaining is not None
+
+    def test_deletes_orphaned_user_recipe_ratings(self, db_session, test_user):
+        """Test that UserRecipeRating records for pruned recipes are deleted."""
+        # Create an old unpersisted recipe
+        old_date = datetime.now(timezone.utc) - timedelta(days=10)
+        recipe_id = uuid4()
+        old_recipe = Recipe(
+            id=recipe_id,
+            name="Old Browse Recipe",
+            source_type="hellofresh_web",
+            is_persisted=False,
+            created_at=old_date,
+            created_by=test_user.id,
+        )
+        db_session.add(old_recipe)
+        db_session.commit()
+
+        # Create a rating for this recipe
+        rating_id = uuid4()
+        rating = UserRecipeRating(
+            id=rating_id,
+            user_id=test_user.id,
+            recipe_id=recipe_id,
+            rating=4.5,
+            is_favorite=True,
+        )
+        db_session.add(rating)
+        db_session.commit()
+
+        # Verify rating exists before cleanup
+        rating_before = db_session.query(UserRecipeRating).filter_by(id=rating_id).first()
+        assert rating_before is not None
+
+        # Run cleanup
+        pruned_count = prune_unpersisted_recipes(db_session)
+
+        # Verify recipe and rating were both deleted
+        assert pruned_count == 1
+        recipe_after = db_session.query(Recipe).filter_by(id=recipe_id).first()
+        rating_after = db_session.query(UserRecipeRating).filter_by(id=rating_id).first()
+        assert recipe_after is None
+        assert rating_after is None
+
+    def test_returns_correct_count_multiple_recipes(self, db_session, test_user):
+        """Test that prune function returns correct count when multiple recipes are pruned."""
+        old_date = datetime.now(timezone.utc) - timedelta(days=10)
+
+        # Create 3 old unpersisted recipes
+        old_recipe_ids = []
+        for i in range(3):
+            recipe_id = uuid4()
+            recipe = Recipe(
+                id=recipe_id,
+                name=f"Old Recipe {i}",
+                source_type="hellofresh_web",
+                is_persisted=False,
+                created_at=old_date,
+                created_by=test_user.id,
+            )
+            old_recipe_ids.append(recipe_id)
+            db_session.add(recipe)
+
+        # Create 1 persisted old recipe (should not be pruned)
+        persisted_recipe_id = uuid4()
+        persisted_recipe = Recipe(
+            id=persisted_recipe_id,
+            name="Persisted Recipe",
+            source_type="manual",
+            is_persisted=True,
+            created_at=old_date,
+            created_by=test_user.id,
+        )
+        db_session.add(persisted_recipe)
+
+        # Create 1 recent unpersisted recipe (should not be pruned)
+        recent_recipe_id = uuid4()
+        recent_recipe = Recipe(
+            id=recent_recipe_id,
+            name="Recent Recipe",
+            source_type="hellofresh_web",
+            is_persisted=False,
+            created_at=datetime.now(timezone.utc) - timedelta(days=3),
+            created_by=test_user.id,
+        )
+        db_session.add(recent_recipe)
+        db_session.commit()
+
+        # Run cleanup
+        pruned_count = prune_unpersisted_recipes(db_session)
+
+        # Verify correct count
+        assert pruned_count == 3
+
+        # Verify only the old unpersisted recipes were deleted
+        for recipe_id in old_recipe_ids:
+            assert db_session.query(Recipe).filter_by(id=recipe_id).first() is None
+        assert db_session.query(Recipe).filter_by(id=persisted_recipe_id).first() is not None
+        assert db_session.query(Recipe).filter_by(id=recent_recipe_id).first() is not None
+
+    def test_no_recipes_to_prune(self, db_session, test_user):
+        """Test that cleanup returns 0 when there are no recipes to prune."""
+        # Create only recent recipes
+        recipe_id = uuid4()
+        recent_recipe = Recipe(
+            id=recipe_id,
+            name="Recent Recipe",
+            source_type="hellofresh_web",
+            is_persisted=False,
+            created_at=datetime.now(timezone.utc) - timedelta(days=3),
+            created_by=test_user.id,
+        )
+        db_session.add(recent_recipe)
+        db_session.commit()
+
+        # Run cleanup
+        pruned_count = prune_unpersisted_recipes(db_session)
+
+        # Verify no recipes were pruned
+        assert pruned_count == 0
+
+    def test_empty_database(self, db_session):
+        """Test that cleanup handles empty database gracefully."""
+        # Run cleanup on empty database
+        pruned_count = prune_unpersisted_recipes(db_session)
+
+        # Verify no errors and returns 0
+        assert pruned_count == 0
+
+    def test_custom_ttl_setting(self, db_session, test_user, monkeypatch):
+        """Test that cleanup respects custom TTL setting."""
+        # Set custom TTL to 3 days
+        monkeypatch.setenv("BROWSE_CACHE_TTL_DAYS", "3")
+        from src.config import get_settings
+        get_settings.cache_clear()  # Clear cache to pick up new setting
+
+        # Create a recipe that's 5 days old (would be pruned with 3-day TTL)
+        old_date = datetime.now(timezone.utc) - timedelta(days=5)
+        recipe_id = uuid4()
+        old_recipe = Recipe(
+            id=recipe_id,
+            name="5-Day Old Recipe",
+            source_type="hellofresh_web",
+            is_persisted=False,
+            created_at=old_date,
+            created_by=test_user.id,
+        )
+        db_session.add(old_recipe)
+        db_session.commit()
+
+        # Run cleanup
+        pruned_count = prune_unpersisted_recipes(db_session)
+
+        # Verify recipe was pruned (5 days > 3 day TTL)
+        assert pruned_count == 1
+        remaining = db_session.query(Recipe).filter_by(id=recipe_id).first()
+        assert remaining is None


### PR DESCRIPTION
## Work in Progress

Closes #476

[Phase 2.5B] Implement browse cache cleanup job

**Time Estimate**: 45min

**Description**:
Create a cleanup job that prunes non-persisted recipes older than `BROWSE_CACHE_TTL_DAYS` (default 7). Also deletes orphaned UserRecipeView records for pruned recipes.

**Claude Context**:
Files to Read:
- src/services/task_worker.py (background task patterns)
- src/db/models/recipe.py (Recipe.is_persisted)
- src/db/models/user_recipe_view.py (UserRecipeView after #5)

Files to Modify:
- src/services/cleanup_service.py (create new file)
- src/main.py (register cleanup job in lifespan)
- tests/services/test_cleanup_service.py (create new test file)

Related Issues: #2 (is_persisted), #5 (UserRecipeView)

**Acceptance Criteria**:
- [ ] Create `src/services/cleanup_service.py` with `prune_unpersisted_recipes(db: Session)` function
- [ ] Reads TTL from `BROWSE_CACHE_TTL_DAYS` env var (default 7)
- [ ] Deletes recipes where `is_persisted=False AND created_at < now() - TTL_DAYS`
- [ ] Cascade deletes associated UserRecipeView records
- [ ] Logs count of pruned recipes
- [ ] Cleanup job registered in FastAPI lifespan for daily execution
- [ ] Tests: non-persisted recipe older than TTL is pruned
- [ ] Tests: persisted recipe is not pruned
- [ ] Tests: UserRecipeView records for pruned recipes are deleted

**Verification Commands**:
```bash
.venv/bin/python -m pytest tests/services/test_cleanup_service.py -x -q
```

**Done Definition**: Done when cleanup job prunes old non-persisted recipes and their orphaned view records.

**Scope Boundary**:
- DO: Implement cleanup function, register in lifespan
- DO NOT: Implement real-time scheduling (daily check in lifespan is sufficient for MVP)

**Dependencies**: After #2 (needs: is_persisted field), After #5 (needs: UserRecipeView model)

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**4** files, **2** commits (+2 added, ~2 modified, -0 deleted)
- `M` src/config.py
- `M` src/main.py
- `A` src/services/cleanup_service.py
- `A` tests/services/test_cleanup_service.py

### Commits
- 0132344 refactor: [Phase 2.5B] Implement browse cache cleanup job
- f3d9766 chore: initialize work on #476 [Phase 2.5B] Implement browse cache cleanup job
<!-- /sharkrite-changes-summary -->