### PR TITLE
[Phase 2.5C] Create feed service with core queries

### DIFF
--- a/src/routers/__init__.py
+++ b/src/routers/__init__.py
@@ -6,6 +6,7 @@
 # - grocery.py (1F)
 # - prepared_foods.py (1G)
 # - scraper.py (2C - scraper/import endpoints)
+# - feed.py (2.5C - personalized recipe feed)
 
 from src.routers.auth import router as auth_router
 from src.routers.users import router as users_router
@@ -17,5 +18,6 @@ from src.routers.prepared_foods import router as prepared_foods_router
 from src.routers.scraper import router as scraper_router
 from src.routers.tasks import router as tasks_router
 from src.routers.receipts import router as receipts_router
+from src.routers.feed import router as feed_router
 
-__all__ = ["auth_router", "users_router", "substitutions_router", "inventory_router", "recipes_router", "grocery_router", "prepared_foods_router", "scraper_router", "tasks_router", "receipts_router"]
+__all__ = ["auth_router", "users_router", "substitutions_router", "inventory_router", "recipes_router", "grocery_router", "prepared_foods_router", "scraper_router", "tasks_router", "receipts_router", "feed_router"]

--- a/src/routers/feed.py
+++ b/src/routers/feed.py
@@ -1,0 +1,69 @@
+"""
+Feed router - Personalized recipe recommendations.
+
+Provides endpoints for the home feed with inventory-aware and behavior-based
+recipe recommendations.
+"""
+
+import logging
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from src.db.database import get_db
+from src.db.models.user import User
+from src.routers.auth import get_current_user
+from src.services import feed_service
+from src.schemas.feed import HomeFeedResponseSchema, FeedSectionSchema, RecipeCardSchema
+
+router = APIRouter(prefix="/feed", tags=["feed"])
+logger = logging.getLogger(__name__)
+
+
+@router.get("/home", response_model=HomeFeedResponseSchema)
+def get_home_feed(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    Get personalized home feed with recipe recommendations.
+
+    Returns two sections:
+    - Make This Right Now: Recipes user can cook based on current inventory (top 10)
+    - On Repeat: Recipes user repeatedly engages with (top 15)
+
+    Cold start behavior: Returns empty arrays if no matching recipes found.
+
+    Requires authentication.
+    """
+    # Get Make This Right Now recipes (inventory-aware)
+    make_now_recipes = feed_service.get_make_now_recipes(
+        user_id=current_user.id,
+        db=db,
+        limit=10
+    )
+
+    # Get On Repeat recipes (behavioral signals)
+    on_repeat_recipes = feed_service.get_on_repeat_recipes(
+        user_id=current_user.id,
+        db=db,
+        limit=15
+    )
+
+    # Build response
+    response = HomeFeedResponseSchema(
+        make_now=FeedSectionSchema(
+            title="Make This Right Now",
+            recipes=[RecipeCardSchema.model_validate(r) for r in make_now_recipes]
+        ),
+        on_repeat=FeedSectionSchema(
+            title="On Repeat",
+            recipes=[RecipeCardSchema.model_validate(r) for r in on_repeat_recipes]
+        )
+    )
+
+    logger.info(
+        f"Home feed for user {current_user.id}: "
+        f"{len(make_now_recipes)} make-now, {len(on_repeat_recipes)} on-repeat"
+    )
+
+    return response

--- a/src/schemas/feed.py
+++ b/src/schemas/feed.py
@@ -1,0 +1,39 @@
+"""
+Pydantic schemas for feed endpoints.
+
+Defines response models for personalized recipe feed.
+"""
+
+from uuid import UUID
+from typing import Optional
+from pydantic import BaseModel, Field
+
+
+class RecipeCardSchema(BaseModel):
+    """Recipe data returned in feed sections."""
+
+    id: UUID = Field(..., description="Recipe ID")
+    name: str = Field(..., description="Recipe name")
+    source_type: str = Field(..., description="Source type")
+    source_image: Optional[str] = Field(None, description="Recipe image URL")
+    prep_time_minutes: Optional[int] = Field(None, description="Prep time in minutes")
+    cook_time_minutes: Optional[int] = Field(None, description="Cook time in minutes")
+    base_servings: int = Field(..., description="Number of servings")
+    tags: list[str] = Field(default_factory=list, description="Recipe tags")
+    times_cooked: int = Field(..., description="Number of times cooked")
+
+    model_config = {"from_attributes": True}
+
+
+class FeedSectionSchema(BaseModel):
+    """Generic feed section with title and recipes."""
+
+    title: str = Field(..., description="Section title")
+    recipes: list[RecipeCardSchema] = Field(..., description="Recipe cards in this section")
+
+
+class HomeFeedResponseSchema(BaseModel):
+    """Response schema for GET /feed/home endpoint."""
+
+    make_now: FeedSectionSchema = Field(..., description="Make This Right Now section")
+    on_repeat: FeedSectionSchema = Field(..., description="On Repeat section")

--- a/src/services/feed_service.py
+++ b/src/services/feed_service.py
@@ -1,0 +1,170 @@
+"""
+Feed service - Personalized recipe recommendations.
+
+Provides "Make This Right Now" (inventory-aware) and "On Repeat" (behavioral signals)
+query logic for the home feed.
+"""
+
+import logging
+from uuid import UUID
+from datetime import datetime
+from sqlalchemy import func, case, distinct
+from sqlalchemy.orm import Session
+
+from src.db.models.recipe import Recipe
+from src.db.models.recipe_ingredient import RecipeIngredient
+from src.db.models.inventory_item import InventoryItem
+from src.db.models.user_recipe import UserRecipeRating
+
+logger = logging.getLogger(__name__)
+
+
+def get_make_now_recipes(user_id: UUID, db: Session, limit: int = 10) -> list[Recipe]:
+    """
+    Get recipes the user can make right now based on inventory availability.
+
+    Returns persisted recipes where the user has 100% of required (non-optional)
+    ingredients available. Results are sorted by freshness priority (ingredients
+    expiring soonest) then by times_cooked descending.
+
+    Args:
+        user_id: User ID to check inventory for
+        db: Database session
+        limit: Maximum number of recipes to return (default 10)
+
+    Returns:
+        List of Recipe objects with 100% ingredient availability
+
+    Note:
+        - Only checks required ingredients (is_optional=False)
+        - Uses case-insensitive ingredient name matching
+        - Freshness priority based on earliest expiration_date in recipe's ingredients
+        - TODO: Add fuzzy matching for ingredient names
+        - TODO: Add unit conversion between recipe and inventory units
+    """
+    # Subquery: For each recipe, count total required ingredients
+    total_ingredients_subq = (
+        db.query(
+            RecipeIngredient.recipe_id,
+            func.count(distinct(RecipeIngredient.id)).label("total_required")
+        )
+        .filter(RecipeIngredient.is_optional == False)  # noqa: E712
+        .group_by(RecipeIngredient.recipe_id)
+        .subquery()
+    )
+
+    # Subquery: For each recipe, count matched ingredients in user's inventory
+    # Match by case-insensitive ingredient name
+    matched_ingredients_subq = (
+        db.query(
+            RecipeIngredient.recipe_id,
+            func.count(distinct(RecipeIngredient.id)).label("matched_count")
+        )
+        .join(
+            InventoryItem,
+            func.lower(RecipeIngredient.ingredient_name) == func.lower(InventoryItem.name)
+        )
+        .filter(RecipeIngredient.is_optional == False)  # noqa: E712
+        .filter(InventoryItem.added_by == user_id)
+        .filter(InventoryItem.quantity > 0)  # Only count items with available quantity
+        .group_by(RecipeIngredient.recipe_id)
+        .subquery()
+    )
+
+    # Subquery: For each recipe, get earliest expiration date of its ingredients
+    # This drives freshness priority sorting
+    freshness_subq = (
+        db.query(
+            RecipeIngredient.recipe_id,
+            func.min(InventoryItem.expiration_date).label("earliest_expiration")
+        )
+        .join(
+            InventoryItem,
+            func.lower(RecipeIngredient.ingredient_name) == func.lower(InventoryItem.name)
+        )
+        .filter(InventoryItem.added_by == user_id)
+        .filter(InventoryItem.expiration_date.isnot(None))
+        .group_by(RecipeIngredient.recipe_id)
+        .subquery()
+    )
+
+    # Main query: Get recipes with 100% ingredient availability
+    query = (
+        db.query(Recipe)
+        .join(total_ingredients_subq, Recipe.id == total_ingredients_subq.c.recipe_id)
+        .outerjoin(matched_ingredients_subq, Recipe.id == matched_ingredients_subq.c.recipe_id)
+        .outerjoin(freshness_subq, Recipe.id == freshness_subq.c.recipe_id)
+        .filter(Recipe.is_persisted == True)  # noqa: E712
+        .filter(
+            # Only recipes with 100% ingredient availability
+            # Handle case where matched_count is NULL (0 matches)
+            func.coalesce(matched_ingredients_subq.c.matched_count, 0)
+            == total_ingredients_subq.c.total_required
+        )
+        .order_by(
+            # Sort by freshness (earliest expiration first), NULL last
+            case(
+                (freshness_subq.c.earliest_expiration.is_(None), None),
+                else_=freshness_subq.c.earliest_expiration
+            ).asc().nullslast(),
+            # Then by popularity (times cooked)
+            Recipe.times_cooked.desc()
+        )
+        .limit(limit)
+    )
+
+    recipes = query.all()
+    logger.info(f"Found {len(recipes)} make-now recipes for user {user_id}")
+    return recipes
+
+
+def get_on_repeat_recipes(user_id: UUID, db: Session, limit: int = 15) -> list[Recipe]:
+    """
+    Get recipes the user repeatedly engages with based on behavioral signals.
+
+    Weighted scoring from:
+    - Viewed-not-cooked (0.25) - TODO: requires UserRecipeView model from #5
+    - High-frequency-cooked (0.30) - TODO: requires UserCookEvent model from #4
+    - Recently-rated (0.25) - IMPLEMENTED: uses UserRecipeRating.updated_at
+    - Genre-affinity (0.20) - TODO: requires cook history analysis
+
+    Args:
+        user_id: User ID to get recommendations for
+        db: Database session
+        limit: Maximum number of recipes to return (default 15)
+
+    Returns:
+        List of Recipe objects sorted by engagement score
+
+    Note:
+        Current implementation only uses recently-rated signal (0.25 weight).
+        Full weighted scoring will be available after dependencies #4 and #5 complete.
+        Returns empty list if no rating data exists (cold start case).
+    """
+    # TODO (#4): Add viewed-not-cooked signal (0.25)
+    # Requires UserRecipeView model to track views and correlate with cook events
+
+    # TODO (#4): Add high-frequency-cooked signal (0.30)
+    # Requires UserCookEvent model to calculate cook frequency
+
+    # TODO (#4, #5): Add genre-affinity signal (0.20)
+    # Requires cook history to analyze preferred tags/genres
+
+    # Current implementation: Recently-rated signal only
+    # Uses updated_at from UserRecipeRating as recency indicator
+    # Orders by most recent rating first
+    query = (
+        db.query(Recipe)
+        .join(UserRecipeRating, Recipe.id == UserRecipeRating.recipe_id)
+        .filter(UserRecipeRating.user_id == user_id)
+        .filter(Recipe.is_persisted == True)  # noqa: E712
+        .order_by(UserRecipeRating.updated_at.desc())
+        .limit(limit)
+    )
+
+    recipes = query.all()
+    logger.info(
+        f"Found {len(recipes)} on-repeat recipes for user {user_id} "
+        f"(recently-rated signal only, awaiting #4 and #5 for full scoring)"
+    )
+    return recipes

--- a/tests/routers/test_feed.py
+++ b/tests/routers/test_feed.py
@@ -1,0 +1,485 @@
+"""
+Integration tests for feed endpoints.
+
+Tests cover:
+- GET /feed/home: personalized home feed with make_now and on_repeat sections
+- Make This Right Now: inventory-aware recipe recommendations
+- On Repeat: behavioral signal-based recommendations
+- Authentication requirements
+- Cold start scenarios (empty results)
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from uuid import uuid4
+from datetime import datetime, timedelta
+
+from src.db.database import Base, get_db
+from src.db import models
+from src.db.models.user import User, UserRole
+from src.db.models.recipe import Recipe
+from src.db.models.recipe_ingredient import RecipeIngredient
+from src.db.models.inventory_item import InventoryItem
+from src.db.models.user_recipe import UserRecipeRating
+from src.services.auth_service import hash_password, create_access_token
+
+from fastapi import FastAPI
+from src.routers import feed as feed_router
+
+# Create a test app without lifespan
+app = FastAPI(
+    title="FreshUp",
+    description="Privacy-first kitchen management system",
+    version="0.1.0",
+)
+
+# Register the feed router
+app.include_router(feed_router.router)
+
+
+# Create an in-memory SQLite database for testing
+TEST_DATABASE_URL = "sqlite:///:memory:"
+
+
+@pytest.fixture(autouse=True)
+def setup_test_env(monkeypatch):
+    """Set up test environment variables."""
+    from src.config import get_settings
+    get_settings.cache_clear()
+
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars")
+    monkeypatch.setenv("JWT_ALGORITHM", "HS256")
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    monkeypatch.setenv("ACCESS_TOKEN_EXPIRE_MINUTES", "43200")
+
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def db_session():
+    """Create a fresh database session for each test."""
+    from sqlalchemy.pool import StaticPool
+
+    # Import models to ensure all SQLAlchemy model classes are registered
+    # with Base.metadata before create_all() is called
+    _ = models
+
+    engine = create_engine(
+        TEST_DATABASE_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+@pytest.fixture
+def client(db_session):
+    """Create a test client with database dependency override."""
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def test_user(db_session):
+    """Create a test user."""
+    user = User(
+        id=uuid4(),
+        email="test@example.com",
+        hashed_password=hash_password("testpassword123"),
+        name="Test User",
+        role=UserRole.member.value,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def auth_headers(test_user):
+    """Generate authorization headers for test user."""
+    access_token = create_access_token({"sub": str(test_user.id)})
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+class TestHomeFeed:
+    """Test home feed endpoint."""
+
+    def test_home_feed_requires_authentication(self, client):
+        """Test that home feed endpoint requires authentication."""
+        response = client.get("/feed/home")
+        assert response.status_code == 401
+
+    def test_home_feed_empty_cold_start(self, client, auth_headers, test_user, db_session):
+        """Test home feed returns empty sections when user has no data (cold start)."""
+        response = client.get("/feed/home", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should have both sections
+        assert "make_now" in data
+        assert "on_repeat" in data
+
+        # Sections should have titles and empty recipe lists
+        assert data["make_now"]["title"] == "Make This Right Now"
+        assert data["make_now"]["recipes"] == []
+
+        assert data["on_repeat"]["title"] == "On Repeat"
+        assert data["on_repeat"]["recipes"] == []
+
+    def test_make_now_returns_recipes_with_full_inventory(self, client, auth_headers, test_user, db_session):
+        """Test Make This Right Now returns recipes where user has 100% of ingredients."""
+        # Create a persisted recipe
+        recipe = Recipe(
+            id=uuid4(),
+            name="Pasta Carbonara",
+            source_type="manual",
+            is_persisted=True,
+            times_cooked=5,
+            created_by=test_user.id
+        )
+        db_session.add(recipe)
+        db_session.commit()
+
+        # Add required ingredients to recipe
+        ingredient1 = RecipeIngredient(
+            id=uuid4(),
+            recipe_id=recipe.id,
+            ingredient_name="Spaghetti",
+            quantity=200,
+            unit="g",
+            is_optional=False
+        )
+        ingredient2 = RecipeIngredient(
+            id=uuid4(),
+            recipe_id=recipe.id,
+            ingredient_name="Bacon",
+            quantity=100,
+            unit="g",
+            is_optional=False
+        )
+        db_session.add_all([ingredient1, ingredient2])
+        db_session.commit()
+
+        # Add matching inventory items for user
+        inventory1 = InventoryItem(
+            id=uuid4(),
+            name="Spaghetti",
+            quantity=500,
+            unit="g",
+            category="grain",
+            storage_location="pantry",
+            added_by=test_user.id
+        )
+        inventory2 = InventoryItem(
+            id=uuid4(),
+            name="Bacon",
+            quantity=200,
+            unit="g",
+            category="protein",
+            storage_location="fridge",
+            added_by=test_user.id
+        )
+        db_session.add_all([inventory1, inventory2])
+        db_session.commit()
+
+        # Call endpoint
+        response = client.get("/feed/home", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should have the recipe in make_now section
+        assert len(data["make_now"]["recipes"]) == 1
+        assert data["make_now"]["recipes"][0]["name"] == "Pasta Carbonara"
+        assert data["make_now"]["recipes"][0]["times_cooked"] == 5
+
+    def test_make_now_excludes_recipes_with_partial_inventory(self, client, auth_headers, test_user, db_session):
+        """Test Make This Right Now excludes recipes when user is missing ingredients."""
+        # Create a persisted recipe
+        recipe = Recipe(
+            id=uuid4(),
+            name="Incomplete Recipe",
+            source_type="manual",
+            is_persisted=True,
+            times_cooked=3,
+            created_by=test_user.id
+        )
+        db_session.add(recipe)
+        db_session.commit()
+
+        # Add required ingredients to recipe
+        ingredient1 = RecipeIngredient(
+            id=uuid4(),
+            recipe_id=recipe.id,
+            ingredient_name="Ingredient A",
+            quantity=100,
+            unit="g",
+            is_optional=False
+        )
+        ingredient2 = RecipeIngredient(
+            id=uuid4(),
+            recipe_id=recipe.id,
+            ingredient_name="Ingredient B",
+            quantity=100,
+            unit="g",
+            is_optional=False
+        )
+        db_session.add_all([ingredient1, ingredient2])
+        db_session.commit()
+
+        # Only add ONE inventory item (missing Ingredient B)
+        inventory1 = InventoryItem(
+            id=uuid4(),
+            name="Ingredient A",
+            quantity=200,
+            unit="g",
+            category="pantry_staple",
+            storage_location="pantry",
+            added_by=test_user.id
+        )
+        db_session.add(inventory1)
+        db_session.commit()
+
+        # Call endpoint
+        response = client.get("/feed/home", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Recipe should NOT appear in make_now (missing ingredient)
+        assert len(data["make_now"]["recipes"]) == 0
+
+    def test_make_now_ignores_optional_ingredients(self, client, auth_headers, test_user, db_session):
+        """Test Make This Right Now only checks required ingredients, not optional ones."""
+        # Create a persisted recipe
+        recipe = Recipe(
+            id=uuid4(),
+            name="Recipe with Optional",
+            source_type="manual",
+            is_persisted=True,
+            times_cooked=2,
+            created_by=test_user.id
+        )
+        db_session.add(recipe)
+        db_session.commit()
+
+        # Add required and optional ingredients
+        required_ingredient = RecipeIngredient(
+            id=uuid4(),
+            recipe_id=recipe.id,
+            ingredient_name="Required Item",
+            quantity=100,
+            unit="g",
+            is_optional=False
+        )
+        optional_ingredient = RecipeIngredient(
+            id=uuid4(),
+            recipe_id=recipe.id,
+            ingredient_name="Optional Garnish",
+            quantity=10,
+            unit="g",
+            is_optional=True
+        )
+        db_session.add_all([required_ingredient, optional_ingredient])
+        db_session.commit()
+
+        # Only add the required ingredient to inventory (skip optional)
+        inventory = InventoryItem(
+            id=uuid4(),
+            name="Required Item",
+            quantity=200,
+            unit="g",
+            category="pantry_staple",
+            storage_location="pantry",
+            added_by=test_user.id
+        )
+        db_session.add(inventory)
+        db_session.commit()
+
+        # Call endpoint
+        response = client.get("/feed/home", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Recipe SHOULD appear (has all required ingredients)
+        assert len(data["make_now"]["recipes"]) == 1
+        assert data["make_now"]["recipes"][0]["name"] == "Recipe with Optional"
+
+    def test_make_now_sorts_by_freshness_then_popularity(self, client, auth_headers, test_user, db_session):
+        """Test Make This Right Now sorts by ingredient freshness (expiration) then times_cooked."""
+        # Create two persisted recipes
+        recipe1 = Recipe(
+            id=uuid4(),
+            name="Fresh Recipe",
+            source_type="manual",
+            is_persisted=True,
+            times_cooked=1,
+            created_by=test_user.id
+        )
+        recipe2 = Recipe(
+            id=uuid4(),
+            name="Popular Recipe",
+            source_type="manual",
+            is_persisted=True,
+            times_cooked=10,
+            created_by=test_user.id
+        )
+        db_session.add_all([recipe1, recipe2])
+        db_session.commit()
+
+        # Recipe 1: ingredient expiring soon
+        ingredient1 = RecipeIngredient(
+            id=uuid4(),
+            recipe_id=recipe1.id,
+            ingredient_name="Milk",
+            quantity=100,
+            unit="ml",
+            is_optional=False
+        )
+        # Recipe 2: ingredient not expiring
+        ingredient2 = RecipeIngredient(
+            id=uuid4(),
+            recipe_id=recipe2.id,
+            ingredient_name="Rice",
+            quantity=100,
+            unit="g",
+            is_optional=False
+        )
+        db_session.add_all([ingredient1, ingredient2])
+        db_session.commit()
+
+        # Add inventory with expiration dates
+        inventory1 = InventoryItem(
+            id=uuid4(),
+            name="Milk",
+            quantity=500,
+            unit="ml",
+            category="dairy",
+            storage_location="fridge",
+            added_by=test_user.id,
+            expiration_date=datetime.now() + timedelta(days=2)  # Expires soon
+        )
+        inventory2 = InventoryItem(
+            id=uuid4(),
+            name="Rice",
+            quantity=1000,
+            unit="g",
+            category="grain",
+            storage_location="pantry",
+            added_by=test_user.id,
+            expiration_date=None  # No expiration
+        )
+        db_session.add_all([inventory1, inventory2])
+        db_session.commit()
+
+        # Call endpoint
+        response = client.get("/feed/home", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should have both recipes
+        assert len(data["make_now"]["recipes"]) == 2
+
+        # Fresh Recipe should come first (earlier expiration)
+        assert data["make_now"]["recipes"][0]["name"] == "Fresh Recipe"
+        # Popular Recipe should come second
+        assert data["make_now"]["recipes"][1]["name"] == "Popular Recipe"
+
+    def test_on_repeat_returns_recently_rated_recipes(self, client, auth_headers, test_user, db_session):
+        """Test On Repeat returns recipes based on recent ratings."""
+        # Create persisted recipes
+        recipe1 = Recipe(
+            id=uuid4(),
+            name="Recently Rated Recipe",
+            source_type="manual",
+            is_persisted=True,
+            created_by=test_user.id
+        )
+        recipe2 = Recipe(
+            id=uuid4(),
+            name="Older Rated Recipe",
+            source_type="manual",
+            is_persisted=True,
+            created_by=test_user.id
+        )
+        db_session.add_all([recipe1, recipe2])
+        db_session.commit()
+
+        # Add ratings with different timestamps
+        rating1 = UserRecipeRating(
+            id=uuid4(),
+            user_id=test_user.id,
+            recipe_id=recipe1.id,
+            rating=5.0,
+            created_at=datetime.now() - timedelta(days=1),
+            updated_at=datetime.now() - timedelta(hours=1)  # Updated recently
+        )
+        rating2 = UserRecipeRating(
+            id=uuid4(),
+            user_id=test_user.id,
+            recipe_id=recipe2.id,
+            rating=4.0,
+            created_at=datetime.now() - timedelta(days=10),
+            updated_at=datetime.now() - timedelta(days=10)  # Updated long ago
+        )
+        db_session.add_all([rating1, rating2])
+        db_session.commit()
+
+        # Call endpoint
+        response = client.get("/feed/home", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should have both recipes in on_repeat
+        assert len(data["on_repeat"]["recipes"]) == 2
+
+        # Recently rated should come first
+        assert data["on_repeat"]["recipes"][0]["name"] == "Recently Rated Recipe"
+        assert data["on_repeat"]["recipes"][1]["name"] == "Older Rated Recipe"
+
+    def test_on_repeat_empty_when_no_ratings(self, client, auth_headers, test_user, db_session):
+        """Test On Repeat returns empty when user has no ratings (cold start)."""
+        # Create a persisted recipe but no ratings
+        recipe = Recipe(
+            id=uuid4(),
+            name="Unrated Recipe",
+            source_type="manual",
+            is_persisted=True,
+            created_by=test_user.id
+        )
+        db_session.add(recipe)
+        db_session.commit()
+
+        # Call endpoint
+        response = client.get("/feed/home", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # On Repeat should be empty (no ratings yet)
+        assert len(data["on_repeat"]["recipes"]) == 0


### PR DESCRIPTION
## Work in Progress

Closes #477

[Phase 2.5C] Create feed service with core queries

**Time Estimate**: 2hr

**Description**:
Create the feed service with "Make This Right Now" (inventory-aware) and "On Repeat" (behavioral signals) query logic. Add `GET /feed/home` endpoint returning the personalized feed structure.

**Claude Context**:
Files to Read:
- src/db/models/recipe.py (Recipe model)
- src/db/models/inventory_item.py (InventoryItem model for availability)
- src/db/models/user_cook_event.py (cook events after #4)
- src/db/models/user_recipe_view.py (view events after #5)
- src/db/models/user_recipe.py (UserRecipeRelation after #1)
- docs/implementation-plan-recipe-engagement.md (Section 3.2, 3.3 for query logic)

Files to Modify:
- src/services/feed_service.py (create new file)
- src/routers/feed.py (create new file)
- src/routers/__init__.py (register feed router)
- src/schemas/feed.py (create new file with response schemas)
- tests/routers/test_feed.py (create new test file)

Related Issues: #1, #4, #5 (need relation, cook, view models)

**Acceptance Criteria**:
- [ ] Create `src/services/feed_service.py` with query functions
- [ ] `get_make_now_recipes(user_id, db)`: returns persisted recipes with 100% ingredient availability, sorted by freshness priority then times_cooked
- [ ] `get_on_repeat_recipes(user_id, db)`: weighted score from viewed-not-cooked (0.25), high-freq-cooked (0.30), recently-rated (0.25), genre-affinity (0.20)
- [ ] Create `GET /feed/home` endpoint returning: make_now (top 10), on_repeat (top 15)
- [ ] Response includes recipe data in each section
- [ ] Cold start fallback: if make_now/on_repeat empty, return empty arrays (fallback rows handled in #12)
- [ ] Tests: make_now returns inventory-available recipes
- [ ] Tests: on_repeat scores view/cook/rating signals correctly

**Verification Commands**:
```bash
.venv/bin/python -m pytest tests/routers/test_feed.py -x -q
```

**Done Definition**: Done when /feed/home returns make_now and on_repeat sections with correctly scored recipes.

**Scope Boundary**:
- DO: Implement make_now and on_repeat queries
- DO NOT: Implement personalized rows (Issue "[Phase 2.5C] Add personalized rows and browse endpoint")
- DO NOT: Implement fallback rows (bundled with personalized rows issue)

**Dependencies**: After #1 (UserRecipeRelation), After #4 (UserCookEvent), After #5 (UserRecipeView)

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**5** files, **2** commits (+4 added, ~1 modified, -0 deleted)
- `M` src/routers/__init__.py
- `A` src/routers/feed.py
- `A` src/schemas/feed.py
- `A` src/services/feed_service.py
- `A` tests/routers/test_feed.py

### Commits
- f9d2760 feat: [Phase 2.5C] Create feed service with core queries
- 092f0aa chore: initialize work on #477 [Phase 2.5C] Create feed service with core queries
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-05-03T23:44:05Z:**
- Created: #488 
- Updated: none