### PR TITLE
Add personalized rows and browse endpoint

### DIFF
--- a/src/routers/feed.py
+++ b/src/routers/feed.py
@@ -13,7 +13,13 @@ from src.db.database import get_db
 from src.db.models.user import User
 from src.routers.auth import get_current_user
 from src.services import feed_service
-from src.schemas.feed import HomeFeedResponseSchema, FeedSectionSchema, RecipeCardSchema
+from src.schemas.feed import (
+    HomeFeedResponseSchema,
+    FeedSectionSchema,
+    RecipeCardSchema,
+    FeedRowSchema,
+    BrowseFeedResponseSchema
+)
 
 router = APIRouter(prefix="/feed", tags=["feed"])
 logger = logging.getLogger(__name__)
@@ -27,11 +33,14 @@ def get_home_feed(
     """
     Get personalized home feed with recipe recommendations.
 
-    Returns two sections:
+    Returns multiple sections:
     - Make This Right Now: Recipes user can cook based on current inventory (top 10)
     - On Repeat: Recipes user repeatedly engages with (top 15)
+    - Personalized rows: Tag-based rows from user patterns (3-4 rows max)
+    - Source rows: Source-specific rows from user patterns (2 rows max, >=5 saves)
+    - Fallback rows: Popular/Quick/New recipes for cold start or variety
 
-    Cold start behavior: Returns empty arrays if no matching recipes found.
+    Cold start behavior: When personalized/source rows are empty, fallback rows provide content.
 
     Requires authentication.
     """
@@ -49,6 +58,51 @@ def get_home_feed(
         limit=15
     )
 
+    # Build personalized rows (tag-based patterns)
+    personalized_rows_data = feed_service.build_personalized_rows(
+        user_id=current_user.id,
+        db=db,
+        max_rows=4
+    )
+
+    # Build source rows (source-based patterns)
+    source_rows_data = feed_service.build_source_rows(
+        user_id=current_user.id,
+        db=db,
+        max_rows=2
+    )
+
+    # Build fallback rows (cold start or variety)
+    fallback_rows_data = feed_service.build_fallback_rows(db=db)
+
+    # Convert row data to schemas
+    personalized_rows = [
+        FeedRowSchema(
+            title=row["title"],
+            recipes=[RecipeCardSchema.model_validate(r) for r in row["recipes"]],
+            browse_url=row.get("browse_url")
+        )
+        for row in personalized_rows_data
+    ]
+
+    source_rows = [
+        FeedRowSchema(
+            title=row["title"],
+            recipes=[RecipeCardSchema.model_validate(r) for r in row["recipes"]],
+            browse_url=row.get("browse_url")
+        )
+        for row in source_rows_data
+    ]
+
+    fallback_rows = [
+        FeedRowSchema(
+            title=row["title"],
+            recipes=[RecipeCardSchema.model_validate(r) for r in row["recipes"]],
+            browse_url=row.get("browse_url")
+        )
+        for row in fallback_rows_data
+    ]
+
     # Build response
     response = HomeFeedResponseSchema(
         make_now=FeedSectionSchema(
@@ -58,12 +112,73 @@ def get_home_feed(
         on_repeat=FeedSectionSchema(
             title="On Repeat",
             recipes=[RecipeCardSchema.model_validate(r) for r in on_repeat_recipes]
-        )
+        ),
+        personalized_rows=personalized_rows,
+        source_rows=source_rows,
+        fallback_rows=fallback_rows
     )
 
     logger.info(
         f"Home feed for user {current_user.id}: "
-        f"{len(make_now_recipes)} make-now, {len(on_repeat_recipes)} on-repeat"
+        f"{len(make_now_recipes)} make-now, {len(on_repeat_recipes)} on-repeat, "
+        f"{len(personalized_rows)} personalized rows, {len(source_rows)} source rows, "
+        f"{len(fallback_rows)} fallback rows"
     )
 
     return response
+
+
+@router.get("/browse", response_model=BrowseFeedResponseSchema)
+def get_browse_feed(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    Get browse feed with all carousel sections for recipe discovery.
+
+    Returns all available feed sections:
+    - Personalized rows (tag-based patterns)
+    - Source rows (source-based patterns)
+    - Fallback rows (Popular/Quick/New)
+
+    This endpoint provides the full recipe browse experience with all
+    available carousels. Future enhancement: add filter param to narrow
+    by tag/source/etc.
+
+    Requires authentication.
+    """
+    # Build all row types
+    personalized_rows_data = feed_service.build_personalized_rows(
+        user_id=current_user.id,
+        db=db,
+        max_rows=4
+    )
+
+    source_rows_data = feed_service.build_source_rows(
+        user_id=current_user.id,
+        db=db,
+        max_rows=2
+    )
+
+    fallback_rows_data = feed_service.build_fallback_rows(db=db)
+
+    # Combine all sections
+    all_sections_data = personalized_rows_data + source_rows_data + fallback_rows_data
+
+    # Convert to schemas
+    sections = [
+        FeedRowSchema(
+            title=row["title"],
+            recipes=[RecipeCardSchema.model_validate(r) for r in row["recipes"]],
+            browse_url=row.get("browse_url")
+        )
+        for row in all_sections_data
+    ]
+
+    logger.info(
+        f"Browse feed for user {current_user.id}: {len(sections)} total sections "
+        f"({len(personalized_rows_data)} personalized, {len(source_rows_data)} source, "
+        f"{len(fallback_rows_data)} fallback)"
+    )
+
+    return BrowseFeedResponseSchema(sections=sections)

--- a/src/schemas/feed.py
+++ b/src/schemas/feed.py
@@ -32,8 +32,34 @@ class FeedSectionSchema(BaseModel):
     recipes: list[RecipeCardSchema] = Field(..., description="Recipe cards in this section")
 
 
+class FeedRowSchema(BaseModel):
+    """Feed row with title, recipes, and optional browse URL for expansion."""
+
+    title: str = Field(..., description="Row title (ends with period per design system)")
+    recipes: list[RecipeCardSchema] = Field(..., description="Recipe cards in this row")
+    browse_url: Optional[str] = Field(None, description="URL for 'See all' expansion")
+
+
 class HomeFeedResponseSchema(BaseModel):
     """Response schema for GET /feed/home endpoint."""
 
     make_now: FeedSectionSchema = Field(..., description="Make This Right Now section")
     on_repeat: FeedSectionSchema = Field(..., description="On Repeat section")
+    personalized_rows: list[FeedRowSchema] = Field(
+        default_factory=list,
+        description="Personalized rows based on user patterns (3-4 max)"
+    )
+    source_rows: list[FeedRowSchema] = Field(
+        default_factory=list,
+        description="Source-specific rows (2 max, requires >=5 saves)"
+    )
+    fallback_rows: list[FeedRowSchema] = Field(
+        default_factory=list,
+        description="Fallback rows for cold start or variety"
+    )
+
+
+class BrowseFeedResponseSchema(BaseModel):
+    """Response schema for GET /feed/browse endpoint."""
+
+    sections: list[FeedRowSchema] = Field(..., description="All carousel sections for browse page")

--- a/src/services/feed_service.py
+++ b/src/services/feed_service.py
@@ -240,6 +240,25 @@ def get_user_source_patterns(user_id: UUID, db: Session, min_saves: int = 5) -> 
     return patterns
 
 
+def _get_saved_recipe_ids(user_id: UUID, db: Session) -> set[UUID]:
+    """
+    Get IDs of all recipes the user has saved/rated.
+
+    Args:
+        user_id: User ID to get saved recipes for
+        db: Database session
+
+    Returns:
+        Set of recipe IDs the user has rated/saved
+    """
+    return {
+        rating.recipe_id
+        for rating in db.query(UserRecipeRating.recipe_id)
+        .filter(UserRecipeRating.user_id == user_id)
+        .all()
+    }
+
+
 def get_recipes_by_tag(user_id: UUID, db: Session, tag: str, limit: int = 10) -> list[Recipe]:
     """
     Get recipes matching a specific tag, mixing saved and non-saved recipes.
@@ -269,12 +288,7 @@ def get_recipes_by_tag(user_id: UUID, db: Session, tag: str, limit: int = 10) ->
     matching_recipes = [r for r in all_recipes if tag in r.tags]
 
     # Get IDs of recipes user has saved
-    saved_recipe_ids = {
-        rating.recipe_id
-        for rating in db.query(UserRecipeRating.recipe_id)
-        .filter(UserRecipeRating.user_id == user_id)
-        .all()
-    }
+    saved_recipe_ids = _get_saved_recipe_ids(user_id, db)
 
     # Sort: saved recipes first, then by times_cooked
     # This prioritizes recipes the user has already saved while also
@@ -316,12 +330,7 @@ def get_recipes_by_source(user_id: UUID, db: Session, source_type: str, limit: i
     )
 
     # Get IDs of recipes user has saved
-    saved_recipe_ids = {
-        rating.recipe_id
-        for rating in db.query(UserRecipeRating.recipe_id)
-        .filter(UserRecipeRating.user_id == user_id)
-        .all()
-    }
+    saved_recipe_ids = _get_saved_recipe_ids(user_id, db)
 
     # Sort: saved recipes first, then by times_cooked
     def sort_key(recipe):

--- a/src/services/feed_service.py
+++ b/src/services/feed_service.py
@@ -168,3 +168,372 @@ def get_on_repeat_recipes(user_id: UUID, db: Session, limit: int = 15) -> list[R
         f"(recently-rated signal only, awaiting #4 and #5 for full scoring)"
     )
     return recipes
+
+
+def get_user_tag_patterns(user_id: UUID, db: Session, min_saves: int = 3) -> list[tuple[str, int]]:
+    """
+    Detect user's tag patterns based on saved recipe count.
+
+    Analyzes recipes the user has rated/saved to find their preferred tags.
+    Returns tags that appear in at least `min_saves` recipes.
+
+    Args:
+        user_id: User ID to analyze patterns for
+        db: Database session
+        min_saves: Minimum number of saved recipes required for a tag to qualify (default 3)
+
+    Returns:
+        List of (tag, count) tuples sorted by count descending
+    """
+    # Get all recipes the user has rated/saved
+    saved_recipes = (
+        db.query(Recipe)
+        .join(UserRecipeRating, Recipe.id == UserRecipeRating.recipe_id)
+        .filter(UserRecipeRating.user_id == user_id)
+        .all()
+    )
+
+    # Count tag occurrences across saved recipes
+    # This finds which tags appear most frequently in user's saved recipes
+    tag_counts = {}
+    for recipe in saved_recipes:
+        for tag in recipe.tags:
+            tag_counts[tag] = tag_counts.get(tag, 0) + 1
+
+    # Filter by minimum threshold and sort by count descending
+    # Only tags with >= min_saves occurrences qualify as patterns
+    patterns = [(tag, count) for tag, count in tag_counts.items() if count >= min_saves]
+    patterns.sort(key=lambda x: x[1], reverse=True)
+
+    logger.info(f"Found {len(patterns)} tag patterns for user {user_id} (min_saves={min_saves})")
+    return patterns
+
+
+def get_user_source_patterns(user_id: UUID, db: Session, min_saves: int = 5) -> list[tuple[str, int]]:
+    """
+    Detect user's source type patterns based on saved recipe count.
+
+    Analyzes recipes the user has rated/saved to find their preferred sources.
+    Returns source types that appear in at least `min_saves` recipes.
+
+    Args:
+        user_id: User ID to analyze patterns for
+        db: Database session
+        min_saves: Minimum number of saved recipes required for a source to qualify (default 5)
+
+    Returns:
+        List of (source_type, count) tuples sorted by count descending
+    """
+    # Count source types in user's saved recipes
+    source_counts = (
+        db.query(Recipe.source_type, func.count(Recipe.id).label("count"))
+        .join(UserRecipeRating, Recipe.id == UserRecipeRating.recipe_id)
+        .filter(UserRecipeRating.user_id == user_id)
+        .group_by(Recipe.source_type)
+        .having(func.count(Recipe.id) >= min_saves)
+        .order_by(func.count(Recipe.id).desc())
+        .all()
+    )
+
+    patterns = [(source_type, count) for source_type, count in source_counts]
+    logger.info(f"Found {len(patterns)} source patterns for user {user_id} (min_saves={min_saves})")
+    return patterns
+
+
+def get_recipes_by_tag(user_id: UUID, db: Session, tag: str, limit: int = 10) -> list[Recipe]:
+    """
+    Get recipes matching a specific tag, mixing saved and non-saved recipes.
+
+    Returns persisted recipes with the given tag, prioritizing:
+    1. Saved recipes (user has rated/saved them)
+    2. Non-saved recipes ordered by times_cooked descending
+
+    Args:
+        user_id: User ID for determining saved status
+        db: Database session
+        tag: Tag to filter recipes by
+        limit: Maximum number of recipes to return (default 10)
+
+    Returns:
+        List of Recipe objects with the specified tag
+    """
+    # Get all persisted recipes and filter by tag in Python
+    # (SQLite JSON querying has limited support in SQLAlchemy)
+    all_recipes = (
+        db.query(Recipe)
+        .filter(Recipe.is_persisted == True)  # noqa: E712
+        .all()
+    )
+
+    # Filter recipes that have the tag
+    matching_recipes = [r for r in all_recipes if tag in r.tags]
+
+    # Get IDs of recipes user has saved
+    saved_recipe_ids = {
+        rating.recipe_id
+        for rating in db.query(UserRecipeRating.recipe_id)
+        .filter(UserRecipeRating.user_id == user_id)
+        .all()
+    }
+
+    # Sort: saved recipes first, then by times_cooked
+    # This prioritizes recipes the user has already saved while also
+    # showing new recipes they might be interested in based on the tag pattern
+    def sort_key(recipe):
+        is_saved = 1 if recipe.id in saved_recipe_ids else 0
+        return (-is_saved, -recipe.times_cooked)  # Negative for descending order
+
+    matching_recipes.sort(key=sort_key)
+    recipes = matching_recipes[:limit]
+
+    logger.info(f"Found {len(recipes)} recipes for tag '{tag}' for user {user_id}")
+    return recipes
+
+
+def get_recipes_by_source(user_id: UUID, db: Session, source_type: str, limit: int = 10) -> list[Recipe]:
+    """
+    Get recipes from a specific source type, mixing saved and non-saved recipes.
+
+    Returns persisted recipes from the given source, prioritizing:
+    1. Saved recipes (user has rated/saved them)
+    2. Non-saved recipes ordered by times_cooked descending
+
+    Args:
+        user_id: User ID for determining saved status
+        db: Database session
+        source_type: Source type to filter recipes by
+        limit: Maximum number of recipes to return (default 10)
+
+    Returns:
+        List of Recipe objects from the specified source
+    """
+    # Get recipes from this source
+    matching_recipes = (
+        db.query(Recipe)
+        .filter(Recipe.is_persisted == True)  # noqa: E712
+        .filter(Recipe.source_type == source_type)
+        .all()
+    )
+
+    # Get IDs of recipes user has saved
+    saved_recipe_ids = {
+        rating.recipe_id
+        for rating in db.query(UserRecipeRating.recipe_id)
+        .filter(UserRecipeRating.user_id == user_id)
+        .all()
+    }
+
+    # Sort: saved recipes first, then by times_cooked
+    def sort_key(recipe):
+        is_saved = 1 if recipe.id in saved_recipe_ids else 0
+        return (-is_saved, -recipe.times_cooked)
+
+    matching_recipes.sort(key=sort_key)
+    recipes = matching_recipes[:limit]
+
+    logger.info(f"Found {len(recipes)} recipes from source '{source_type}' for user {user_id}")
+    return recipes
+
+
+def get_popular_recipes(db: Session, limit: int = 10) -> list[Recipe]:
+    """
+    Get popular recipes sorted by times cooked.
+
+    Fallback row for cold start or variety.
+
+    Args:
+        db: Database session
+        limit: Maximum number of recipes to return (default 10)
+
+    Returns:
+        List of Recipe objects sorted by times_cooked descending
+    """
+    query = (
+        db.query(Recipe)
+        .filter(Recipe.is_persisted == True)  # noqa: E712
+        .filter(Recipe.times_cooked > 0)
+        .order_by(Recipe.times_cooked.desc())
+        .limit(limit)
+    )
+
+    recipes = query.all()
+    logger.info(f"Found {len(recipes)} popular recipes")
+    return recipes
+
+
+def get_quick_recipes(db: Session, limit: int = 10) -> list[Recipe]:
+    """
+    Get quick meal recipes (cook time <= 30 minutes).
+
+    Fallback row for cold start or variety.
+
+    Args:
+        db: Database session
+        limit: Maximum number of recipes to return (default 10)
+
+    Returns:
+        List of Recipe objects with cook_time_minutes <= 30
+    """
+    query = (
+        db.query(Recipe)
+        .filter(Recipe.is_persisted == True)  # noqa: E712
+        .filter(Recipe.cook_time_minutes.isnot(None))
+        .filter(Recipe.cook_time_minutes <= 30)
+        .order_by(Recipe.times_cooked.desc())
+        .limit(limit)
+    )
+
+    recipes = query.all()
+    logger.info(f"Found {len(recipes)} quick recipes")
+    return recipes
+
+
+def get_new_recipes(db: Session, limit: int = 10) -> list[Recipe]:
+    """
+    Get recently created recipes.
+
+    Fallback row for cold start or variety.
+
+    Args:
+        db: Database session
+        limit: Maximum number of recipes to return (default 10)
+
+    Returns:
+        List of Recipe objects sorted by created_at descending
+    """
+    query = (
+        db.query(Recipe)
+        .filter(Recipe.is_persisted == True)  # noqa: E712
+        .order_by(Recipe.created_at.desc())
+        .limit(limit)
+    )
+
+    recipes = query.all()
+    logger.info(f"Found {len(recipes)} new recipes")
+    return recipes
+
+
+def build_personalized_rows(user_id: UUID, db: Session, max_rows: int = 4) -> list[dict]:
+    """
+    Build personalized feed rows based on user's tag patterns.
+
+    Detects tags user frequently saves (>=3 saves) and creates rows with
+    recipes matching those tags. Each row includes both saved and non-saved
+    recipes to encourage discovery.
+
+    Args:
+        user_id: User ID to build personalized rows for
+        db: Database session
+        max_rows: Maximum number of rows to generate (default 4)
+
+    Returns:
+        List of row dicts with {title, recipes, browse_url}
+    """
+    tag_patterns = get_user_tag_patterns(user_id, db, min_saves=3)
+    rows = []
+
+    for tag, _count in tag_patterns[:max_rows]:
+        recipes = get_recipes_by_tag(user_id, db, tag, limit=10)
+        if recipes:
+            # Format tag for display: capitalize first letter, add period
+            display_tag = tag.capitalize() if tag else tag
+            rows.append({
+                "title": f"{display_tag}.",
+                "recipes": recipes,
+                "browse_url": f"/feed/browse?tag={tag}"
+            })
+
+    logger.info(f"Built {len(rows)} personalized rows for user {user_id}")
+    return rows
+
+
+def build_source_rows(user_id: UUID, db: Session, max_rows: int = 2) -> list[dict]:
+    """
+    Build source-specific feed rows based on user's source patterns.
+
+    Detects sources user frequently saves from (>=5 saves) and creates rows
+    with recipes from those sources. Each row includes both saved and non-saved
+    recipes to encourage discovery.
+
+    Args:
+        user_id: User ID to build source rows for
+        db: Database session
+        max_rows: Maximum number of rows to generate (default 2)
+
+    Returns:
+        List of row dicts with {title, recipes, browse_url}
+    """
+    source_patterns = get_user_source_patterns(user_id, db, min_saves=5)
+    rows = []
+
+    # Map source_type to display name
+    source_display_names = {
+        "hellofresh_card": "HelloFresh",
+        "hellofresh_web": "HelloFresh",
+        "kitchen_sanctuary": "Kitchen Sanctuary",
+        "url_import": "URL imports",
+        "manual": "Manual entries",
+        "photo_upload": "Photo uploads",
+        "ad_hoc": "Ad-hoc recipes"
+    }
+
+    for source_type, _count in source_patterns[:max_rows]:
+        recipes = get_recipes_by_source(user_id, db, source_type, limit=10)
+        if recipes:
+            display_name = source_display_names.get(source_type, source_type.replace("_", " ").title())
+            rows.append({
+                "title": f"From {display_name}.",
+                "recipes": recipes,
+                "browse_url": f"/feed/browse?source={source_type}"
+            })
+
+    logger.info(f"Built {len(rows)} source rows for user {user_id}")
+    return rows
+
+
+def build_fallback_rows(db: Session) -> list[dict]:
+    """
+    Build fallback feed rows for cold start or variety.
+
+    Returns three standard rows:
+    - Popular recipes (by times_cooked)
+    - Quick meals (cook_time <= 30 minutes)
+    - New recipes (recently created)
+
+    Args:
+        db: Database session
+
+    Returns:
+        List of row dicts with {title, recipes, browse_url}
+    """
+    rows = []
+
+    # Popular recipes
+    popular_recipes = get_popular_recipes(db, limit=10)
+    if popular_recipes:
+        rows.append({
+            "title": "Popular recipes.",
+            "recipes": popular_recipes,
+            "browse_url": "/feed/browse?sort=popular"
+        })
+
+    # Quick meals
+    quick_recipes = get_quick_recipes(db, limit=10)
+    if quick_recipes:
+        rows.append({
+            "title": "Quick meals.",
+            "recipes": quick_recipes,
+            "browse_url": "/feed/browse?quick=true"
+        })
+
+    # New recipes
+    new_recipes = get_new_recipes(db, limit=10)
+    if new_recipes:
+        rows.append({
+            "title": "New recipes.",
+            "recipes": new_recipes,
+            "browse_url": "/feed/browse?sort=newest"
+        })
+
+    logger.info(f"Built {len(rows)} fallback rows")
+    return rows

--- a/tests/routers/test_feed.py
+++ b/tests/routers/test_feed.py
@@ -483,3 +483,608 @@ class TestHomeFeed:
 
         # On Repeat should be empty (no ratings yet)
         assert len(data["on_repeat"]["recipes"]) == 0
+
+    def test_home_feed_includes_new_row_fields(self, client, auth_headers, test_user, db_session):
+        """Test home feed response includes new personalized/source/fallback row fields."""
+        response = client.get("/feed/home", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should have new fields
+        assert "personalized_rows" in data
+        assert "source_rows" in data
+        assert "fallback_rows" in data
+
+        # Fields should be arrays
+        assert isinstance(data["personalized_rows"], list)
+        assert isinstance(data["source_rows"], list)
+        assert isinstance(data["fallback_rows"], list)
+
+
+class TestPersonalizedRows:
+    """Test personalized rows (tag-based patterns)."""
+
+    def test_personalized_rows_detect_tag_patterns(self, client, auth_headers, test_user, db_session):
+        """Test personalized rows detect user's tag patterns from saved recipes."""
+        # Create recipes with tags
+        recipe1 = Recipe(
+            id=uuid4(),
+            name="Indian Curry",
+            source_type="manual",
+            is_persisted=True,
+            tags=["indian", "spicy"],
+            times_cooked=5
+        )
+        recipe2 = Recipe(
+            id=uuid4(),
+            name="Indian Tikka",
+            source_type="manual",
+            is_persisted=True,
+            tags=["indian", "grilled"],
+            times_cooked=3
+        )
+        recipe3 = Recipe(
+            id=uuid4(),
+            name="Indian Biryani",
+            source_type="manual",
+            is_persisted=True,
+            tags=["indian", "rice"],
+            times_cooked=7
+        )
+        # Another recipe with indian tag (not saved)
+        recipe4 = Recipe(
+            id=uuid4(),
+            name="Indian Dal",
+            source_type="manual",
+            is_persisted=True,
+            tags=["indian", "vegetarian"],
+            times_cooked=2
+        )
+        db_session.add_all([recipe1, recipe2, recipe3, recipe4])
+        db_session.commit()
+
+        # User saves 3 recipes with "indian" tag (meets >=3 threshold)
+        rating1 = UserRecipeRating(
+            id=uuid4(),
+            user_id=test_user.id,
+            recipe_id=recipe1.id,
+            rating=5.0
+        )
+        rating2 = UserRecipeRating(
+            id=uuid4(),
+            user_id=test_user.id,
+            recipe_id=recipe2.id,
+            rating=4.0
+        )
+        rating3 = UserRecipeRating(
+            id=uuid4(),
+            user_id=test_user.id,
+            recipe_id=recipe3.id,
+            rating=5.0
+        )
+        db_session.add_all([rating1, rating2, rating3])
+        db_session.commit()
+
+        # Call endpoint
+        response = client.get("/feed/home", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should have at least one personalized row for "indian" tag
+        assert len(data["personalized_rows"]) >= 1
+
+        # Check first row is for indian cuisine
+        indian_row = data["personalized_rows"][0]
+        assert "indian" in indian_row["title"].lower()
+        assert indian_row["title"].endswith(".")  # Design system: period at end
+        assert len(indian_row["recipes"]) >= 3  # Should include saved + non-saved
+
+        # Row should include browse_url
+        assert indian_row["browse_url"] is not None
+        assert "tag=indian" in indian_row["browse_url"]
+
+    def test_personalized_rows_mix_saved_and_non_saved(self, client, auth_headers, test_user, db_session):
+        """Test personalized rows include both saved and non-saved recipes."""
+        # Create multiple recipes with same tag
+        recipes = []
+        for i in range(8):
+            recipe = Recipe(
+                id=uuid4(),
+                name=f"Vegan Recipe {i}",
+                source_type="manual",
+                is_persisted=True,
+                tags=["vegan"],
+                times_cooked=i + 1
+            )
+            recipes.append(recipe)
+            db_session.add(recipe)
+        db_session.commit()
+
+        # User saves only first 3 (meets >=3 threshold)
+        for i in range(3):
+            rating = UserRecipeRating(
+                id=uuid4(),
+                user_id=test_user.id,
+                recipe_id=recipes[i].id,
+                rating=5.0
+            )
+            db_session.add(rating)
+        db_session.commit()
+
+        # Call endpoint
+        response = client.get("/feed/home", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should have personalized row for vegan tag
+        assert len(data["personalized_rows"]) >= 1
+
+        vegan_row = data["personalized_rows"][0]
+        # Should have more than just saved recipes (includes non-saved for discovery)
+        assert len(vegan_row["recipes"]) > 3
+
+    def test_personalized_rows_respect_min_saves_threshold(self, client, auth_headers, test_user, db_session):
+        """Test personalized rows only include tags with >=3 saved recipes."""
+        # Create recipes with different tags
+        recipe1 = Recipe(
+            id=uuid4(),
+            name="One Off Recipe",
+            source_type="manual",
+            is_persisted=True,
+            tags=["rare_tag"],
+            times_cooked=1
+        )
+        recipe2 = Recipe(
+            id=uuid4(),
+            name="Another One Off",
+            source_type="manual",
+            is_persisted=True,
+            tags=["rare_tag"],
+            times_cooked=1
+        )
+        db_session.add_all([recipe1, recipe2])
+        db_session.commit()
+
+        # User saves only 2 recipes with "rare_tag" (below threshold)
+        rating1 = UserRecipeRating(
+            id=uuid4(),
+            user_id=test_user.id,
+            recipe_id=recipe1.id,
+            rating=5.0
+        )
+        rating2 = UserRecipeRating(
+            id=uuid4(),
+            user_id=test_user.id,
+            recipe_id=recipe2.id,
+            rating=4.0
+        )
+        db_session.add_all([rating1, rating2])
+        db_session.commit()
+
+        # Call endpoint
+        response = client.get("/feed/home", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should NOT have personalized row for "rare_tag" (below threshold)
+        for row in data["personalized_rows"]:
+            assert "rare_tag" not in row["title"].lower()
+
+    def test_personalized_rows_max_limit(self, client, auth_headers, test_user, db_session):
+        """Test personalized rows respect max limit of 4 rows."""
+        # Create recipes with 5 different tags, all meeting threshold
+        tags = ["italian", "mexican", "chinese", "japanese", "thai"]
+        for tag in tags:
+            for i in range(3):  # Create 3 recipes per tag to meet threshold
+                recipe = Recipe(
+                    id=uuid4(),
+                    name=f"{tag.title()} Recipe {i}",
+                    source_type="manual",
+                    is_persisted=True,
+                    tags=[tag],
+                    times_cooked=i + 1
+                )
+                db_session.add(recipe)
+                db_session.commit()
+
+                # User saves all recipes
+                rating = UserRecipeRating(
+                    id=uuid4(),
+                    user_id=test_user.id,
+                    recipe_id=recipe.id,
+                    rating=5.0
+                )
+                db_session.add(rating)
+        db_session.commit()
+
+        # Call endpoint
+        response = client.get("/feed/home", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should have at most 4 personalized rows (even though 5 tags qualify)
+        assert len(data["personalized_rows"]) <= 4
+
+
+class TestSourceRows:
+    """Test source-specific rows."""
+
+    def test_source_rows_detect_source_patterns(self, client, auth_headers, test_user, db_session):
+        """Test source rows detect user's source patterns from saved recipes."""
+        # Create 5 HelloFresh recipes (meets >=5 threshold)
+        for i in range(5):
+            recipe = Recipe(
+                id=uuid4(),
+                name=f"HelloFresh Recipe {i}",
+                source_type="hellofresh_web",
+                is_persisted=True,
+                times_cooked=i + 1
+            )
+            db_session.add(recipe)
+            db_session.commit()
+
+            # User saves all
+            rating = UserRecipeRating(
+                id=uuid4(),
+                user_id=test_user.id,
+                recipe_id=recipe.id,
+                rating=5.0
+            )
+            db_session.add(rating)
+        db_session.commit()
+
+        # Call endpoint
+        response = client.get("/feed/home", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should have at least one source row
+        assert len(data["source_rows"]) >= 1
+
+        # Check first row is for HelloFresh
+        hf_row = data["source_rows"][0]
+        assert "HelloFresh" in hf_row["title"]
+        assert hf_row["title"].endswith(".")  # Design system
+        assert len(hf_row["recipes"]) >= 5
+
+        # Row should include browse_url
+        assert hf_row["browse_url"] is not None
+        assert "source=hellofresh" in hf_row["browse_url"]
+
+    def test_source_rows_respect_min_saves_threshold(self, client, auth_headers, test_user, db_session):
+        """Test source rows only include sources with >=5 saved recipes."""
+        # Create 4 recipes from manual source (below threshold)
+        for i in range(4):
+            recipe = Recipe(
+                id=uuid4(),
+                name=f"Manual Recipe {i}",
+                source_type="manual",
+                is_persisted=True,
+                times_cooked=i + 1
+            )
+            db_session.add(recipe)
+            db_session.commit()
+
+            rating = UserRecipeRating(
+                id=uuid4(),
+                user_id=test_user.id,
+                recipe_id=recipe.id,
+                rating=5.0
+            )
+            db_session.add(rating)
+        db_session.commit()
+
+        # Call endpoint
+        response = client.get("/feed/home", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should NOT have source row for "manual" (below threshold)
+        for row in data["source_rows"]:
+            assert "manual" not in row["title"].lower()
+
+    def test_source_rows_max_limit(self, client, auth_headers, test_user, db_session):
+        """Test source rows respect max limit of 2 rows."""
+        # Create 3 different sources, all meeting threshold
+        sources = ["hellofresh_web", "kitchen_sanctuary", "url_import"]
+        for source in sources:
+            for i in range(5):  # Create 5 recipes per source
+                recipe = Recipe(
+                    id=uuid4(),
+                    name=f"{source} Recipe {i}",
+                    source_type=source,
+                    is_persisted=True,
+                    times_cooked=i + 1
+                )
+                db_session.add(recipe)
+                db_session.commit()
+
+                rating = UserRecipeRating(
+                    id=uuid4(),
+                    user_id=test_user.id,
+                    recipe_id=recipe.id,
+                    rating=5.0
+                )
+                db_session.add(rating)
+        db_session.commit()
+
+        # Call endpoint
+        response = client.get("/feed/home", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should have at most 2 source rows (even though 3 sources qualify)
+        assert len(data["source_rows"]) <= 2
+
+
+class TestFallbackRows:
+    """Test fallback rows (Popular/Quick/New)."""
+
+    def test_fallback_rows_include_popular_quick_new(self, client, auth_headers, test_user, db_session):
+        """Test fallback rows include Popular, Quick, and New sections."""
+        # Create popular recipe (high times_cooked)
+        popular_recipe = Recipe(
+            id=uuid4(),
+            name="Very Popular Recipe",
+            source_type="manual",
+            is_persisted=True,
+            times_cooked=50,
+            cook_time_minutes=45
+        )
+        # Create quick recipe (cook_time <= 30)
+        quick_recipe = Recipe(
+            id=uuid4(),
+            name="Quick Recipe",
+            source_type="manual",
+            is_persisted=True,
+            times_cooked=5,
+            cook_time_minutes=20
+        )
+        # Create new recipe (recent created_at)
+        new_recipe = Recipe(
+            id=uuid4(),
+            name="Brand New Recipe",
+            source_type="manual",
+            is_persisted=True,
+            times_cooked=1,
+            cook_time_minutes=60,
+            created_at=datetime.now() - timedelta(hours=1)
+        )
+        db_session.add_all([popular_recipe, quick_recipe, new_recipe])
+        db_session.commit()
+
+        # Call endpoint
+        response = client.get("/feed/home", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should have 3 fallback rows
+        assert len(data["fallback_rows"]) == 3
+
+        # Check row titles
+        titles = [row["title"] for row in data["fallback_rows"]]
+        assert "Popular recipes." in titles
+        assert "Quick meals." in titles
+        assert "New recipes." in titles
+
+        # Each row should have browse_url
+        for row in data["fallback_rows"]:
+            assert row["browse_url"] is not None
+
+    def test_fallback_rows_popular_sorted_by_times_cooked(self, client, auth_headers, test_user, db_session):
+        """Test Popular recipes row sorted by times_cooked descending."""
+        # Create recipes with different times_cooked
+        recipe1 = Recipe(
+            id=uuid4(),
+            name="Most Popular",
+            source_type="manual",
+            is_persisted=True,
+            times_cooked=100
+        )
+        recipe2 = Recipe(
+            id=uuid4(),
+            name="Medium Popular",
+            source_type="manual",
+            is_persisted=True,
+            times_cooked=50
+        )
+        recipe3 = Recipe(
+            id=uuid4(),
+            name="Less Popular",
+            source_type="manual",
+            is_persisted=True,
+            times_cooked=10
+        )
+        db_session.add_all([recipe1, recipe2, recipe3])
+        db_session.commit()
+
+        # Call endpoint
+        response = client.get("/feed/home", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Find Popular recipes row
+        popular_row = next(
+            (row for row in data["fallback_rows"] if "Popular" in row["title"]),
+            None
+        )
+        assert popular_row is not None
+
+        # Should be sorted by times_cooked descending
+        recipes = popular_row["recipes"]
+        assert recipes[0]["name"] == "Most Popular"
+        assert recipes[1]["name"] == "Medium Popular"
+        assert recipes[2]["name"] == "Less Popular"
+
+    def test_fallback_rows_quick_filtered_by_cook_time(self, client, auth_headers, test_user, db_session):
+        """Test Quick meals row only includes recipes with cook_time <= 30."""
+        # Create quick recipe
+        quick_recipe = Recipe(
+            id=uuid4(),
+            name="Quick Recipe",
+            source_type="manual",
+            is_persisted=True,
+            cook_time_minutes=25,
+            times_cooked=5
+        )
+        # Create slow recipe
+        slow_recipe = Recipe(
+            id=uuid4(),
+            name="Slow Recipe",
+            source_type="manual",
+            is_persisted=True,
+            cook_time_minutes=60,
+            times_cooked=10
+        )
+        db_session.add_all([quick_recipe, slow_recipe])
+        db_session.commit()
+
+        # Call endpoint
+        response = client.get("/feed/home", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Find Quick meals row
+        quick_row = next(
+            (row for row in data["fallback_rows"] if "Quick" in row["title"]),
+            None
+        )
+        assert quick_row is not None
+
+        # Should only include quick recipe
+        recipe_names = [r["name"] for r in quick_row["recipes"]]
+        assert "Quick Recipe" in recipe_names
+        assert "Slow Recipe" not in recipe_names
+
+    def test_fallback_rows_new_sorted_by_created_at(self, client, auth_headers, test_user, db_session):
+        """Test New recipes row sorted by created_at descending."""
+        # Create recipes with different created_at times
+        recipe1 = Recipe(
+            id=uuid4(),
+            name="Newest",
+            source_type="manual",
+            is_persisted=True,
+            created_at=datetime.now() - timedelta(hours=1)
+        )
+        recipe2 = Recipe(
+            id=uuid4(),
+            name="Middle",
+            source_type="manual",
+            is_persisted=True,
+            created_at=datetime.now() - timedelta(days=1)
+        )
+        recipe3 = Recipe(
+            id=uuid4(),
+            name="Oldest",
+            source_type="manual",
+            is_persisted=True,
+            created_at=datetime.now() - timedelta(days=7)
+        )
+        db_session.add_all([recipe1, recipe2, recipe3])
+        db_session.commit()
+
+        # Call endpoint
+        response = client.get("/feed/home", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Find New recipes row
+        new_row = next(
+            (row for row in data["fallback_rows"] if "New" in row["title"]),
+            None
+        )
+        assert new_row is not None
+
+        # Should be sorted by created_at descending
+        recipes = new_row["recipes"]
+        assert recipes[0]["name"] == "Newest"
+        assert recipes[1]["name"] == "Middle"
+        assert recipes[2]["name"] == "Oldest"
+
+
+class TestBrowseEndpoint:
+    """Test /feed/browse endpoint."""
+
+    def test_browse_requires_authentication(self, client):
+        """Test browse endpoint requires authentication."""
+        response = client.get("/feed/browse")
+        assert response.status_code == 401
+
+    def test_browse_returns_all_sections(self, client, auth_headers, test_user, db_session):
+        """Test browse endpoint returns all carousel sections."""
+        # Create some recipes for fallback rows
+        recipe = Recipe(
+            id=uuid4(),
+            name="Test Recipe",
+            source_type="manual",
+            is_persisted=True,
+            times_cooked=10,
+            cook_time_minutes=25
+        )
+        db_session.add(recipe)
+        db_session.commit()
+
+        # Call endpoint
+        response = client.get("/feed/browse", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should have sections field
+        assert "sections" in data
+        assert isinstance(data["sections"], list)
+
+        # Should have at least fallback rows
+        assert len(data["sections"]) >= 1
+
+    def test_browse_combines_personalized_source_fallback(self, client, auth_headers, test_user, db_session):
+        """Test browse endpoint combines personalized, source, and fallback rows."""
+        # Create recipes with tags (for personalized rows)
+        for i in range(3):
+            recipe = Recipe(
+                id=uuid4(),
+                name=f"Italian Recipe {i}",
+                source_type="manual",
+                is_persisted=True,
+                tags=["italian"],
+                times_cooked=i + 1,  # Needed for "Popular recipes" row
+                cook_time_minutes=25  # Needed for "Quick meals" row
+            )
+            db_session.add(recipe)
+            db_session.commit()
+
+            rating = UserRecipeRating(
+                id=uuid4(),
+                user_id=test_user.id,
+                recipe_id=recipe.id,
+                rating=5.0
+            )
+            db_session.add(rating)
+        db_session.commit()
+
+        # Call endpoint
+        response = client.get("/feed/browse", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should have multiple sections (personalized + fallback)
+        assert len(data["sections"]) >= 4  # At least 1 personalized + 3 fallback
+
+        # Sections should have required fields
+        for section in data["sections"]:
+            assert "title" in section
+            assert "recipes" in section
+            assert section["title"].endswith(".")  # Design system


### PR DESCRIPTION
## Work in Progress

Closes #478

Add personalized rows and browse endpoint

**Time Estimate**: 2hr

**Description**:
Extend feed service with dynamic personalized rows (pattern detection), source-specific rows, and fallback rows. Add `GET /feed/browse` endpoint for the recipe browse page.

**Claude Context**:
Files to Read:
- src/services/feed_service.py (core queries from #11)
- docs/implementation-plan-recipe-engagement.md (Section 3.4, 3.5, 3.7)

Files to Modify:
- src/services/feed_service.py (add pattern detection queries)
- src/routers/feed.py (add browse endpoint, extend home response)
- src/schemas/feed.py (add row schemas)
- tests/routers/test_feed.py (add pattern/source/fallback tests)

Related Issues: #11 (needs core feed service)

**Acceptance Criteria**:
- [ ] Pattern detection: find top tags/source_types by user save count (>=3 saves threshold)
- [ ] `GET /feed/home` extended with: personalized_rows (3-4 max), source_rows (2 max, >=5 saves), fallback_rows
- [ ] Personalized rows include both saved and non-persisted recipes matching pattern
- [ ] Source rows include browse_url for "See all" expansion
- [ ] Fallback rows: "Popular recipes" (by times_cooked), "Quick meals" (cook_time<=30), "New recipes" (recent created_at)
- [ ] `GET /feed/browse` returns: search-compatible structure with all carousel sections
- [ ] Row titles follow design system: "Indian cuisine.", "From HelloFresh.", "Quick meals."
- [ ] Cold start: personalized/source rows empty → fill with fallback rows
- [ ] Tests: pattern detection finds top tags, source rows threshold, fallback content

**Verification Commands**:
```bash
.venv/bin/python -m pytest tests/routers/test_feed.py -x -q
```

**Done Definition**: Done when /feed/home returns all row types and /feed/browse exists.

**Scope Boundary**:
- DO: Implement pattern detection, source rows, fallback rows, browse endpoint
- DO NOT: Implement filter param on browse (basic browse only for now)

**Dependencies**: After #11 (needs: core feed service)

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**4** files, **2** commits (+0 added, ~4 modified, -0 deleted)
- `M` src/routers/feed.py
- `M` src/schemas/feed.py
- `M` src/services/feed_service.py
- `M` tests/routers/test_feed.py

### Commits
- a65af70 feat: Add personalized rows and browse endpoint
- 5e7a1ba chore: initialize work on #478 Add personalized rows and browse endpoint
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues
Created: #493 
**From assessment on 2026-05-03T23:55:12Z:**
- Created: #491 
- Updated: none