### PR TITLE
[Phase 2.5D] Implement auto-generated menus

### DIFF
--- a/alembic/versions/oi0jpexw8quw_add_is_persisted_to_recipes.py
+++ b/alembic/versions/oi0jpexw8quw_add_is_persisted_to_recipes.py
@@ -1,0 +1,30 @@
+"""add is_persisted to recipes
+
+Revision ID: oi0jpexw8quw
+Revises: nh9iocxw7qtv
+Create Date: 2026-05-03 17:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'oi0jpexw8quw'
+down_revision: Union[str, None] = 'nh9iocxw7qtv'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add is_persisted column to recipes table with default true."""
+    with op.batch_alter_table('recipes', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('is_persisted', sa.Boolean(), nullable=False, server_default='1'))
+
+
+def downgrade() -> None:
+    """Remove is_persisted column from recipes table."""
+    with op.batch_alter_table('recipes', schema=None) as batch_op:
+        batch_op.drop_column('is_persisted')

--- a/alembic/versions/oi0jpexw8quw_add_is_persisted_to_recipes.py
+++ b/alembic/versions/oi0jpexw8quw_add_is_persisted_to_recipes.py
@@ -22,9 +22,11 @@ def upgrade() -> None:
     """Add is_persisted column to recipes table with default true."""
     with op.batch_alter_table('recipes', schema=None) as batch_op:
         batch_op.add_column(sa.Column('is_persisted', sa.Boolean(), nullable=False, server_default='1'))
+        batch_op.create_index('ix_recipes_is_persisted', ['is_persisted'])
 
 
 def downgrade() -> None:
     """Remove is_persisted column from recipes table."""
     with op.batch_alter_table('recipes', schema=None) as batch_op:
+        batch_op.drop_index('ix_recipes_is_persisted')
         batch_op.drop_column('is_persisted')

--- a/alembic/versions/pj1kqfxy9rvw_rename_user_recipe_rating_to_relation.py
+++ b/alembic/versions/pj1kqfxy9rvw_rename_user_recipe_rating_to_relation.py
@@ -1,0 +1,102 @@
+"""rename user_recipe_rating to relation
+
+Revision ID: pj1kqfxy9rvw
+Revises: oi0jpexw8quw
+Create Date: 2026-05-03 17:15:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'pj1kqfxy9rvw'
+down_revision: Union[str, None] = 'oi0jpexw8quw'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """
+    Rename user_recipe_ratings table to user_recipe_relations and add new fields.
+
+    Migration sequence:
+    1. Rename table
+    2. Add new columns
+    3. Migrate data from old columns to new columns
+    4. Drop old columns
+    5. Rename unique constraint
+    """
+    # Step 1: Rename table and update constraint
+    with op.batch_alter_table('user_recipe_ratings', schema=None) as batch_op:
+        batch_op.drop_constraint('uq_user_recipe_rating', type_='unique')
+
+    op.rename_table('user_recipe_ratings', 'user_recipe_relations')
+
+    # Step 2: Add new columns
+    with op.batch_alter_table('user_recipe_relations', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('is_bookmarked', sa.Boolean(), nullable=False, server_default='0'))
+        batch_op.add_column(sa.Column('is_liked', sa.Boolean(), nullable=False, server_default='0'))
+        batch_op.add_column(sa.Column('rating_photos', sa.JSON(), nullable=True))
+        batch_op.add_column(sa.Column('rating_comment', sa.String(2000), nullable=True))
+        batch_op.add_column(sa.Column('menu_id', sa.UUID(), nullable=True))
+
+        # Add foreign key for menu_id (references future menus table)
+        # Note: This FK will be validated when menus table is created
+        batch_op.create_foreign_key(
+            'fk_user_recipe_relations_menu_id_menus',
+            'menus',
+            ['menu_id'],
+            ['id']
+        )
+
+        # Add renamed unique constraint
+        batch_op.create_unique_constraint('uq_user_recipe_relation', ['user_id', 'recipe_id'])
+
+    # Step 3: Migrate data - copy is_favorite to is_bookmarked, notes to rating_comment
+    op.execute(
+        'UPDATE user_recipe_relations SET is_bookmarked = is_favorite WHERE is_favorite = 1'
+    )
+    op.execute(
+        'UPDATE user_recipe_relations SET rating_comment = notes WHERE notes IS NOT NULL'
+    )
+
+    # Step 4: Drop old columns
+    with op.batch_alter_table('user_recipe_relations', schema=None) as batch_op:
+        batch_op.drop_column('is_favorite')
+        batch_op.drop_column('notes')
+
+
+def downgrade() -> None:
+    """Reverse the migration - restore user_recipe_ratings table."""
+    # Add back old columns
+    with op.batch_alter_table('user_recipe_relations', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('is_favorite', sa.Boolean(), nullable=False, server_default='0'))
+        batch_op.add_column(sa.Column('notes', sa.String(1000), nullable=True))
+
+    # Migrate data back
+    op.execute(
+        'UPDATE user_recipe_relations SET is_favorite = is_bookmarked WHERE is_bookmarked = 1'
+    )
+    op.execute(
+        'UPDATE user_recipe_relations SET notes = SUBSTR(rating_comment, 1, 1000) WHERE rating_comment IS NOT NULL'
+    )
+
+    # Drop new columns
+    with op.batch_alter_table('user_recipe_relations', schema=None) as batch_op:
+        batch_op.drop_constraint('fk_user_recipe_relations_menu_id_menus', type_='foreignkey')
+        batch_op.drop_constraint('uq_user_recipe_relation', type_='unique')
+        batch_op.drop_column('menu_id')
+        batch_op.drop_column('rating_comment')
+        batch_op.drop_column('rating_photos')
+        batch_op.drop_column('is_liked')
+        batch_op.drop_column('is_bookmarked')
+
+    # Rename table back
+    op.rename_table('user_recipe_relations', 'user_recipe_ratings')
+
+    # Restore original constraint
+    with op.batch_alter_table('user_recipe_ratings', schema=None) as batch_op:
+        batch_op.create_unique_constraint('uq_user_recipe_rating', ['user_id', 'recipe_id'])

--- a/alembic/versions/pj1kqfxy9rvw_rename_user_recipe_rating_to_relation.py
+++ b/alembic/versions/pj1kqfxy9rvw_rename_user_recipe_rating_to_relation.py
@@ -70,6 +70,10 @@ def downgrade() -> None:
     op.execute(
         'UPDATE user_recipe_relations SET is_favorite = is_bookmarked WHERE is_bookmarked = 1'
     )
+    # WARNING: notes is varchar(1000) but rating_comment is varchar(2000).
+    # SUBSTR silently truncates anything over 1000 chars on downgrade.
+    # Acceptable because downgrades are rare and only run intentionally,
+    # but be aware data loss is possible if users wrote long comments.
     op.execute(
         'UPDATE user_recipe_relations SET notes = SUBSTR(rating_comment, 1, 1000) WHERE rating_comment IS NOT NULL'
     )

--- a/alembic/versions/pj1kqfxy9rvw_rename_user_recipe_rating_to_relation.py
+++ b/alembic/versions/pj1kqfxy9rvw_rename_user_recipe_rating_to_relation.py
@@ -41,16 +41,6 @@ def upgrade() -> None:
         batch_op.add_column(sa.Column('is_liked', sa.Boolean(), nullable=False, server_default='0'))
         batch_op.add_column(sa.Column('rating_photos', sa.JSON(), nullable=True))
         batch_op.add_column(sa.Column('rating_comment', sa.String(2000), nullable=True))
-        batch_op.add_column(sa.Column('menu_id', sa.UUID(), nullable=True))
-
-        # Add foreign key for menu_id (references future menus table)
-        # Note: This FK will be validated when menus table is created
-        batch_op.create_foreign_key(
-            'fk_user_recipe_relations_menu_id_menus',
-            'menus',
-            ['menu_id'],
-            ['id']
-        )
 
         # Add renamed unique constraint
         batch_op.create_unique_constraint('uq_user_recipe_relation', ['user_id', 'recipe_id'])
@@ -86,9 +76,7 @@ def downgrade() -> None:
 
     # Drop new columns
     with op.batch_alter_table('user_recipe_relations', schema=None) as batch_op:
-        batch_op.drop_constraint('fk_user_recipe_relations_menu_id_menus', type_='foreignkey')
         batch_op.drop_constraint('uq_user_recipe_relation', type_='unique')
-        batch_op.drop_column('menu_id')
         batch_op.drop_column('rating_comment')
         batch_op.drop_column('rating_photos')
         batch_op.drop_column('is_liked')

--- a/alembic/versions/qk2lrgyz0swx_create_menu_and_menu_recipe_tables.py
+++ b/alembic/versions/qk2lrgyz0swx_create_menu_and_menu_recipe_tables.py
@@ -51,7 +51,7 @@ def upgrade() -> None:
         sa.Column('added_at', sa.DateTime(), server_default=sa.func.now(), nullable=False),
         sa.PrimaryKeyConstraint('menu_id', 'recipe_id'),
         sa.ForeignKeyConstraint(['menu_id'], ['menus.id'], name='fk_menu_recipes_menu_id_menus'),
-        sa.ForeignKeyConstraint(['recipe_id'], ['recipes.id'], name='fk_menu_recipes_recipe_id_recipes'),
+        sa.ForeignKeyConstraint(['recipe_id'], ['recipes.id'], name='fk_menu_recipes_recipe_id_recipes', ondelete='CASCADE'),
         sa.UniqueConstraint('menu_id', 'recipe_id', name='uq_menu_recipe'),
     )
 
@@ -64,12 +64,14 @@ def upgrade() -> None:
             ['menu_id'],
             ['id']
         )
+        batch_op.create_index('ix_user_recipe_relations_menu_id', ['menu_id'])
 
 
 def downgrade() -> None:
     """Drop menu_recipes and menus tables."""
     # Remove menu_id column from user_recipe_relations
     with op.batch_alter_table('user_recipe_relations', schema=None) as batch_op:
+        batch_op.drop_index('ix_user_recipe_relations_menu_id')
         batch_op.drop_constraint('fk_user_recipe_relations_menu_id_menus', type_='foreignkey')
         batch_op.drop_column('menu_id')
 

--- a/alembic/versions/qk2lrgyz0swx_create_menu_and_menu_recipe_tables.py
+++ b/alembic/versions/qk2lrgyz0swx_create_menu_and_menu_recipe_tables.py
@@ -55,6 +55,10 @@ def upgrade() -> None:
         sa.UniqueConstraint('menu_id', 'recipe_id', name='uq_menu_recipe'),
     )
 
+    # The composite PK indexes (menu_id, recipe_id) — leftmost-prefix only —
+    # so recipe_id-only lookups would full-scan without this.
+    op.create_index('ix_menu_recipes_recipe_id', 'menu_recipes', ['recipe_id'])
+
     # Add menu_id column to user_recipe_relations table (now that menus table exists)
     with op.batch_alter_table('user_recipe_relations', schema=None) as batch_op:
         batch_op.add_column(sa.Column('menu_id', sa.UUID(), nullable=True))
@@ -84,6 +88,7 @@ def downgrade() -> None:
         batch_op.drop_column('menu_id')
 
     # Drop tables
+    op.drop_index('ix_menu_recipes_recipe_id', table_name='menu_recipes')
     op.drop_table('menu_recipes')
     op.drop_index('ix_menus_user_id', table_name='menus')
     op.drop_table('menus')

--- a/alembic/versions/qk2lrgyz0swx_create_menu_and_menu_recipe_tables.py
+++ b/alembic/versions/qk2lrgyz0swx_create_menu_and_menu_recipe_tables.py
@@ -62,15 +62,23 @@ def upgrade() -> None:
             'fk_user_recipe_relations_menu_id_menus',
             'menus',
             ['menu_id'],
-            ['id']
+            ['id'],
+            ondelete='SET NULL'
         )
+        # Create index on the new menu_id FK
         batch_op.create_index('ix_user_recipe_relations_menu_id', ['menu_id'])
+        # Create missing indexes on existing FKs (user_id and recipe_id)
+        batch_op.create_index('ix_user_recipe_relations_user_id', ['user_id'])
+        batch_op.create_index('ix_user_recipe_relations_recipe_id', ['recipe_id'])
 
 
 def downgrade() -> None:
     """Drop menu_recipes and menus tables."""
     # Remove menu_id column from user_recipe_relations
     with op.batch_alter_table('user_recipe_relations', schema=None) as batch_op:
+        # Drop indexes created in upgrade (including the FK indexes we added)
+        batch_op.drop_index('ix_user_recipe_relations_recipe_id')
+        batch_op.drop_index('ix_user_recipe_relations_user_id')
         batch_op.drop_index('ix_user_recipe_relations_menu_id')
         batch_op.drop_constraint('fk_user_recipe_relations_menu_id_menus', type_='foreignkey')
         batch_op.drop_column('menu_id')

--- a/alembic/versions/qk2lrgyz0swx_create_menu_and_menu_recipe_tables.py
+++ b/alembic/versions/qk2lrgyz0swx_create_menu_and_menu_recipe_tables.py
@@ -37,6 +37,9 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(['user_id'], ['users.id'], name='fk_menus_user_id_users'),
     )
 
+    # Create index on user_id for efficient menu listing queries
+    op.create_index('ix_menus_user_id', 'menus', ['user_id'])
+
     # Create menu_recipes join table
     op.create_table(
         'menu_recipes',
@@ -52,8 +55,25 @@ def upgrade() -> None:
         sa.UniqueConstraint('menu_id', 'recipe_id', name='uq_menu_recipe'),
     )
 
+    # Add menu_id column to user_recipe_relations table (now that menus table exists)
+    with op.batch_alter_table('user_recipe_relations', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('menu_id', sa.UUID(), nullable=True))
+        batch_op.create_foreign_key(
+            'fk_user_recipe_relations_menu_id_menus',
+            'menus',
+            ['menu_id'],
+            ['id']
+        )
+
 
 def downgrade() -> None:
     """Drop menu_recipes and menus tables."""
+    # Remove menu_id column from user_recipe_relations
+    with op.batch_alter_table('user_recipe_relations', schema=None) as batch_op:
+        batch_op.drop_constraint('fk_user_recipe_relations_menu_id_menus', type_='foreignkey')
+        batch_op.drop_column('menu_id')
+
+    # Drop tables
     op.drop_table('menu_recipes')
+    op.drop_index('ix_menus_user_id', table_name='menus')
     op.drop_table('menus')

--- a/alembic/versions/qk2lrgyz0swx_create_menu_and_menu_recipe_tables.py
+++ b/alembic/versions/qk2lrgyz0swx_create_menu_and_menu_recipe_tables.py
@@ -1,0 +1,59 @@
+"""create menu and menu_recipe tables
+
+Revision ID: qk2lrgyz0swx
+Revises: pj1kqfxy9rvw
+Create Date: 2026-05-03 17:30:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'qk2lrgyz0swx'
+down_revision: Union[str, None] = 'pj1kqfxy9rvw'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create menus and menu_recipes tables."""
+    # Create menus table
+    op.create_table(
+        'menus',
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('user_id', sa.UUID(), nullable=False),
+        sa.Column('name', sa.String(255), nullable=False),
+        sa.Column('description', sa.String(500), nullable=True),
+        sa.Column('filter_rules', sa.JSON(), nullable=True),
+        sa.Column('is_auto_generated', sa.Boolean(), nullable=False, server_default='0'),
+        sa.Column('cover_image', sa.String(2048), nullable=True),
+        sa.Column('sort_order', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('created_at', sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], name='fk_menus_user_id_users'),
+    )
+
+    # Create menu_recipes join table
+    op.create_table(
+        'menu_recipes',
+        sa.Column('menu_id', sa.UUID(), nullable=False),
+        sa.Column('recipe_id', sa.UUID(), nullable=False),
+        sa.Column('sort_order', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('manually_added', sa.Boolean(), nullable=False, server_default='0'),
+        sa.Column('manually_removed', sa.Boolean(), nullable=False, server_default='0'),
+        sa.Column('added_at', sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint('menu_id', 'recipe_id'),
+        sa.ForeignKeyConstraint(['menu_id'], ['menus.id'], name='fk_menu_recipes_menu_id_menus'),
+        sa.ForeignKeyConstraint(['recipe_id'], ['recipes.id'], name='fk_menu_recipes_recipe_id_recipes'),
+        sa.UniqueConstraint('menu_id', 'recipe_id', name='uq_menu_recipe'),
+    )
+
+
+def downgrade() -> None:
+    """Drop menu_recipes and menus tables."""
+    op.drop_table('menu_recipes')
+    op.drop_table('menus')

--- a/src/db/models/__init__.py
+++ b/src/db/models/__init__.py
@@ -25,7 +25,8 @@ from src.db.models.meal_plan import (
 from src.db.models.grocery_list import GroceryListItem, GrocerySource
 from src.db.models.substitution import SubstitutionPreference, SubstitutionContext
 from src.db.models.consumption_pattern import ConsumptionPattern
-from src.db.models.user_recipe import UserRecipeRating
+from src.db.models.user_recipe import UserRecipeRelation
+from src.db.models.menu import Menu, MenuRecipe
 from src.db.models.processing_task import ProcessingTask, TaskType, TaskStatus
 
 __all__ = [
@@ -57,7 +58,9 @@ __all__ = [
     "SubstitutionPreference",
     "SubstitutionContext",
     "ConsumptionPattern",
-    "UserRecipeRating",
+    "UserRecipeRelation",
+    "Menu",
+    "MenuRecipe",
     "ProcessingTask",
     "TaskType",
     "TaskStatus",

--- a/src/db/models/menu.py
+++ b/src/db/models/menu.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import String, Integer, Boolean, ForeignKey, JSON, DateTime, func, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.db.database import Base
+
+
+class Menu(Base):
+    """
+    User-created recipe collections with optional auto-generation via filter rules.
+
+    Menus can be manually curated or auto-generated based on filter rules (e.g., dietary
+    preferences, tags, ratings). The MenuRecipe join table tracks manual additions/removals
+    to override auto-generated results.
+    """
+    __tablename__ = "menus"
+
+    id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
+    user_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"))
+    name: Mapped[str] = mapped_column(String(255))
+    description: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)
+    filter_rules: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
+    is_auto_generated: Mapped[bool] = mapped_column(Boolean, default=False)
+    cover_image: Mapped[Optional[str]] = mapped_column(String(2048), nullable=True)
+    sort_order: Mapped[int] = mapped_column(Integer, default=0)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), onupdate=func.now())
+
+    # Relationships
+    user_rel: Mapped["User"] = relationship(back_populates="menus")
+    menu_recipes: Mapped[list["MenuRecipe"]] = relationship(back_populates="menu_rel", cascade="all, delete-orphan")
+    user_recipe_relations: Mapped[list["UserRecipeRelation"]] = relationship(back_populates="menu_rel")
+
+
+class MenuRecipe(Base):
+    """
+    Join table for Menu-Recipe many-to-many relationship with ordering and manual override flags.
+
+    Tracks which recipes belong to which menus, plus metadata about manual user actions
+    (manually added/removed recipes override auto-generation rules).
+    """
+    __tablename__ = "menu_recipes"
+    __table_args__ = (
+        UniqueConstraint('menu_id', 'recipe_id', name='uq_menu_recipe'),
+    )
+
+    menu_id: Mapped[UUID] = mapped_column(ForeignKey("menus.id"), primary_key=True)
+    recipe_id: Mapped[UUID] = mapped_column(ForeignKey("recipes.id"), primary_key=True)
+    sort_order: Mapped[int] = mapped_column(Integer, default=0)
+    manually_added: Mapped[bool] = mapped_column(Boolean, default=False)
+    manually_removed: Mapped[bool] = mapped_column(Boolean, default=False)
+    added_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+
+    # Relationships
+    menu_rel: Mapped["Menu"] = relationship(back_populates="menu_recipes")
+    recipe_rel: Mapped["Recipe"] = relationship(back_populates="menu_recipes")

--- a/src/db/models/menu.py
+++ b/src/db/models/menu.py
@@ -50,7 +50,7 @@ class MenuRecipe(Base):
     )
 
     menu_id: Mapped[UUID] = mapped_column(ForeignKey("menus.id"), primary_key=True)
-    recipe_id: Mapped[UUID] = mapped_column(ForeignKey("recipes.id"), primary_key=True)
+    recipe_id: Mapped[UUID] = mapped_column(ForeignKey("recipes.id", ondelete="CASCADE"), primary_key=True)
     sort_order: Mapped[int] = mapped_column(Integer, default=0)
     manually_added: Mapped[bool] = mapped_column(Boolean, default=False)
     manually_removed: Mapped[bool] = mapped_column(Boolean, default=False)

--- a/src/db/models/recipe.py
+++ b/src/db/models/recipe.py
@@ -5,7 +5,7 @@ from uuid import UUID, uuid4
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import String, Integer, JSON, ForeignKey, DateTime, func
+from sqlalchemy import String, Integer, JSON, ForeignKey, DateTime, Boolean, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.db.database import Base
@@ -39,11 +39,13 @@ class Recipe(Base):
     times_cooked: Mapped[int] = mapped_column(Integer, default=0)
     created_by: Mapped[Optional[UUID]] = mapped_column(ForeignKey("users.id"), nullable=True)
     notes: Mapped[Optional[str]] = mapped_column(String(10000), nullable=True)
+    is_persisted: Mapped[bool] = mapped_column(Boolean, default=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), onupdate=func.now())
 
     # Relationships
     created_by_user: Mapped[Optional["User"]] = relationship(back_populates="recipes_created")
     ingredients: Mapped[list["RecipeIngredient"]] = relationship(back_populates="recipe_rel")
-    user_ratings: Mapped[list["UserRecipeRating"]] = relationship(back_populates="recipe_rel")
+    user_relations: Mapped[list["UserRecipeRelation"]] = relationship(back_populates="recipe_rel")
+    menu_recipes: Mapped[list["MenuRecipe"]] = relationship(back_populates="recipe_rel")
     prepared_foods: Mapped[list["PreparedFood"]] = relationship(back_populates="source_recipe_rel")

--- a/src/db/models/recipe.py
+++ b/src/db/models/recipe.py
@@ -40,7 +40,6 @@ class Recipe(Base):
     is_persisted: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     created_by: Mapped[Optional[UUID]] = mapped_column(ForeignKey("users.id"), nullable=True)
     notes: Mapped[Optional[str]] = mapped_column(String(10000), nullable=True)
-    is_persisted: Mapped[bool] = mapped_column(Boolean, default=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), onupdate=func.now())
 

--- a/src/db/models/user.py
+++ b/src/db/models/user.py
@@ -57,5 +57,6 @@ class User(Base):
         back_populates="added_by_user", foreign_keys="GroceryListItem.added_by"
     )
     substitution_preferences: Mapped[list["SubstitutionPreference"]] = relationship(back_populates="user_rel")
-    recipe_ratings: Mapped[list["UserRecipeRating"]] = relationship(back_populates="user_rel")
+    recipe_relations: Mapped[list["UserRecipeRelation"]] = relationship(back_populates="user_rel")
+    menus: Mapped[list["Menu"]] = relationship(back_populates="user_rel")
     audit_logs: Mapped[list["AuthAuditLog"]] = relationship(back_populates="user")

--- a/src/db/models/user_recipe.py
+++ b/src/db/models/user_recipe.py
@@ -4,27 +4,37 @@ from uuid import UUID, uuid4
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import String, Float, Boolean, ForeignKey, UniqueConstraint, DateTime, func
+from sqlalchemy import String, Float, Boolean, ForeignKey, UniqueConstraint, DateTime, JSON, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.db.database import Base
 
 
-class UserRecipeRating(Base):
-    __tablename__ = "user_recipe_ratings"
+class UserRecipeRelation(Base):
+    """
+    Tracks user engagement with recipes: ratings, bookmarks, likes, and menu associations.
+
+    Each user can have one relation record per recipe containing all their interactions
+    with that recipe (rating, bookmark status, like status, photos, comments).
+    """
+    __tablename__ = "user_recipe_relations"
     __table_args__ = (
-        UniqueConstraint('user_id', 'recipe_id', name='uq_user_recipe_rating'),
+        UniqueConstraint('user_id', 'recipe_id', name='uq_user_recipe_relation'),
     )
 
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
     user_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"))
     recipe_id: Mapped[UUID] = mapped_column(ForeignKey("recipes.id"))
     rating: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
-    is_favorite: Mapped[bool] = mapped_column(Boolean, default=False)
-    notes: Mapped[Optional[str]] = mapped_column(String(1000), nullable=True)
+    is_bookmarked: Mapped[bool] = mapped_column(Boolean, default=False)
+    is_liked: Mapped[bool] = mapped_column(Boolean, default=False)
+    rating_photos: Mapped[Optional[list]] = mapped_column(JSON, nullable=True)
+    rating_comment: Mapped[Optional[str]] = mapped_column(String(2000), nullable=True)
+    menu_id: Mapped[Optional[UUID]] = mapped_column(ForeignKey("menus.id"), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), onupdate=func.now())
 
     # Relationships
-    user_rel: Mapped["User"] = relationship(back_populates="recipe_ratings")
-    recipe_rel: Mapped["Recipe"] = relationship(back_populates="user_ratings")
+    user_rel: Mapped["User"] = relationship(back_populates="recipe_relations")
+    recipe_rel: Mapped["Recipe"] = relationship(back_populates="user_relations")
+    menu_rel: Mapped[Optional["Menu"]] = relationship(back_populates="user_recipe_relations")

--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,7 @@ from slowapi.errors import RateLimitExceeded
 
 from src.config import get_settings
 from src.db.database import Base, init_engine, get_engine, get_session_factory
-from src.routers import auth_router, users_router, substitutions_router, inventory_router, recipes_router, grocery_router, prepared_foods_router, scraper_router, tasks_router, receipts_router
+from src.routers import auth_router, users_router, substitutions_router, inventory_router, recipes_router, grocery_router, prepared_foods_router, scraper_router, tasks_router, receipts_router, feed_router, menus_router
 from src.middleware.rate_limit import limiter
 from src.services.task_worker import background_task_worker
 from src.services.cleanup_service import prune_unpersisted_recipes
@@ -134,6 +134,8 @@ app.include_router(prepared_foods_router)
 app.include_router(scraper_router)
 app.include_router(tasks_router)
 app.include_router(receipts_router)
+app.include_router(feed_router)
+app.include_router(menus_router)
 
 
 @app.get("/health")

--- a/src/routers/__init__.py
+++ b/src/routers/__init__.py
@@ -19,5 +19,6 @@ from src.routers.scraper import router as scraper_router
 from src.routers.tasks import router as tasks_router
 from src.routers.receipts import router as receipts_router
 from src.routers.feed import router as feed_router
+from src.routers.menus import router as menus_router
 
-__all__ = ["auth_router", "users_router", "substitutions_router", "inventory_router", "recipes_router", "grocery_router", "prepared_foods_router", "scraper_router", "tasks_router", "receipts_router", "feed_router"]
+__all__ = ["auth_router", "users_router", "substitutions_router", "inventory_router", "recipes_router", "grocery_router", "prepared_foods_router", "scraper_router", "tasks_router", "receipts_router", "feed_router", "menus_router"]

--- a/src/routers/menus.py
+++ b/src/routers/menus.py
@@ -1,0 +1,427 @@
+"""
+Menu CRUD endpoints for FreshUp.
+
+Provides endpoints for users to manage their menus (manual and auto-generated).
+All endpoints are scoped to the authenticated user's menus.
+
+Logging Policy:
+    User-provided menu names are NOT logged as they may contain sensitive
+    information (e.g., dietary preferences, cultural indicators).
+    Logs include operational metadata (user_id, menu_id) for
+    debugging while protecting user privacy per OWASP recommendations.
+"""
+
+import logging
+from uuid import UUID
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError, IntegrityError
+
+from src.db.database import get_db
+from src.db.models.user import User
+from src.db.models.recipe import Recipe
+from src.middleware.auth import get_current_user
+from src.schemas.menu import (
+    MenuCreate,
+    MenuUpdate,
+    MenuResponse,
+    MenuListResponse,
+    MenuRecipeCreate,
+    MenuRecipeResponse,
+    MenuRecipesResponse,
+    MenuGenerateRequest,
+    MenuGenerateResponse,
+)
+from src.schemas.recipe import RecipeResponse, RecipeListResponse
+from src.services import menu_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/menus", tags=["menus"])
+
+
+@router.get("", response_model=MenuListResponse)
+def get_menus(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Get all menus for the authenticated user, ordered by sort_order.
+
+    Args:
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        MenuListResponse: List of user's menus
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+    """
+    try:
+        menus = menu_service.get_user_menus(current_user.id, db)
+        return MenuListResponse(menus=menus, total=len(menus))
+    except SQLAlchemyError as e:
+        logger.error(f"Database error retrieving menus for user {current_user.id}")
+        logger.debug(f"Database error occurred: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to retrieve menus"
+        )
+
+
+@router.post("", response_model=MenuResponse, status_code=status.HTTP_201_CREATED)
+def create_menu(
+    menu_data: MenuCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Create a new manual menu for the authenticated user.
+
+    Args:
+        menu_data: Menu data (name, description, filter_rules, etc.)
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        MenuResponse: Created menu
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(400): If data integrity violation occurs
+    """
+    try:
+        # Convert filter_rules to dict if provided
+        filter_rules_dict = None
+        if menu_data.filter_rules:
+            filter_rules_dict = menu_data.filter_rules.model_dump()
+
+        menu = menu_service.create_menu(
+            user_id=current_user.id,
+            name=menu_data.name,
+            description=menu_data.description,
+            filter_rules=filter_rules_dict,
+            is_auto_generated=menu_data.is_auto_generated,
+            cover_image=menu_data.cover_image,
+            sort_order=menu_data.sort_order,
+            db=db,
+        )
+        return menu
+    except IntegrityError as e:
+        db.rollback()
+        logger.error(f"Integrity error during menu creation for user {current_user.id}")
+        logger.debug(f"Integrity error occurred during menu creation: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Menu creation failed due to data integrity violation"
+        )
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during menu creation for user {current_user.id}")
+        logger.debug(f"Database error occurred during menu creation: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create menu"
+        )
+
+
+@router.put("/{menu_id}", response_model=MenuResponse)
+def update_menu(
+    menu_id: UUID,
+    menu_data: MenuUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Update an existing menu.
+
+    Only the menu owner can update it. Returns 404 if menu doesn't exist or user doesn't own it.
+
+    Args:
+        menu_id: Menu ID to update
+        menu_data: Updated menu data
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        MenuResponse: Updated menu
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If menu not found or user doesn't own it
+    """
+    menu = menu_service.get_menu_by_id(menu_id, current_user.id, db)
+    if not menu:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Menu not found"
+        )
+
+    try:
+        # Convert filter_rules to dict if provided
+        filter_rules_dict = None
+        if menu_data.filter_rules is not None:
+            filter_rules_dict = menu_data.filter_rules.model_dump()
+
+        updated_menu = menu_service.update_menu(
+            menu=menu,
+            name=menu_data.name,
+            description=menu_data.description,
+            filter_rules=filter_rules_dict,
+            sort_order=menu_data.sort_order,
+            db=db,
+        )
+        return updated_menu
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during menu update for menu {menu_id}")
+        logger.debug(f"Database error occurred during menu update: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to update menu"
+        )
+
+
+@router.delete("/{menu_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_menu(
+    menu_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Delete a menu and all its MenuRecipe entries (cascade).
+
+    Only the menu owner can delete it. Returns 404 if menu doesn't exist or user doesn't own it.
+
+    Args:
+        menu_id: Menu ID to delete
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If menu not found or user doesn't own it
+    """
+    menu = menu_service.get_menu_by_id(menu_id, current_user.id, db)
+    if not menu:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Menu not found"
+        )
+
+    try:
+        menu_service.delete_menu(menu, db)
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error during menu deletion for menu {menu_id}")
+        logger.debug(f"Database error occurred during menu deletion: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to delete menu"
+        )
+
+
+@router.get("/{menu_id}/recipes", response_model=MenuRecipesResponse)
+def get_menu_recipes(
+    menu_id: UUID,
+    offset: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=100),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Get recipes in a menu with pagination.
+
+    Only the menu owner can view its recipes. Returns 404 if menu doesn't exist or user doesn't own it.
+
+    Args:
+        menu_id: Menu ID to get recipes for
+        offset: Pagination offset (default 0)
+        limit: Pagination limit (default 50, max 100)
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        MenuRecipesResponse: Paginated list of recipes in the menu
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If menu not found or user doesn't own it
+    """
+    menu = menu_service.get_menu_by_id(menu_id, current_user.id, db)
+    if not menu:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Menu not found"
+        )
+
+    try:
+        recipes, total = menu_service.get_menu_recipes(menu_id, db, offset=offset, limit=limit)
+        # Convert Recipe objects to RecipeListResponse
+        recipe_list = [RecipeListResponse.model_validate(r) for r in recipes]
+        return MenuRecipesResponse(recipes=recipe_list, total=total)
+    except SQLAlchemyError as e:
+        logger.error(f"Database error retrieving recipes for menu {menu_id}")
+        logger.debug(f"Database error occurred: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to retrieve menu recipes"
+        )
+
+
+@router.post("/{menu_id}/recipes", response_model=MenuRecipeResponse, status_code=status.HTTP_201_CREATED)
+def add_recipe_to_menu(
+    menu_id: UUID,
+    recipe_data: MenuRecipeCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Add a recipe to a menu.
+
+    Sets manually_added=true if the recipe doesn't match the menu's filter rules.
+    Only the menu owner can add recipes. Returns 404 if menu doesn't exist or user doesn't own it.
+
+    Args:
+        menu_id: Menu ID to add recipe to
+        recipe_data: Recipe data (recipe_id, sort_order)
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        MenuRecipeResponse: Created MenuRecipe entry
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If menu or recipe not found, or user doesn't own menu
+        HTTPException(400): If recipe already in menu (duplicate)
+    """
+    menu = menu_service.get_menu_by_id(menu_id, current_user.id, db)
+    if not menu:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Menu not found"
+        )
+
+    try:
+        menu_recipe = menu_service.add_recipe_to_menu(
+            menu=menu,
+            recipe_id=recipe_data.recipe_id,
+            sort_order=recipe_data.sort_order,
+            db=db,
+        )
+        return menu_recipe
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e)
+        )
+    except IntegrityError as e:
+        db.rollback()
+        logger.error(f"Integrity error adding recipe to menu {menu_id}")
+        logger.debug(f"Integrity error occurred: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Recipe already in menu"
+        )
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error adding recipe to menu {menu_id}")
+        logger.debug(f"Database error occurred: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to add recipe to menu"
+        )
+
+
+@router.delete("/{menu_id}/recipes/{recipe_id}", status_code=status.HTTP_204_NO_CONTENT)
+def remove_recipe_from_menu(
+    menu_id: UUID,
+    recipe_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Remove a recipe from a menu.
+
+    Sets manually_removed=true if the recipe matches the menu's filter rules (instead of deleting).
+    Otherwise, deletes the MenuRecipe entry.
+    Only the menu owner can remove recipes. Returns 404 if menu doesn't exist or user doesn't own it.
+
+    Args:
+        menu_id: Menu ID to remove recipe from
+        recipe_id: Recipe ID to remove
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+        HTTPException(404): If menu or recipe not found, or user doesn't own menu
+    """
+    menu = menu_service.get_menu_by_id(menu_id, current_user.id, db)
+    if not menu:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Menu not found"
+        )
+
+    try:
+        menu_service.remove_recipe_from_menu(menu, recipe_id, db)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e)
+        )
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error removing recipe from menu {menu_id}")
+        logger.debug(f"Database error occurred: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to remove recipe from menu"
+        )
+
+
+@router.post("/generate", response_model=MenuGenerateResponse, status_code=status.HTTP_201_CREATED)
+def generate_menus(
+    request: MenuGenerateRequest = MenuGenerateRequest(),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Auto-generate menus from user's behavioral patterns.
+
+    Detects tag patterns from saved recipes (>= min_saves) and creates menus with filter rules.
+    Populates menus with user's bookmarked+liked recipes matching the filter rules.
+
+    Args:
+        request: Generation parameters (min_saves, max_menus)
+        current_user: Authenticated user (injected by get_current_user dependency)
+        db: Database session
+
+    Returns:
+        MenuGenerateResponse: Generated menus
+
+    Raises:
+        HTTPException(401): If Authorization header is missing or token is invalid
+    """
+    try:
+        generated_menus = menu_service.generate_menus_from_patterns(
+            user_id=current_user.id,
+            db=db,
+            min_saves=request.min_saves,
+            max_menus=request.max_menus,
+        )
+        return MenuGenerateResponse(
+            generated_menus=generated_menus,
+            total_generated=len(generated_menus)
+        )
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error(f"Database error generating menus for user {current_user.id}")
+        logger.debug(f"Database error occurred: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to generate menus"
+        )

--- a/src/routers/recipes.py
+++ b/src/routers/recipes.py
@@ -23,7 +23,7 @@ from src.db.database import get_db
 from src.db.models.user import User
 from src.db.models.recipe import Recipe, SourceType
 from src.db.models.recipe_ingredient import RecipeIngredient
-from src.db.models.user_recipe import UserRecipeRating
+from src.db.models.user_recipe import UserRecipeRelation
 from src.db.models.inventory_item import InventoryItem
 from src.schemas.recipe import (
     RecipeCreate,
@@ -33,8 +33,8 @@ from src.schemas.recipe import (
     RecipeIngredientCreate,
     RecipeIngredientUpdate,
     RecipeIngredientResponse,
-    UserRecipeRatingCreate,
-    UserRecipeRatingResponse,
+    UserRecipeRelationCreate,
+    UserRecipeRelationResponse,
     RecipeAggregateRatingsResponse,
     AdHocRecipeCreate,
 )
@@ -776,27 +776,27 @@ def delete_recipe_ingredient(
     return None
 
 
-@router.post("/{recipe_id}/rate", response_model=UserRecipeRatingResponse, status_code=status.HTTP_200_OK)
+@router.post("/{recipe_id}/rate", response_model=UserRecipeRelationResponse, status_code=status.HTTP_200_OK)
 def rate_recipe(
     recipe_id: UUID,
-    rating_data: UserRecipeRatingCreate,
+    rating_data: UserRecipeRelationCreate,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
     """
-    Create or update a rating for a recipe (upsert behavior).
+    Create or update a relation for a recipe (upsert behavior).
 
-    Each user can have only one rating per recipe. If a rating already exists,
-    this endpoint will update it. Otherwise, it creates a new rating.
+    Each user can have only one relation per recipe. If a relation already exists,
+    this endpoint will update it. Otherwise, it creates a new relation.
 
     Args:
         recipe_id: UUID of the recipe to rate
-        rating_data: Rating data (rating value, is_favorite, notes)
+        rating_data: Relation data (rating value, is_bookmarked, is_liked, etc.)
         current_user: Authenticated user (injected by get_current_user dependency)
         db: Database session
 
     Returns:
-        UserRecipeRatingResponse: Created or updated rating
+        UserRecipeRelationResponse: Created or updated relation
 
     Raises:
         HTTPException(401): If Authorization header is missing or token is invalid
@@ -811,86 +811,86 @@ def rate_recipe(
             detail="Recipe not found"
         )
 
-    # Check if user already has a rating for this recipe
-    existing_rating = (
-        db.query(UserRecipeRating)
+    # Check if user already has a relation for this recipe
+    existing_relation = (
+        db.query(UserRecipeRelation)
         .filter(
-            UserRecipeRating.user_id == current_user.id,
-            UserRecipeRating.recipe_id == recipe_id,
+            UserRecipeRelation.user_id == current_user.id,
+            UserRecipeRelation.recipe_id == recipe_id,
         )
         .first()
     )
 
-    if existing_rating:
-        # Update existing rating
+    if existing_relation:
+        # Update existing relation
         update_dict = rating_data.model_dump()
         for field, value in update_dict.items():
-            setattr(existing_rating, field, value)
+            setattr(existing_relation, field, value)
 
         try:
             db.commit()
-            db.refresh(existing_rating)
+            db.refresh(existing_relation)
         except SQLAlchemyError as e:
             db.rollback()
-            logger.error(f"Database error during rating update for user {current_user.id}")
-            logger.debug(f"Database error occurred during rating update: {e}")
+            logger.error(f"Database error during relation update for user {current_user.id}")
+            logger.debug(f"Database error occurred during relation update: {e}")
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="An error occurred while updating the rating"
+                detail="An error occurred while updating the relation"
             )
 
         logger.info(
-            f"Recipe rating updated: user_id={current_user.id}, "
-            f"recipe_id={recipe_id}, rating_id={existing_rating.id}"
+            f"Recipe relation updated: user_id={current_user.id}, "
+            f"recipe_id={recipe_id}, relation_id={existing_relation.id}"
         )
-        return existing_rating
+        return existing_relation
     else:
-        # Create new rating
-        new_rating = UserRecipeRating(
+        # Create new relation
+        new_relation = UserRecipeRelation(
             user_id=current_user.id,
             recipe_id=recipe_id,
             **rating_data.model_dump()
         )
-        db.add(new_rating)
+        db.add(new_relation)
 
         try:
             db.commit()
-            db.refresh(new_rating)
+            db.refresh(new_relation)
         except IntegrityError as e:
             db.rollback()
-            logger.error(f"Integrity error during rating creation for user {current_user.id}")
-            logger.debug(f"Integrity error occurred during rating creation: {e}")
+            logger.error(f"Integrity error during relation creation for user {current_user.id}")
+            logger.debug(f"Integrity error occurred during relation creation: {e}")
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Rating creation failed due to data integrity violation"
+                detail="Relation creation failed due to data integrity violation"
             )
         except SQLAlchemyError as e:
             db.rollback()
-            logger.error(f"Database error during rating creation for user {current_user.id}")
-            logger.debug(f"Database error occurred during rating creation: {e}")
+            logger.error(f"Database error during relation creation for user {current_user.id}")
+            logger.debug(f"Database error occurred during relation creation: {e}")
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="An error occurred while creating the rating"
+                detail="An error occurred while creating the relation"
             )
 
         logger.info(
-            f"Recipe rating created: user_id={current_user.id}, "
-            f"recipe_id={recipe_id}, rating_id={new_rating.id}"
+            f"Recipe relation created: user_id={current_user.id}, "
+            f"recipe_id={recipe_id}, relation_id={new_relation.id}"
         )
-        return new_rating
+        return new_relation
 
 
-@router.get("/{recipe_id}/my-rating", response_model=UserRecipeRatingResponse)
+@router.get("/{recipe_id}/my-rating", response_model=UserRecipeRelationResponse)
 def get_my_rating(
     recipe_id: UUID,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
     """
-    Get the current user's rating for a recipe.
+    Get the current user's relation for a recipe.
 
-    Returns the authenticated user's rating for the specified recipe.
-    Returns 404 if the user hasn't rated this recipe yet.
+    Returns the authenticated user's relation for the specified recipe.
+    Returns 404 if the user hasn't created a relation for this recipe yet.
 
     Args:
         recipe_id: UUID of the recipe
@@ -898,7 +898,7 @@ def get_my_rating(
         db: Database session
 
     Returns:
-        UserRecipeRatingResponse: User's rating for this recipe
+        UserRecipeRelationResponse: User's relation for this recipe
 
     Raises:
         HTTPException(401): If Authorization header is missing or token is invalid
@@ -912,23 +912,23 @@ def get_my_rating(
             detail="Recipe not found"
         )
 
-    # Get user's rating
-    rating = (
-        db.query(UserRecipeRating)
+    # Get user's relation
+    relation = (
+        db.query(UserRecipeRelation)
         .filter(
-            UserRecipeRating.user_id == current_user.id,
-            UserRecipeRating.recipe_id == recipe_id,
+            UserRecipeRelation.user_id == current_user.id,
+            UserRecipeRelation.recipe_id == recipe_id,
         )
         .first()
     )
 
-    if not rating:
+    if not relation:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Rating not found"
         )
 
-    return rating
+    return relation
 
 
 @router.delete("/{recipe_id}/my-rating", status_code=status.HTTP_204_NO_CONTENT)
@@ -938,10 +938,10 @@ def delete_my_rating(
     db: Session = Depends(get_db),
 ):
     """
-    Delete the current user's rating for a recipe.
+    Delete the current user's relation for a recipe.
 
-    Removes the authenticated user's rating for the specified recipe.
-    Returns 204 even if no rating exists (idempotent behavior).
+    Removes the authenticated user's relation for the specified recipe.
+    Returns 204 even if no relation exists (idempotent behavior).
 
     Args:
         recipe_id: UUID of the recipe
@@ -963,31 +963,31 @@ def delete_my_rating(
             detail="Recipe not found"
         )
 
-    # Get user's rating (if exists)
-    rating = (
-        db.query(UserRecipeRating)
+    # Get user's relation (if exists)
+    relation = (
+        db.query(UserRecipeRelation)
         .filter(
-            UserRecipeRating.user_id == current_user.id,
-            UserRecipeRating.recipe_id == recipe_id,
+            UserRecipeRelation.user_id == current_user.id,
+            UserRecipeRelation.recipe_id == recipe_id,
         )
         .first()
     )
 
-    if rating:
+    if relation:
         try:
-            db.delete(rating)
+            db.delete(relation)
             db.commit()
         except SQLAlchemyError as e:
             db.rollback()
-            logger.error(f"Database error during rating deletion for user {current_user.id}")
-            logger.debug(f"Database error occurred during rating deletion: {e}")
+            logger.error(f"Database error during relation deletion for user {current_user.id}")
+            logger.debug(f"Database error occurred during relation deletion: {e}")
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="An error occurred while deleting the rating"
+                detail="An error occurred while deleting the relation"
             )
 
         logger.info(
-            f"Recipe rating deleted: user_id={current_user.id}, "
+            f"Recipe relation deleted: user_id={current_user.id}, "
             f"recipe_id={recipe_id}"
         )
 
@@ -1004,7 +1004,7 @@ def get_recipe_ratings(
     Get aggregate rating statistics for a recipe.
 
     Returns the average rating, total rating count, and favorite count
-    across all users who have rated this recipe. This is a shared read
+    across all users who have relations with this recipe. This is a shared read
     endpoint - all users can see aggregate stats for any recipe.
 
     Args:
@@ -1030,15 +1030,15 @@ def get_recipe_ratings(
     # Calculate aggregate statistics across all users
     # - average_rating: Average of all non-null rating values (func.avg automatically excludes nulls)
     # - rating_count: Count of rows where rating is not None (users who provided numeric ratings)
-    # - favorite_count: Count of rows where is_favorite is True (users who favorited)
+    # - favorite_count: Count of rows where is_bookmarked is True (users who favorited)
     # Note: Users can favorite without rating (rating=None), so favorite_count may exceed rating_count
     stats = (
         db.query(
-            func.avg(UserRecipeRating.rating).label('average_rating'),
-            func.count(UserRecipeRating.id).filter(UserRecipeRating.rating.isnot(None)).label('rating_count'),
-            func.count(UserRecipeRating.id).filter(UserRecipeRating.is_favorite.is_(True)).label('favorite_count'),
+            func.avg(UserRecipeRelation.rating).label('average_rating'),
+            func.count(UserRecipeRelation.id).filter(UserRecipeRelation.rating.isnot(None)).label('rating_count'),
+            func.count(UserRecipeRelation.id).filter(UserRecipeRelation.is_bookmarked.is_(True)).label('favorite_count'),
         )
-        .filter(UserRecipeRating.recipe_id == recipe_id)
+        .filter(UserRecipeRelation.recipe_id == recipe_id)
         .first()
     )
 

--- a/src/schemas/menu.py
+++ b/src/schemas/menu.py
@@ -4,21 +4,21 @@ Pydantic schemas for Menu and MenuRecipe API requests/responses.
 
 from uuid import UUID
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Literal
 from pydantic import BaseModel, Field, ConfigDict
 
 
 # Filter rule schemas
 class FilterRule(BaseModel):
     """Individual filter rule for recipe matching."""
-    field: str = Field(..., description="Field to filter on: tags, source_type, cook_time_minutes")
-    operator: str = Field(..., description="Operator: contains, not_contains, eq, in, <=, >=")
+    field: Literal["tags", "source_type", "cook_time_minutes"] = Field(..., description="Field to filter on: tags, source_type, cook_time_minutes")
+    operator: Literal["contains", "not_contains", "eq", "in", "<=", ">="] = Field(..., description="Operator: contains, not_contains, eq, in, <=, >=")
     value: str | int | list[str] = Field(..., description="Value to match against")
 
 
 class FilterRules(BaseModel):
     """Collection of filter rules with match logic."""
-    match_logic: str = Field("all", description="Match logic: 'all' (AND) or 'any' (OR)")
+    match_logic: Literal["all", "any"] = Field("all", description="Match logic: 'all' (AND) or 'any' (OR)")
     rules: list[FilterRule] = Field(default_factory=list)
 
 

--- a/src/schemas/menu.py
+++ b/src/schemas/menu.py
@@ -1,0 +1,104 @@
+"""
+Pydantic schemas for Menu and MenuRecipe API requests/responses.
+"""
+
+from uuid import UUID
+from datetime import datetime
+from typing import Optional
+from pydantic import BaseModel, Field, ConfigDict
+
+
+# Filter rule schemas
+class FilterRule(BaseModel):
+    """Individual filter rule for recipe matching."""
+    field: str = Field(..., description="Field to filter on: tags, source_type, cook_time_minutes")
+    operator: str = Field(..., description="Operator: contains, not_contains, eq, in, <=, >=")
+    value: str | int | list[str] = Field(..., description="Value to match against")
+
+
+class FilterRules(BaseModel):
+    """Collection of filter rules with match logic."""
+    match_logic: str = Field("all", description="Match logic: 'all' (AND) or 'any' (OR)")
+    rules: list[FilterRule] = Field(default_factory=list)
+
+
+# Menu schemas
+class MenuCreate(BaseModel):
+    """Schema for creating a new menu."""
+    name: str = Field(..., max_length=255)
+    description: Optional[str] = Field(None, max_length=500)
+    filter_rules: Optional[FilterRules] = None
+    is_auto_generated: bool = False
+    cover_image: Optional[str] = Field(None, max_length=2048)
+    sort_order: int = 0
+
+
+class MenuUpdate(BaseModel):
+    """Schema for updating an existing menu."""
+    name: Optional[str] = Field(None, max_length=255)
+    description: Optional[str] = Field(None, max_length=500)
+    filter_rules: Optional[FilterRules] = None
+    sort_order: Optional[int] = None
+
+
+class MenuResponse(BaseModel):
+    """Schema for menu response."""
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    user_id: UUID
+    name: str
+    description: Optional[str]
+    filter_rules: Optional[dict]
+    is_auto_generated: bool
+    cover_image: Optional[str]
+    sort_order: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class MenuListResponse(BaseModel):
+    """Schema for list of menus."""
+    menus: list[MenuResponse]
+    total: int
+
+
+# MenuRecipe schemas
+class MenuRecipeCreate(BaseModel):
+    """Schema for adding a recipe to a menu."""
+    recipe_id: UUID
+    sort_order: int = 0
+
+
+class MenuRecipeResponse(BaseModel):
+    """Schema for menu recipe response."""
+    model_config = ConfigDict(from_attributes=True)
+
+    menu_id: UUID
+    recipe_id: UUID
+    sort_order: int
+    manually_added: bool
+    manually_removed: bool
+    added_at: datetime
+
+
+# Pagination response for menu recipes
+class MenuRecipesResponse(BaseModel):
+    """Schema for paginated menu recipes response."""
+    model_config = ConfigDict(from_attributes=True)
+
+    recipes: list  # List of Recipe model objects - FastAPI will serialize them
+    total: int
+
+
+# Auto-generation schema
+class MenuGenerateRequest(BaseModel):
+    """Schema for auto-generating menus from user patterns."""
+    min_saves: int = Field(3, description="Minimum number of saves required for pattern detection")
+    max_menus: int = Field(4, description="Maximum number of menus to generate")
+
+
+class MenuGenerateResponse(BaseModel):
+    """Schema for auto-generation response."""
+    generated_menus: list[MenuResponse]
+    total_generated: int

--- a/src/schemas/recipe.py
+++ b/src/schemas/recipe.py
@@ -167,6 +167,7 @@ class RecipeResponse(BaseModel):
     times_cooked: int
     created_by: Optional[UUID]
     notes: Optional[str]
+    is_persisted: bool
 
 
 class RecipeListResponse(BaseModel):
@@ -264,12 +265,15 @@ class RecipeIngredientResponse(BaseModel):
     step_index: Optional[int]
 
 
-class UserRecipeRatingCreate(BaseModel):
-    """Request schema for creating or updating a recipe rating."""
+class UserRecipeRelationCreate(BaseModel):
+    """Request schema for creating or updating a recipe relation."""
 
     rating: Optional[float] = Field(default=None, description="Rating value (0.0-5.0)")
-    is_favorite: bool = Field(default=False, description="Whether recipe is favorited")
-    notes: Optional[str] = Field(default=None, max_length=1000, description="Personal notes about the recipe")
+    is_bookmarked: bool = Field(default=False, description="Whether recipe is bookmarked")
+    is_liked: bool = Field(default=False, description="Whether recipe is liked")
+    rating_photos: Optional[list[str]] = Field(default=None, description="URLs of rating photos")
+    rating_comment: Optional[str] = Field(default=None, max_length=2000, description="Personal comment about the recipe")
+    menu_id: Optional[UUID] = Field(default=None, description="Associated menu ID")
 
     @field_validator('rating')
     @classmethod
@@ -281,8 +285,8 @@ class UserRecipeRatingCreate(BaseModel):
         return v
 
 
-class UserRecipeRatingResponse(BaseModel):
-    """Response schema for user recipe rating data."""
+class UserRecipeRelationResponse(BaseModel):
+    """Response schema for user recipe relation data."""
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -290,8 +294,11 @@ class UserRecipeRatingResponse(BaseModel):
     user_id: UUID
     recipe_id: UUID
     rating: Optional[float]
-    is_favorite: bool
-    notes: Optional[str]
+    is_bookmarked: bool
+    is_liked: bool
+    rating_photos: Optional[list]
+    rating_comment: Optional[str]
+    menu_id: Optional[UUID]
 
 
 class RecipeAggregateRatingsResponse(BaseModel):

--- a/src/services/feed_service.py
+++ b/src/services/feed_service.py
@@ -188,8 +188,8 @@ def get_user_tag_patterns(user_id: UUID, db: Session, min_saves: int = 3) -> lis
     # Get all recipes the user has rated/saved
     saved_recipes = (
         db.query(Recipe)
-        .join(UserRecipeRating, Recipe.id == UserRecipeRating.recipe_id)
-        .filter(UserRecipeRating.user_id == user_id)
+        .join(UserRecipeRelation, Recipe.id == UserRecipeRelation.recipe_id)
+        .filter(UserRecipeRelation.user_id == user_id)
         .all()
     )
 
@@ -227,8 +227,8 @@ def get_user_source_patterns(user_id: UUID, db: Session, min_saves: int = 5) -> 
     # Count source types in user's saved recipes
     source_counts = (
         db.query(Recipe.source_type, func.count(Recipe.id).label("count"))
-        .join(UserRecipeRating, Recipe.id == UserRecipeRating.recipe_id)
-        .filter(UserRecipeRating.user_id == user_id)
+        .join(UserRecipeRelation, Recipe.id == UserRecipeRelation.recipe_id)
+        .filter(UserRecipeRelation.user_id == user_id)
         .group_by(Recipe.source_type)
         .having(func.count(Recipe.id) >= min_saves)
         .order_by(func.count(Recipe.id).desc())
@@ -252,9 +252,9 @@ def _get_saved_recipe_ids(user_id: UUID, db: Session) -> set[UUID]:
         Set of recipe IDs the user has rated/saved
     """
     return {
-        rating.recipe_id
-        for rating in db.query(UserRecipeRating.recipe_id)
-        .filter(UserRecipeRating.user_id == user_id)
+        relation.recipe_id
+        for relation in db.query(UserRecipeRelation.recipe_id)
+        .filter(UserRecipeRelation.user_id == user_id)
         .all()
     }
 

--- a/src/services/menu_service.py
+++ b/src/services/menu_service.py
@@ -1,0 +1,556 @@
+"""
+Menu service - CRUD operations and auto-generation logic for user menus.
+
+Provides manual menu management and auto-generated menu creation from behavioral patterns.
+"""
+
+import logging
+from uuid import UUID
+from datetime import datetime
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
+
+from src.db.models.menu import Menu, MenuRecipe
+from src.db.models.recipe import Recipe
+from src.db.models.user_recipe import UserRecipeRelation
+from src.services.feed_service import get_user_tag_patterns
+from src.schemas.menu import FilterRules
+
+logger = logging.getLogger(__name__)
+
+
+def get_user_menus(user_id: UUID, db: Session) -> list[Menu]:
+    """
+    Get all menus for a user, ordered by sort_order.
+
+    Args:
+        user_id: User ID to get menus for
+        db: Database session
+
+    Returns:
+        List of Menu objects ordered by sort_order
+    """
+    menus = (
+        db.query(Menu)
+        .filter(Menu.user_id == user_id)
+        .order_by(Menu.sort_order.asc(), Menu.created_at.desc())
+        .all()
+    )
+    logger.info(f"Retrieved {len(menus)} menus for user {user_id}")
+    return menus
+
+
+def get_menu_by_id(menu_id: UUID, user_id: UUID, db: Session) -> Menu | None:
+    """
+    Get a specific menu by ID, ensuring it belongs to the user.
+
+    Args:
+        menu_id: Menu ID to retrieve
+        user_id: User ID for ownership verification
+        db: Database session
+
+    Returns:
+        Menu object if found and owned by user, None otherwise
+    """
+    menu = (
+        db.query(Menu)
+        .filter(Menu.id == menu_id, Menu.user_id == user_id)
+        .first()
+    )
+    return menu
+
+
+def create_menu(
+    user_id: UUID,
+    name: str,
+    db: Session,
+    description: str | None = None,
+    filter_rules: dict | None = None,
+    is_auto_generated: bool = False,
+    cover_image: str | None = None,
+    sort_order: int = 0,
+) -> Menu:
+    """
+    Create a new menu for a user.
+
+    Args:
+        user_id: User ID who owns the menu
+        name: Menu name
+        db: Database session
+        description: Optional menu description
+        filter_rules: Optional filter rules for auto-population
+        is_auto_generated: Whether this menu was auto-generated
+        cover_image: Optional cover image URL
+        sort_order: Sort order for menu display
+
+    Returns:
+        Created Menu object
+
+    Raises:
+        IntegrityError: If database constraint is violated
+    """
+    menu = Menu(
+        user_id=user_id,
+        name=name,
+        description=description,
+        filter_rules=filter_rules,
+        is_auto_generated=is_auto_generated,
+        cover_image=cover_image,
+        sort_order=sort_order,
+    )
+
+    db.add(menu)
+    db.commit()
+    db.refresh(menu)
+
+    logger.info(f"Created menu {menu.id} for user {user_id} (auto_generated={is_auto_generated})")
+    return menu
+
+
+def update_menu(
+    menu: Menu,
+    db: Session,
+    name: str | None = None,
+    description: str | None = None,
+    filter_rules: dict | None = None,
+    sort_order: int | None = None,
+) -> Menu:
+    """
+    Update an existing menu.
+
+    Args:
+        menu: Menu object to update
+        db: Database session
+        name: Optional new name
+        description: Optional new description
+        filter_rules: Optional new filter rules
+        sort_order: Optional new sort order
+
+    Returns:
+        Updated Menu object
+    """
+    if name is not None:
+        menu.name = name
+    if description is not None:
+        menu.description = description
+    if filter_rules is not None:
+        menu.filter_rules = filter_rules
+    if sort_order is not None:
+        menu.sort_order = sort_order
+
+    db.commit()
+    db.refresh(menu)
+
+    logger.info(f"Updated menu {menu.id}")
+    return menu
+
+
+def delete_menu(menu: Menu, db: Session) -> None:
+    """
+    Delete a menu and all its MenuRecipe entries (cascade).
+
+    Args:
+        menu: Menu object to delete
+        db: Database session
+    """
+    menu_id = menu.id
+    db.delete(menu)
+    db.commit()
+    logger.info(f"Deleted menu {menu_id}")
+
+
+def get_menu_recipes(menu_id: UUID, db: Session, offset: int = 0, limit: int = 50) -> tuple[list[Recipe], int]:
+    """
+    Get recipes in a menu with pagination.
+
+    Args:
+        menu_id: Menu ID to get recipes for
+        db: Database session
+        offset: Pagination offset
+        limit: Pagination limit
+
+    Returns:
+        Tuple of (list of Recipe objects, total count)
+    """
+    # Get total count
+    total = (
+        db.query(MenuRecipe)
+        .filter(MenuRecipe.menu_id == menu_id)
+        .filter(MenuRecipe.manually_removed == False)  # noqa: E712
+        .count()
+    )
+
+    # Get paginated recipes ordered by sort_order
+    menu_recipes = (
+        db.query(MenuRecipe)
+        .filter(MenuRecipe.menu_id == menu_id)
+        .filter(MenuRecipe.manually_removed == False)  # noqa: E712
+        .order_by(MenuRecipe.sort_order.asc(), MenuRecipe.added_at.desc())
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
+
+    recipe_ids = [mr.recipe_id for mr in menu_recipes]
+    recipes = (
+        db.query(Recipe)
+        .filter(Recipe.id.in_(recipe_ids))
+        .all()
+    )
+
+    # Maintain sort order from menu_recipes
+    recipe_map = {r.id: r for r in recipes}
+    sorted_recipes = [recipe_map[rid] for rid in recipe_ids if rid in recipe_map]
+
+    return sorted_recipes, total
+
+
+def add_recipe_to_menu(
+    menu: Menu,
+    recipe_id: UUID,
+    db: Session,
+    sort_order: int = 0,
+) -> MenuRecipe:
+    """
+    Add a recipe to a menu.
+
+    If the recipe doesn't match the menu's filter rules, sets manually_added=True.
+    If a MenuRecipe entry exists with manually_removed=True, updates it to manually_removed=False.
+
+    Args:
+        menu: Menu object to add recipe to
+        recipe_id: Recipe ID to add
+        db: Database session
+        sort_order: Sort order for the recipe in the menu
+
+    Returns:
+        MenuRecipe object
+
+    Raises:
+        IntegrityError: If unique constraint is violated (duplicate menu_id + recipe_id)
+    """
+    # Check if MenuRecipe entry already exists
+    existing = (
+        db.query(MenuRecipe)
+        .filter(MenuRecipe.menu_id == menu.id, MenuRecipe.recipe_id == recipe_id)
+        .first()
+    )
+
+    if existing:
+        # If it was manually removed, restore it
+        if existing.manually_removed:
+            existing.manually_removed = False
+            existing.added_at = datetime.utcnow()
+            db.commit()
+            db.refresh(existing)
+            logger.info(f"Restored recipe {recipe_id} to menu {menu.id}")
+            return existing
+        # Otherwise it's a duplicate (should be caught by unique constraint)
+        raise IntegrityError("Recipe already in menu", None, None)
+
+    # Get the recipe and check if it matches filter rules
+    recipe = db.query(Recipe).filter(Recipe.id == recipe_id).first()
+    if not recipe:
+        raise ValueError(f"Recipe {recipe_id} not found")
+
+    matches_filter = False
+    if menu.filter_rules:
+        matches_filter = evaluate_filter_rules(recipe, menu.filter_rules, menu.user_id, db)
+
+    # Create MenuRecipe entry
+    menu_recipe = MenuRecipe(
+        menu_id=menu.id,
+        recipe_id=recipe_id,
+        sort_order=sort_order,
+        manually_added=not matches_filter,  # True if doesn't match filter
+        manually_removed=False,
+    )
+
+    db.add(menu_recipe)
+    db.commit()
+    db.refresh(menu_recipe)
+
+    logger.info(f"Added recipe {recipe_id} to menu {menu.id} (manually_added={menu_recipe.manually_added})")
+    return menu_recipe
+
+
+def remove_recipe_from_menu(menu: Menu, recipe_id: UUID, db: Session) -> None:
+    """
+    Remove a recipe from a menu.
+
+    If the recipe matches the menu's filter rules, sets manually_removed=True instead of deleting.
+    Otherwise, deletes the MenuRecipe entry.
+
+    Args:
+        menu: Menu object to remove recipe from
+        recipe_id: Recipe ID to remove
+        db: Database session
+    """
+    menu_recipe = (
+        db.query(MenuRecipe)
+        .filter(MenuRecipe.menu_id == menu.id, MenuRecipe.recipe_id == recipe_id)
+        .first()
+    )
+
+    if not menu_recipe:
+        raise ValueError(f"Recipe {recipe_id} not in menu {menu.id}")
+
+    # Get the recipe and check if it matches filter rules
+    recipe = db.query(Recipe).filter(Recipe.id == recipe_id).first()
+    matches_filter = False
+    if recipe and menu.filter_rules:
+        matches_filter = evaluate_filter_rules(recipe, menu.filter_rules, menu.user_id, db)
+
+    if matches_filter:
+        # Set manually_removed flag instead of deleting
+        menu_recipe.manually_removed = True
+        db.commit()
+        logger.info(f"Marked recipe {recipe_id} as manually removed from menu {menu.id}")
+    else:
+        # Delete the entry
+        db.delete(menu_recipe)
+        db.commit()
+        logger.info(f"Removed recipe {recipe_id} from menu {menu.id}")
+
+
+def evaluate_filter_rules(recipe: Recipe, filter_rules: dict, user_id: UUID, db: Session) -> bool:
+    """
+    Evaluate if a recipe matches the given filter rules.
+
+    Supports:
+    - tags: contains, not_contains
+    - source_type: eq, in
+    - cook_time_minutes: <=, >=, eq
+
+    Match logic:
+    - "all": All rules must match (AND)
+    - "any": At least one rule must match (OR)
+
+    Args:
+        recipe: Recipe object to evaluate
+        filter_rules: Filter rules dict with match_logic and rules
+        user_id: User ID (for checking if recipe is saved)
+        db: Database session
+
+    Returns:
+        True if recipe matches filter rules, False otherwise
+    """
+    match_logic = filter_rules.get("match_logic", "all")
+    rules = filter_rules.get("rules", [])
+
+    if not rules:
+        return True  # No rules means everything matches
+
+    results = []
+
+    for rule in rules:
+        field = rule.get("field")
+        operator = rule.get("operator")
+        value = rule.get("value")
+
+        result = _evaluate_single_rule(recipe, field, operator, value)
+        results.append(result)
+
+    # Apply match logic
+    if match_logic == "all":
+        return all(results)  # AND logic
+    elif match_logic == "any":
+        return any(results)  # OR logic
+    else:
+        logger.warning(f"Unknown match_logic '{match_logic}', defaulting to 'all'")
+        return all(results)
+
+
+def _evaluate_single_rule(recipe: Recipe, field: str, operator: str, value: any) -> bool:
+    """
+    Evaluate a single filter rule against a recipe.
+
+    Args:
+        recipe: Recipe object to evaluate
+        field: Field name (tags, source_type, cook_time_minutes)
+        operator: Operator (contains, not_contains, eq, in, <=, >=)
+        value: Value to compare against
+
+    Returns:
+        True if rule matches, False otherwise
+    """
+    if field == "tags":
+        recipe_tags = recipe.tags or []
+        if operator == "contains":
+            return value in recipe_tags
+        elif operator == "not_contains":
+            return value not in recipe_tags
+        else:
+            logger.warning(f"Unsupported operator '{operator}' for field 'tags'")
+            return False
+
+    elif field == "source_type":
+        recipe_source = recipe.source_type
+        if operator == "eq":
+            return recipe_source == value
+        elif operator == "in":
+            return recipe_source in value
+        else:
+            logger.warning(f"Unsupported operator '{operator}' for field 'source_type'")
+            return False
+
+    elif field == "cook_time_minutes":
+        recipe_cook_time = recipe.cook_time_minutes
+        if recipe_cook_time is None:
+            return False  # Can't match if cook time is not set
+
+        if operator == "<=":
+            return recipe_cook_time <= value
+        elif operator == ">=":
+            return recipe_cook_time >= value
+        elif operator == "eq":
+            return recipe_cook_time == value
+        else:
+            logger.warning(f"Unsupported operator '{operator}' for field 'cook_time_minutes'")
+            return False
+
+    else:
+        logger.warning(f"Unknown field '{field}' in filter rule")
+        return False
+
+
+def generate_menus_from_patterns(
+    user_id: UUID,
+    db: Session,
+    min_saves: int = 3,
+    max_menus: int = 4,
+) -> list[Menu]:
+    """
+    Auto-generate menus from user's behavioral patterns.
+
+    Uses tag patterns detected from saved recipes (UserRecipeRelation).
+    Creates menus with filter rules and populates them with matching saved recipes.
+
+    Args:
+        user_id: User ID to generate menus for
+        db: Database session
+        min_saves: Minimum number of saves required for pattern detection
+        max_menus: Maximum number of menus to generate
+
+    Returns:
+        List of generated Menu objects
+    """
+    # Get user's tag patterns
+    tag_patterns = get_user_tag_patterns(user_id, db, min_saves=min_saves)
+
+    if not tag_patterns:
+        logger.info(f"No tag patterns found for user {user_id} (min_saves={min_saves})")
+        return []
+
+    generated_menus = []
+
+    for tag, count in tag_patterns[:max_menus]:
+        # Create filter rules for this tag
+        filter_rules = {
+            "match_logic": "all",
+            "rules": [
+                {
+                    "field": "tags",
+                    "operator": "contains",
+                    "value": tag
+                }
+            ]
+        }
+
+        # Format tag for display: capitalize first letter, add period
+        display_tag = tag.capitalize() if tag else tag
+        menu_name = f"{display_tag}."
+
+        # Create auto-generated menu
+        menu = create_menu(
+            user_id=user_id,
+            name=menu_name,
+            description=f"Auto-generated from your {tag} saves",
+            filter_rules=filter_rules,
+            is_auto_generated=True,
+            db=db,
+        )
+
+        # Populate menu with matching saved recipes
+        _populate_menu_from_filter(menu, user_id, db)
+
+        generated_menus.append(menu)
+
+    logger.info(f"Generated {len(generated_menus)} menus for user {user_id}")
+    return generated_menus
+
+
+def _populate_menu_from_filter(menu: Menu, user_id: UUID, db: Session) -> None:
+    """
+    Populate a menu with recipes matching its filter rules.
+
+    Only includes recipes the user has saved (UserRecipeRelation with is_bookmarked or rating >= 4).
+    Respects manual overrides: skips manually_removed, keeps manually_added.
+
+    Args:
+        menu: Menu object to populate
+        user_id: User ID for filtering saved recipes
+        db: Database session
+    """
+    if not menu.filter_rules:
+        logger.warning(f"Menu {menu.id} has no filter rules, skipping population")
+        return
+
+    # Get user's saved recipes (bookmarked or liked with rating >= 4)
+    saved_relations = (
+        db.query(UserRecipeRelation)
+        .filter(
+            UserRecipeRelation.user_id == user_id,
+            (UserRecipeRelation.is_bookmarked == True) |  # noqa: E712
+            (UserRecipeRelation.rating >= 4)
+        )
+        .all()
+    )
+
+    saved_recipe_ids = [rel.recipe_id for rel in saved_relations]
+    saved_recipes = (
+        db.query(Recipe)
+        .filter(Recipe.id.in_(saved_recipe_ids))
+        .all()
+    )
+
+    # Get existing menu recipes (to check for manual overrides)
+    existing_menu_recipes = (
+        db.query(MenuRecipe)
+        .filter(MenuRecipe.menu_id == menu.id)
+        .all()
+    )
+
+    manually_removed_ids = {
+        mr.recipe_id for mr in existing_menu_recipes if mr.manually_removed
+    }
+    manually_added_ids = {
+        mr.recipe_id for mr in existing_menu_recipes if mr.manually_added
+    }
+    existing_recipe_ids = {mr.recipe_id for mr in existing_menu_recipes}
+
+    # Evaluate filter rules and add matching recipes
+    added_count = 0
+    for recipe in saved_recipes:
+        # Skip if manually removed
+        if recipe.id in manually_removed_ids:
+            continue
+
+        # Skip if already in menu (including manually added)
+        if recipe.id in existing_recipe_ids:
+            continue
+
+        # Check if recipe matches filter rules
+        if evaluate_filter_rules(recipe, menu.filter_rules, user_id, db):
+            menu_recipe = MenuRecipe(
+                menu_id=menu.id,
+                recipe_id=recipe.id,
+                sort_order=0,
+                manually_added=False,
+                manually_removed=False,
+            )
+            db.add(menu_recipe)
+            added_count += 1
+
+    db.commit()
+    logger.info(f"Populated menu {menu.id} with {added_count} recipes")

--- a/src/services/menu_service.py
+++ b/src/services/menu_service.py
@@ -445,6 +445,11 @@ def generate_menus_from_patterns(
     generated_menus = []
 
     for tag, count in tag_patterns[:max_menus]:
+        # Skip empty tags to prevent creating menus named "."
+        if not tag or not tag.strip():
+            logger.warning(f"Skipping empty tag pattern for user {user_id}")
+            continue
+
         # Create filter rules for this tag
         filter_rules = {
             "match_logic": "all",

--- a/tests/routers/test_feed.py
+++ b/tests/routers/test_feed.py
@@ -545,19 +545,19 @@ class TestPersonalizedRows:
         db_session.commit()
 
         # User saves 3 recipes with "indian" tag (meets >=3 threshold)
-        rating1 = UserRecipeRating(
+        rating1 = UserRecipeRelation(
             id=uuid4(),
             user_id=test_user.id,
             recipe_id=recipe1.id,
             rating=5.0
         )
-        rating2 = UserRecipeRating(
+        rating2 = UserRecipeRelation(
             id=uuid4(),
             user_id=test_user.id,
             recipe_id=recipe2.id,
             rating=4.0
         )
-        rating3 = UserRecipeRating(
+        rating3 = UserRecipeRelation(
             id=uuid4(),
             user_id=test_user.id,
             recipe_id=recipe3.id,
@@ -604,7 +604,7 @@ class TestPersonalizedRows:
 
         # User saves only first 3 (meets >=3 threshold)
         for i in range(3):
-            rating = UserRecipeRating(
+            rating = UserRecipeRelation(
                 id=uuid4(),
                 user_id=test_user.id,
                 recipe_id=recipes[i].id,
@@ -649,13 +649,13 @@ class TestPersonalizedRows:
         db_session.commit()
 
         # User saves only 2 recipes with "rare_tag" (below threshold)
-        rating1 = UserRecipeRating(
+        rating1 = UserRecipeRelation(
             id=uuid4(),
             user_id=test_user.id,
             recipe_id=recipe1.id,
             rating=5.0
         )
-        rating2 = UserRecipeRating(
+        rating2 = UserRecipeRelation(
             id=uuid4(),
             user_id=test_user.id,
             recipe_id=recipe2.id,
@@ -692,7 +692,7 @@ class TestPersonalizedRows:
                 db_session.commit()
 
                 # User saves all recipes
-                rating = UserRecipeRating(
+                rating = UserRecipeRelation(
                     id=uuid4(),
                     user_id=test_user.id,
                     recipe_id=recipe.id,
@@ -729,7 +729,7 @@ class TestSourceRows:
             db_session.commit()
 
             # User saves all
-            rating = UserRecipeRating(
+            rating = UserRecipeRelation(
                 id=uuid4(),
                 user_id=test_user.id,
                 recipe_id=recipe.id,
@@ -771,7 +771,7 @@ class TestSourceRows:
             db_session.add(recipe)
             db_session.commit()
 
-            rating = UserRecipeRating(
+            rating = UserRecipeRelation(
                 id=uuid4(),
                 user_id=test_user.id,
                 recipe_id=recipe.id,
@@ -806,7 +806,7 @@ class TestSourceRows:
                 db_session.add(recipe)
                 db_session.commit()
 
-                rating = UserRecipeRating(
+                rating = UserRecipeRelation(
                     id=uuid4(),
                     user_id=test_user.id,
                     recipe_id=recipe.id,
@@ -1065,7 +1065,7 @@ class TestBrowseEndpoint:
             db_session.add(recipe)
             db_session.commit()
 
-            rating = UserRecipeRating(
+            rating = UserRecipeRelation(
                 id=uuid4(),
                 user_id=test_user.id,
                 recipe_id=recipe.id,

--- a/tests/routers/test_menus.py
+++ b/tests/routers/test_menus.py
@@ -1,0 +1,842 @@
+"""
+Integration tests for menu endpoints.
+
+Tests cover:
+- GET /menus: list user's menus
+- POST /menus: create manual menu
+- PUT /menus/{id}: update menu
+- DELETE /menus/{id}: delete menu and cascade to MenuRecipe entries
+- GET /menus/{id}/recipes: get recipes in menu with pagination
+- POST /menus/{id}/recipes: add recipe to menu with manual override logic
+- DELETE /menus/{id}/recipes/{recipe_id}: remove recipe with manual override logic
+- POST /menus/generate: auto-generate menus from user patterns
+- Filter rule evaluation (tags, source_type, cook_time_minutes)
+- Authentication and ownership requirements
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from uuid import uuid4
+from datetime import datetime, timedelta
+
+from src.db.database import Base, get_db
+from src.db import models
+from src.db.models.user import User, UserRole
+from src.db.models.recipe import Recipe
+from src.db.models.menu import Menu, MenuRecipe
+from src.db.models.user_recipe import UserRecipeRelation
+from src.services.auth_service import hash_password, create_access_token
+
+from fastapi import FastAPI
+from src.routers import menus as menus_router
+
+# Create a test app without lifespan
+app = FastAPI(
+    title="FreshUp",
+    description="Privacy-first kitchen management system",
+    version="0.1.0",
+)
+
+# Register the menus router
+app.include_router(menus_router.router)
+
+
+# Create an in-memory SQLite database for testing
+TEST_DATABASE_URL = "sqlite:///:memory:"
+
+
+@pytest.fixture(autouse=True)
+def setup_test_env(monkeypatch):
+    """Set up test environment variables."""
+    from src.config import get_settings
+    get_settings.cache_clear()
+
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars")
+    monkeypatch.setenv("JWT_ALGORITHM", "HS256")
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    monkeypatch.setenv("ACCESS_TOKEN_EXPIRE_MINUTES", "43200")
+
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def db_session():
+    """Create a fresh database session for each test."""
+    from sqlalchemy.pool import StaticPool
+
+    # Import models to ensure all SQLAlchemy model classes are registered
+    # with Base.metadata before create_all() is called
+    _ = models
+
+    engine = create_engine(
+        TEST_DATABASE_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+@pytest.fixture
+def client(db_session):
+    """Create a test client with database dependency override."""
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def test_user(db_session):
+    """Create a test user."""
+    user = User(
+        id=uuid4(),
+        name="Test User",
+        email="test@example.com",
+        role=UserRole.member,
+        hashed_password=hash_password("password123")
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def other_user(db_session):
+    """Create another test user for ownership tests."""
+    user = User(
+        id=uuid4(),
+        name="Other User",
+        email="other@example.com",
+        role=UserRole.member,
+        hashed_password=hash_password("password123")
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def auth_headers(test_user):
+    """Create authentication headers for test user."""
+    token = create_access_token({"sub": str(test_user.id)})
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def other_auth_headers(other_user):
+    """Create authentication headers for other user."""
+    token = create_access_token({"sub": str(other_user.id)})
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_get_menus_empty(client, auth_headers):
+    """Test getting menus when user has none."""
+    response = client.get("/menus", headers=auth_headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["menus"] == []
+    assert data["total"] == 0
+
+
+def test_create_manual_menu(client, auth_headers, test_user, db_session):
+    """Test creating a manual menu."""
+    menu_data = {
+        "name": "My Favorites",
+        "description": "My favorite recipes",
+        "is_auto_generated": False,
+        "sort_order": 0
+    }
+
+    response = client.post("/menus", json=menu_data, headers=auth_headers)
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["name"] == "My Favorites"
+    assert data["description"] == "My favorite recipes"
+    assert data["is_auto_generated"] is False
+    assert data["user_id"] == str(test_user.id)
+
+    # Verify in database
+    menu = db_session.query(Menu).filter(Menu.user_id == test_user.id).first()
+    assert menu is not None
+    assert menu.name == "My Favorites"
+
+
+def test_create_menu_with_filter_rules(client, auth_headers, test_user, db_session):
+    """Test creating a menu with filter rules."""
+    menu_data = {
+        "name": "Quick Meals",
+        "description": "Recipes under 30 minutes",
+        "filter_rules": {
+            "match_logic": "all",
+            "rules": [
+                {
+                    "field": "cook_time_minutes",
+                    "operator": "<=",
+                    "value": 30
+                }
+            ]
+        },
+        "is_auto_generated": False
+    }
+
+    response = client.post("/menus", json=menu_data, headers=auth_headers)
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["filter_rules"] is not None
+    assert data["filter_rules"]["match_logic"] == "all"
+    assert len(data["filter_rules"]["rules"]) == 1
+
+
+def test_get_menus_sorted(client, auth_headers, test_user, db_session):
+    """Test getting menus returns them sorted by sort_order."""
+    # Create menus with different sort orders
+    menu1 = Menu(user_id=test_user.id, name="Second", sort_order=2)
+    menu2 = Menu(user_id=test_user.id, name="First", sort_order=1)
+    menu3 = Menu(user_id=test_user.id, name="Third", sort_order=3)
+    db_session.add_all([menu1, menu2, menu3])
+    db_session.commit()
+
+    response = client.get("/menus", headers=auth_headers)
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data["menus"]) == 3
+    assert data["menus"][0]["name"] == "First"
+    assert data["menus"][1]["name"] == "Second"
+    assert data["menus"][2]["name"] == "Third"
+
+
+def test_update_menu(client, auth_headers, test_user, db_session):
+    """Test updating a menu."""
+    menu = Menu(user_id=test_user.id, name="Old Name", description="Old desc")
+    db_session.add(menu)
+    db_session.commit()
+    db_session.refresh(menu)
+
+    update_data = {
+        "name": "New Name",
+        "description": "New description",
+        "sort_order": 5
+    }
+
+    response = client.put(f"/menus/{menu.id}", json=update_data, headers=auth_headers)
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["name"] == "New Name"
+    assert data["description"] == "New description"
+    assert data["sort_order"] == 5
+
+    # Verify in database
+    db_session.refresh(menu)
+    assert menu.name == "New Name"
+
+
+def test_update_menu_not_found(client, auth_headers):
+    """Test updating a non-existent menu returns 404."""
+    fake_id = uuid4()
+    response = client.put(f"/menus/{fake_id}", json={"name": "New"}, headers=auth_headers)
+    assert response.status_code == 404
+
+
+def test_update_menu_non_owner(client, other_auth_headers, test_user, db_session):
+    """Test that non-owner cannot update a menu."""
+    menu = Menu(user_id=test_user.id, name="Test Menu")
+    db_session.add(menu)
+    db_session.commit()
+
+    response = client.put(f"/menus/{menu.id}", json={"name": "Hacked"}, headers=other_auth_headers)
+    assert response.status_code == 404
+
+
+def test_delete_menu(client, auth_headers, test_user, db_session):
+    """Test deleting a menu."""
+    menu = Menu(user_id=test_user.id, name="To Delete")
+    db_session.add(menu)
+    db_session.commit()
+    menu_id = menu.id
+
+    response = client.delete(f"/menus/{menu_id}", headers=auth_headers)
+    assert response.status_code == 204
+
+    # Verify deleted from database
+    menu = db_session.query(Menu).filter(Menu.id == menu_id).first()
+    assert menu is None
+
+
+def test_delete_menu_cascades_to_menu_recipes(client, auth_headers, test_user, db_session):
+    """Test that deleting a menu cascades to MenuRecipe entries."""
+    menu = Menu(user_id=test_user.id, name="To Delete")
+    recipe = Recipe(name="Test Recipe", source_type="manual", created_by=test_user.id)
+    db_session.add_all([menu, recipe])
+    db_session.commit()
+
+    menu_recipe = MenuRecipe(menu_id=menu.id, recipe_id=recipe.id)
+    db_session.add(menu_recipe)
+    db_session.commit()
+
+    menu_id = menu.id
+
+    response = client.delete(f"/menus/{menu_id}", headers=auth_headers)
+    assert response.status_code == 204
+
+    # Verify MenuRecipe entry is also deleted
+    menu_recipe = db_session.query(MenuRecipe).filter(MenuRecipe.menu_id == menu_id).first()
+    assert menu_recipe is None
+
+
+def test_delete_menu_non_owner(client, other_auth_headers, test_user, db_session):
+    """Test that non-owner cannot delete a menu."""
+    menu = Menu(user_id=test_user.id, name="Protected")
+    db_session.add(menu)
+    db_session.commit()
+
+    response = client.delete(f"/menus/{menu.id}", headers=other_auth_headers)
+    assert response.status_code == 404
+
+
+def test_get_menu_recipes(client, auth_headers, test_user, db_session):
+    """Test getting recipes in a menu."""
+    menu = Menu(user_id=test_user.id, name="Test Menu")
+    recipe1 = Recipe(name="Recipe 1", source_type="manual", created_by=test_user.id)
+    recipe2 = Recipe(name="Recipe 2", source_type="manual", created_by=test_user.id)
+    db_session.add_all([menu, recipe1, recipe2])
+    db_session.commit()
+
+    mr1 = MenuRecipe(menu_id=menu.id, recipe_id=recipe1.id, sort_order=1)
+    mr2 = MenuRecipe(menu_id=menu.id, recipe_id=recipe2.id, sort_order=0)
+    db_session.add_all([mr1, mr2])
+    db_session.commit()
+
+    response = client.get(f"/menus/{menu.id}/recipes", headers=auth_headers)
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["total"] == 2
+    assert len(data["recipes"]) == 2
+    # Should be sorted by sort_order
+    assert data["recipes"][0]["name"] == "Recipe 2"  # sort_order=0
+    assert data["recipes"][1]["name"] == "Recipe 1"  # sort_order=1
+
+
+def test_get_menu_recipes_excludes_manually_removed(client, auth_headers, test_user, db_session):
+    """Test that manually_removed recipes are excluded from results."""
+    menu = Menu(user_id=test_user.id, name="Test Menu")
+    recipe1 = Recipe(name="Visible", source_type="manual", created_by=test_user.id)
+    recipe2 = Recipe(name="Hidden", source_type="manual", created_by=test_user.id)
+    db_session.add_all([menu, recipe1, recipe2])
+    db_session.commit()
+
+    mr1 = MenuRecipe(menu_id=menu.id, recipe_id=recipe1.id, manually_removed=False)
+    mr2 = MenuRecipe(menu_id=menu.id, recipe_id=recipe2.id, manually_removed=True)
+    db_session.add_all([mr1, mr2])
+    db_session.commit()
+
+    response = client.get(f"/menus/{menu.id}/recipes", headers=auth_headers)
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["total"] == 1
+    assert data["recipes"][0]["name"] == "Visible"
+
+
+def test_add_recipe_to_menu(client, auth_headers, test_user, db_session):
+    """Test adding a recipe to a menu."""
+    menu = Menu(user_id=test_user.id, name="Test Menu")
+    recipe = Recipe(name="Test Recipe", source_type="manual", created_by=test_user.id)
+    db_session.add_all([menu, recipe])
+    db_session.commit()
+
+    add_data = {
+        "recipe_id": str(recipe.id),
+        "sort_order": 0
+    }
+
+    response = client.post(f"/menus/{menu.id}/recipes", json=add_data, headers=auth_headers)
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["recipe_id"] == str(recipe.id)
+    assert data["menu_id"] == str(menu.id)
+
+    # Verify in database
+    menu_recipe = db_session.query(MenuRecipe).filter(
+        MenuRecipe.menu_id == menu.id,
+        MenuRecipe.recipe_id == recipe.id
+    ).first()
+    assert menu_recipe is not None
+
+
+def test_add_recipe_sets_manually_added_if_not_matching_filter(client, auth_headers, test_user, db_session):
+    """Test that manually_added is set when recipe doesn't match filter rules."""
+    # Menu with filter: cook_time <= 30
+    menu = Menu(
+        user_id=test_user.id,
+        name="Quick Meals",
+        filter_rules={
+            "match_logic": "all",
+            "rules": [
+                {"field": "cook_time_minutes", "operator": "<=", "value": 30}
+            ]
+        }
+    )
+    # Recipe with cook_time > 30 (doesn't match filter)
+    recipe = Recipe(name="Slow Recipe", source_type="manual", cook_time_minutes=60, created_by=test_user.id)
+    db_session.add_all([menu, recipe])
+    db_session.commit()
+
+    add_data = {"recipe_id": str(recipe.id), "sort_order": 0}
+
+    response = client.post(f"/menus/{menu.id}/recipes", json=add_data, headers=auth_headers)
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["manually_added"] is True
+
+
+def test_add_recipe_doesnt_set_manually_added_if_matching_filter(client, auth_headers, test_user, db_session):
+    """Test that manually_added is False when recipe matches filter rules."""
+    # Menu with filter: cook_time <= 30
+    menu = Menu(
+        user_id=test_user.id,
+        name="Quick Meals",
+        filter_rules={
+            "match_logic": "all",
+            "rules": [
+                {"field": "cook_time_minutes", "operator": "<=", "value": 30}
+            ]
+        }
+    )
+    # Recipe with cook_time <= 30 (matches filter)
+    recipe = Recipe(name="Quick Recipe", source_type="manual", cook_time_minutes=20, created_by=test_user.id)
+    db_session.add_all([menu, recipe])
+    db_session.commit()
+
+    add_data = {"recipe_id": str(recipe.id), "sort_order": 0}
+
+    response = client.post(f"/menus/{menu.id}/recipes", json=add_data, headers=auth_headers)
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["manually_added"] is False
+
+
+def test_remove_recipe_from_menu_deletes_if_not_matching(client, auth_headers, test_user, db_session):
+    """Test that removing a non-matching recipe deletes the MenuRecipe entry."""
+    menu = Menu(
+        user_id=test_user.id,
+        name="Quick Meals",
+        filter_rules={
+            "match_logic": "all",
+            "rules": [
+                {"field": "cook_time_minutes", "operator": "<=", "value": 30}
+            ]
+        }
+    )
+    # Recipe doesn't match filter (cook_time > 30)
+    recipe = Recipe(name="Slow Recipe", source_type="manual", cook_time_minutes=60, created_by=test_user.id)
+    db_session.add_all([menu, recipe])
+    db_session.commit()
+
+    menu_recipe = MenuRecipe(menu_id=menu.id, recipe_id=recipe.id, manually_added=True)
+    db_session.add(menu_recipe)
+    db_session.commit()
+
+    response = client.delete(f"/menus/{menu.id}/recipes/{recipe.id}", headers=auth_headers)
+    assert response.status_code == 204
+
+    # Verify entry is deleted
+    menu_recipe = db_session.query(MenuRecipe).filter(
+        MenuRecipe.menu_id == menu.id,
+        MenuRecipe.recipe_id == recipe.id
+    ).first()
+    assert menu_recipe is None
+
+
+def test_remove_recipe_from_menu_sets_manually_removed_if_matching(client, auth_headers, test_user, db_session):
+    """Test that removing a matching recipe sets manually_removed instead of deleting."""
+    menu = Menu(
+        user_id=test_user.id,
+        name="Quick Meals",
+        filter_rules={
+            "match_logic": "all",
+            "rules": [
+                {"field": "cook_time_minutes", "operator": "<=", "value": 30}
+            ]
+        }
+    )
+    # Recipe matches filter (cook_time <= 30)
+    recipe = Recipe(name="Quick Recipe", source_type="manual", cook_time_minutes=20, created_by=test_user.id)
+    db_session.add_all([menu, recipe])
+    db_session.commit()
+
+    menu_recipe = MenuRecipe(menu_id=menu.id, recipe_id=recipe.id, manually_added=False)
+    db_session.add(menu_recipe)
+    db_session.commit()
+
+    response = client.delete(f"/menus/{menu.id}/recipes/{recipe.id}", headers=auth_headers)
+    assert response.status_code == 204
+
+    # Verify entry still exists but manually_removed is True
+    db_session.refresh(menu_recipe)
+    assert menu_recipe.manually_removed is True
+
+
+def test_auto_generate_menus_from_patterns(client, auth_headers, test_user, db_session):
+    """Test POST /menus/generate creates auto-generated menus from user patterns."""
+    # Create recipes with tags
+    recipe1 = Recipe(name="Pasta 1", source_type="manual", tags=["italian", "pasta"], created_by=test_user.id, is_persisted=True)
+    recipe2 = Recipe(name="Pasta 2", source_type="manual", tags=["italian", "pasta"], created_by=test_user.id, is_persisted=True)
+    recipe3 = Recipe(name="Pasta 3", source_type="manual", tags=["italian", "pasta"], created_by=test_user.id, is_persisted=True)
+    recipe4 = Recipe(name="Curry 1", source_type="manual", tags=["indian", "curry"], created_by=test_user.id, is_persisted=True)
+    db_session.add_all([recipe1, recipe2, recipe3, recipe4])
+    db_session.commit()
+
+    # Create UserRecipeRelation entries (saved recipes)
+    for recipe in [recipe1, recipe2, recipe3]:
+        relation = UserRecipeRelation(user_id=test_user.id, recipe_id=recipe.id, is_bookmarked=True)
+        db_session.add(relation)
+    db_session.commit()
+
+    # Generate menus (min_saves=3, so "italian" and "pasta" should both qualify)
+    request_data = {"min_saves": 3, "max_menus": 4}
+    response = client.post("/menus/generate", json=request_data, headers=auth_headers)
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["total_generated"] >= 1  # At least one tag with >= 3 saves
+    assert len(data["generated_menus"]) >= 1
+
+    # Check first menu
+    menu = data["generated_menus"][0]
+    assert menu["is_auto_generated"] is True
+    # Tag names should be capitalized with period
+    assert menu["name"] in ["Italian.", "Pasta."]
+
+    # Verify filter rules were created
+    assert menu["filter_rules"] is not None
+    assert menu["filter_rules"]["rules"][0]["field"] == "tags"
+    assert menu["filter_rules"]["rules"][0]["value"] in ["italian", "pasta"]
+
+
+def test_auto_generate_menus_populates_with_saved_recipes(client, auth_headers, test_user, db_session):
+    """Test that auto-generated menus are populated with matching saved recipes."""
+    # Create recipes with tags
+    recipe1 = Recipe(name="Italian 1", source_type="manual", tags=["italian"], created_by=test_user.id, is_persisted=True)
+    recipe2 = Recipe(name="Italian 2", source_type="manual", tags=["italian"], created_by=test_user.id, is_persisted=True)
+    recipe3 = Recipe(name="Italian 3", source_type="manual", tags=["italian"], created_by=test_user.id, is_persisted=True)
+    db_session.add_all([recipe1, recipe2, recipe3])
+    db_session.commit()
+
+    # Create UserRecipeRelation entries (saved with bookmarks)
+    for recipe in [recipe1, recipe2, recipe3]:
+        relation = UserRecipeRelation(user_id=test_user.id, recipe_id=recipe.id, is_bookmarked=True)
+        db_session.add(relation)
+    db_session.commit()
+
+    # Generate menus
+    request_data = {"min_saves": 3, "max_menus": 4}
+    response = client.post("/menus/generate", json=request_data, headers=auth_headers)
+    assert response.status_code == 201
+
+    menu_id = response.json()["generated_menus"][0]["id"]
+
+    # Check that menu was populated with recipes
+    response = client.get(f"/menus/{menu_id}/recipes", headers=auth_headers)
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["total"] == 3
+    recipe_names = [r["name"] for r in data["recipes"]]
+    assert "Italian 1" in recipe_names
+    assert "Italian 2" in recipe_names
+    assert "Italian 3" in recipe_names
+
+
+def test_filter_evaluation_tags_contains(client, auth_headers, test_user, db_session):
+    """Test filter rule evaluation: tags contains."""
+    menu = Menu(
+        user_id=test_user.id,
+        name="Italian Menu",
+        filter_rules={
+            "match_logic": "all",
+            "rules": [{"field": "tags", "operator": "contains", "value": "italian"}]
+        }
+    )
+    matching_recipe = Recipe(name="Pasta", source_type="manual", tags=["italian", "pasta"], created_by=test_user.id)
+    non_matching_recipe = Recipe(name="Curry", source_type="manual", tags=["indian"], created_by=test_user.id)
+    db_session.add_all([menu, matching_recipe, non_matching_recipe])
+    db_session.commit()
+
+    # Add matching recipe - should have manually_added=False
+    response = client.post(
+        f"/menus/{menu.id}/recipes",
+        json={"recipe_id": str(matching_recipe.id)},
+        headers=auth_headers
+    )
+    assert response.status_code == 201
+    assert response.json()["manually_added"] is False
+
+    # Add non-matching recipe - should have manually_added=True
+    response = client.post(
+        f"/menus/{menu.id}/recipes",
+        json={"recipe_id": str(non_matching_recipe.id)},
+        headers=auth_headers
+    )
+    assert response.status_code == 201
+    assert response.json()["manually_added"] is True
+
+
+def test_filter_evaluation_source_type_eq(client, auth_headers, test_user, db_session):
+    """Test filter rule evaluation: source_type eq."""
+    menu = Menu(
+        user_id=test_user.id,
+        name="HelloFresh Menu",
+        filter_rules={
+            "match_logic": "all",
+            "rules": [{"field": "source_type", "operator": "eq", "value": "hellofresh_card"}]
+        }
+    )
+    matching_recipe = Recipe(name="HF Recipe", source_type="hellofresh_card", created_by=test_user.id)
+    non_matching_recipe = Recipe(name="Manual Recipe", source_type="manual", created_by=test_user.id)
+    db_session.add_all([menu, matching_recipe, non_matching_recipe])
+    db_session.commit()
+
+    # Add matching recipe
+    response = client.post(
+        f"/menus/{menu.id}/recipes",
+        json={"recipe_id": str(matching_recipe.id)},
+        headers=auth_headers
+    )
+    assert response.status_code == 201
+    assert response.json()["manually_added"] is False
+
+    # Add non-matching recipe
+    response = client.post(
+        f"/menus/{menu.id}/recipes",
+        json={"recipe_id": str(non_matching_recipe.id)},
+        headers=auth_headers
+    )
+    assert response.status_code == 201
+    assert response.json()["manually_added"] is True
+
+
+def test_filter_evaluation_cook_time_lte(client, auth_headers, test_user, db_session):
+    """Test filter rule evaluation: cook_time_minutes <=."""
+    menu = Menu(
+        user_id=test_user.id,
+        name="Quick Meals",
+        filter_rules={
+            "match_logic": "all",
+            "rules": [{"field": "cook_time_minutes", "operator": "<=", "value": 30}]
+        }
+    )
+    matching_recipe = Recipe(name="Quick Recipe", source_type="manual", cook_time_minutes=20, created_by=test_user.id)
+    non_matching_recipe = Recipe(name="Slow Recipe", source_type="manual", cook_time_minutes=60, created_by=test_user.id)
+    db_session.add_all([menu, matching_recipe, non_matching_recipe])
+    db_session.commit()
+
+    # Add matching recipe
+    response = client.post(
+        f"/menus/{menu.id}/recipes",
+        json={"recipe_id": str(matching_recipe.id)},
+        headers=auth_headers
+    )
+    assert response.status_code == 201
+    assert response.json()["manually_added"] is False
+
+    # Add non-matching recipe
+    response = client.post(
+        f"/menus/{menu.id}/recipes",
+        json={"recipe_id": str(non_matching_recipe.id)},
+        headers=auth_headers
+    )
+    assert response.status_code == 201
+    assert response.json()["manually_added"] is True
+
+
+def test_filter_evaluation_match_logic_all(client, auth_headers, test_user, db_session):
+    """Test filter rule evaluation: match_logic 'all' (AND)."""
+    menu = Menu(
+        user_id=test_user.id,
+        name="Quick Italian",
+        filter_rules={
+            "match_logic": "all",
+            "rules": [
+                {"field": "tags", "operator": "contains", "value": "italian"},
+                {"field": "cook_time_minutes", "operator": "<=", "value": 30}
+            ]
+        }
+    )
+    # Matches both rules
+    matching_recipe = Recipe(
+        name="Quick Pasta",
+        source_type="manual",
+        tags=["italian"],
+        cook_time_minutes=20,
+        created_by=test_user.id
+    )
+    # Matches only one rule (italian but > 30 minutes)
+    non_matching_recipe = Recipe(
+        name="Slow Pasta",
+        source_type="manual",
+        tags=["italian"],
+        cook_time_minutes=60,
+        created_by=test_user.id
+    )
+    db_session.add_all([menu, matching_recipe, non_matching_recipe])
+    db_session.commit()
+
+    # Add matching recipe
+    response = client.post(
+        f"/menus/{menu.id}/recipes",
+        json={"recipe_id": str(matching_recipe.id)},
+        headers=auth_headers
+    )
+    assert response.status_code == 201
+    assert response.json()["manually_added"] is False
+
+    # Add non-matching recipe (only matches 1 of 2 rules with AND logic)
+    response = client.post(
+        f"/menus/{menu.id}/recipes",
+        json={"recipe_id": str(non_matching_recipe.id)},
+        headers=auth_headers
+    )
+    assert response.status_code == 201
+    assert response.json()["manually_added"] is True
+
+
+def test_filter_evaluation_match_logic_any(client, auth_headers, test_user, db_session):
+    """Test filter rule evaluation: match_logic 'any' (OR)."""
+    menu = Menu(
+        user_id=test_user.id,
+        name="Italian or Quick",
+        filter_rules={
+            "match_logic": "any",
+            "rules": [
+                {"field": "tags", "operator": "contains", "value": "italian"},
+                {"field": "cook_time_minutes", "operator": "<=", "value": 30}
+            ]
+        }
+    )
+    # Matches first rule only
+    matching_recipe1 = Recipe(
+        name="Slow Pasta",
+        source_type="manual",
+        tags=["italian"],
+        cook_time_minutes=60,
+        created_by=test_user.id
+    )
+    # Matches second rule only
+    matching_recipe2 = Recipe(
+        name="Quick Curry",
+        source_type="manual",
+        tags=["indian"],
+        cook_time_minutes=20,
+        created_by=test_user.id
+    )
+    # Matches neither rule
+    non_matching_recipe = Recipe(
+        name="Slow Curry",
+        source_type="manual",
+        tags=["indian"],
+        cook_time_minutes=60,
+        created_by=test_user.id
+    )
+    db_session.add_all([menu, matching_recipe1, matching_recipe2, non_matching_recipe])
+    db_session.commit()
+
+    # Add matching recipe 1
+    response = client.post(
+        f"/menus/{menu.id}/recipes",
+        json={"recipe_id": str(matching_recipe1.id)},
+        headers=auth_headers
+    )
+    assert response.status_code == 201
+    assert response.json()["manually_added"] is False
+
+    # Add matching recipe 2
+    response = client.post(
+        f"/menus/{menu.id}/recipes",
+        json={"recipe_id": str(matching_recipe2.id)},
+        headers=auth_headers
+    )
+    assert response.status_code == 201
+    assert response.json()["manually_added"] is False
+
+    # Add non-matching recipe
+    response = client.post(
+        f"/menus/{menu.id}/recipes",
+        json={"recipe_id": str(non_matching_recipe.id)},
+        headers=auth_headers
+    )
+    assert response.status_code == 201
+    assert response.json()["manually_added"] is True
+
+
+def test_manual_overrides_respected_in_autogeneration(client, auth_headers, test_user, db_session):
+    """Test that manually_removed recipes are excluded and manually_added recipes are kept during auto-generation."""
+    # Create recipes with italian tag
+    recipe1 = Recipe(name="Italian 1", source_type="manual", tags=["italian"], created_by=test_user.id, is_persisted=True)
+    recipe2 = Recipe(name="Italian 2", source_type="manual", tags=["italian"], created_by=test_user.id, is_persisted=True)
+    recipe3 = Recipe(name="Italian 3", source_type="manual", tags=["italian"], created_by=test_user.id, is_persisted=True)
+    recipe4 = Recipe(name="Non-Italian", source_type="manual", tags=["indian"], created_by=test_user.id, is_persisted=True)
+    db_session.add_all([recipe1, recipe2, recipe3, recipe4])
+    db_session.commit()
+
+    # Save all recipes
+    for recipe in [recipe1, recipe2, recipe3]:
+        relation = UserRecipeRelation(user_id=test_user.id, recipe_id=recipe.id, is_bookmarked=True)
+        db_session.add(relation)
+    db_session.commit()
+
+    # Generate menu
+    response = client.post("/menus/generate", json={"min_saves": 3}, headers=auth_headers)
+    menu_id = response.json()["generated_menus"][0]["id"]
+
+    # Verify menu has all 3 italian recipes
+    response = client.get(f"/menus/{menu_id}/recipes", headers=auth_headers)
+    assert response.json()["total"] == 3
+
+    # Manually remove recipe2
+    response = client.delete(f"/menus/{menu_id}/recipes/{recipe2.id}", headers=auth_headers)
+    assert response.status_code == 204
+
+    # Manually add recipe4 (doesn't match filter)
+    response = client.post(
+        f"/menus/{menu_id}/recipes",
+        json={"recipe_id": str(recipe4.id)},
+        headers=auth_headers
+    )
+    assert response.status_code == 201
+
+    # Verify current state
+    response = client.get(f"/menus/{menu_id}/recipes", headers=auth_headers)
+    data = response.json()
+    recipe_names = [r["name"] for r in data["recipes"]]
+    assert "Italian 1" in recipe_names
+    assert "Italian 2" not in recipe_names  # manually removed
+    assert "Italian 3" in recipe_names
+    assert "Non-Italian" in recipe_names  # manually added

--- a/tests/routers/test_recipes.py
+++ b/tests/routers/test_recipes.py
@@ -1279,8 +1279,8 @@ class TestRecipeRatings:
         """Test creating a new rating for a recipe."""
         rating_data = {
             "rating": 4.5,
-            "is_favorite": True,
-            "notes": "Delicious recipe!",
+            "is_bookmarked": True,
+            "rating_comment": "Delicious recipe!",
         }
 
         response = client.post(
@@ -1292,16 +1292,16 @@ class TestRecipeRatings:
         assert response.status_code == 200
         data = response.json()
         assert data["rating"] == 4.5
-        assert data["is_favorite"] is True
-        assert data["notes"] == "Delicious recipe!"
+        assert data["is_bookmarked"] is True
+        assert data["rating_comment"] == "Delicious recipe!"
         assert data["user_id"] == str(test_user.id)
         assert data["recipe_id"] == str(test_recipe.id)
         assert "id" in data
 
     def test_create_rating_minimal_fields(self, client, auth_headers, test_recipe, test_user):
-        """Test creating rating with only is_favorite (no rating value or notes)."""
+        """Test creating rating with only is_bookmarked (no rating value or comment)."""
         rating_data = {
-            "is_favorite": True,
+            "is_bookmarked": True,
         }
 
         response = client.post(
@@ -1313,16 +1313,16 @@ class TestRecipeRatings:
         assert response.status_code == 200
         data = response.json()
         assert data["rating"] is None
-        assert data["is_favorite"] is True
-        assert data["notes"] is None
+        assert data["is_bookmarked"] is True
+        assert data["rating_comment"] is None
 
     def test_update_rating_upsert(self, client, auth_headers, test_recipe, test_user, db_session):
         """Test updating an existing rating (upsert behavior)."""
         # Create initial rating
         rating_data = {
             "rating": 3.0,
-            "is_favorite": False,
-            "notes": "Initial note",
+            "is_bookmarked": False,
+            "rating_comment": "Initial note",
         }
 
         response = client.post(
@@ -1336,8 +1336,8 @@ class TestRecipeRatings:
         # Update the rating (same endpoint, different data)
         update_data = {
             "rating": 5.0,
-            "is_favorite": True,
-            "notes": "Updated note - much better!",
+            "is_bookmarked": True,
+            "rating_comment": "Updated note - much better!",
         }
 
         response = client.post(
@@ -1350,14 +1350,14 @@ class TestRecipeRatings:
         data = response.json()
         assert data["id"] == initial_id  # Same ID (updated, not created)
         assert data["rating"] == 5.0
-        assert data["is_favorite"] is True
-        assert data["notes"] == "Updated note - much better!"
+        assert data["is_bookmarked"] is True
+        assert data["rating_comment"] == "Updated note - much better!"
 
         # Verify only one rating exists in database
-        from src.db.models.user_recipe import UserRecipeRating
-        ratings = db_session.query(UserRecipeRating).filter(
-            UserRecipeRating.user_id == test_user.id,
-            UserRecipeRating.recipe_id == test_recipe.id,
+        from src.db.models.user_recipe import UserRecipeRelation
+        ratings = db_session.query(UserRecipeRelation).filter(
+            UserRecipeRelation.user_id == test_user.id,
+            UserRecipeRelation.recipe_id == test_recipe.id,
         ).all()
         assert len(ratings) == 1
 
@@ -1365,7 +1365,7 @@ class TestRecipeRatings:
         """Test creating rating for non-existent recipe returns 404."""
         rating_data = {
             "rating": 4.0,
-            "is_favorite": False,
+            "is_bookmarked": False,
         }
 
         fake_recipe_id = uuid4()
@@ -1382,7 +1382,7 @@ class TestRecipeRatings:
         """Test creating rating without auth returns 401."""
         rating_data = {
             "rating": 4.0,
-            "is_favorite": False,
+            "is_bookmarked": False,
         }
 
         response = client.post(
@@ -1396,7 +1396,7 @@ class TestRecipeRatings:
         """Test creating rating with value > 5.0 fails validation."""
         rating_data = {
             "rating": 5.5,
-            "is_favorite": False,
+            "is_bookmarked": False,
         }
 
         response = client.post(
@@ -1414,7 +1414,7 @@ class TestRecipeRatings:
         """Test creating rating with value < 0.0 fails validation."""
         rating_data = {
             "rating": -1.0,
-            "is_favorite": False,
+            "is_bookmarked": False,
         }
 
         response = client.post(
@@ -1430,7 +1430,7 @@ class TestRecipeRatings:
     def test_create_rating_boundary_values(self, client, auth_headers, test_recipe, db_session):
         """Test creating ratings with boundary values (0.0 and 5.0)."""
         # Test 0.0 (minimum valid)
-        rating_data = {"rating": 0.0, "is_favorite": False}
+        rating_data = {"rating": 0.0, "is_bookmarked": False}
         response = client.post(
             f"/recipes/{test_recipe.id}/rate",
             json=rating_data,
@@ -1440,7 +1440,7 @@ class TestRecipeRatings:
         assert response.json()["rating"] == 0.0
 
         # Test 5.0 (maximum valid) - updates existing rating
-        rating_data = {"rating": 5.0, "is_favorite": True}
+        rating_data = {"rating": 5.0, "is_bookmarked": True}
         response = client.post(
             f"/recipes/{test_recipe.id}/rate",
             json=rating_data,
@@ -1452,14 +1452,14 @@ class TestRecipeRatings:
     def test_get_my_rating_success(self, client, auth_headers, test_recipe, test_user, db_session):
         """Test getting user's own rating for a recipe."""
         # Create a rating first
-        from src.db.models.user_recipe import UserRecipeRating
-        rating = UserRecipeRating(
+        from src.db.models.user_recipe import UserRecipeRelation
+        rating = UserRecipeRelation(
             id=uuid4(),
             user_id=test_user.id,
             recipe_id=test_recipe.id,
             rating=4.0,
-            is_favorite=True,
-            notes="My rating",
+            is_bookmarked=True,
+            rating_comment="My rating",
         )
         db_session.add(rating)
         db_session.commit()
@@ -1472,8 +1472,8 @@ class TestRecipeRatings:
         assert response.status_code == 200
         data = response.json()
         assert data["rating"] == 4.0
-        assert data["is_favorite"] is True
-        assert data["notes"] == "My rating"
+        assert data["is_bookmarked"] is True
+        assert data["rating_comment"] == "My rating"
         assert data["user_id"] == str(test_user.id)
 
     def test_get_my_rating_not_found(self, client, auth_headers, test_recipe):
@@ -1506,13 +1506,13 @@ class TestRecipeRatings:
     def test_delete_my_rating_success(self, client, auth_headers, test_recipe, test_user, db_session):
         """Test deleting user's rating successfully."""
         # Create a rating first
-        from src.db.models.user_recipe import UserRecipeRating
-        rating = UserRecipeRating(
+        from src.db.models.user_recipe import UserRecipeRelation
+        rating = UserRecipeRelation(
             id=uuid4(),
             user_id=test_user.id,
             recipe_id=test_recipe.id,
             rating=3.5,
-            is_favorite=False,
+            is_bookmarked=False,
         )
         db_session.add(rating)
         db_session.commit()
@@ -1526,8 +1526,8 @@ class TestRecipeRatings:
         assert response.status_code == 204
 
         # Verify rating is deleted
-        deleted_rating = db_session.query(UserRecipeRating).filter(
-            UserRecipeRating.id == rating_id
+        deleted_rating = db_session.query(UserRecipeRelation).filter(
+            UserRecipeRelation.id == rating_id
         ).first()
         assert deleted_rating is None
 
@@ -1572,13 +1572,13 @@ class TestRecipeRatings:
 
     def test_get_aggregate_ratings_single_rating(self, client, auth_headers, test_recipe, test_user, db_session):
         """Test aggregate ratings with one rating."""
-        from src.db.models.user_recipe import UserRecipeRating
-        rating = UserRecipeRating(
+        from src.db.models.user_recipe import UserRecipeRelation
+        rating = UserRecipeRelation(
             id=uuid4(),
             user_id=test_user.id,
             recipe_id=test_recipe.id,
             rating=4.0,
-            is_favorite=True,
+            is_bookmarked=True,
         )
         db_session.add(rating)
         db_session.commit()
@@ -1596,24 +1596,24 @@ class TestRecipeRatings:
 
     def test_get_aggregate_ratings_multiple_ratings(self, client, auth_headers, test_recipe, test_user, test_user2, db_session):
         """Test aggregate ratings with multiple users' ratings."""
-        from src.db.models.user_recipe import UserRecipeRating
+        from src.db.models.user_recipe import UserRecipeRelation
 
         # User 1 rating
-        rating1 = UserRecipeRating(
+        rating1 = UserRecipeRelation(
             id=uuid4(),
             user_id=test_user.id,
             recipe_id=test_recipe.id,
             rating=4.0,
-            is_favorite=True,
+            is_bookmarked=True,
         )
 
         # User 2 rating
-        rating2 = UserRecipeRating(
+        rating2 = UserRecipeRelation(
             id=uuid4(),
             user_id=test_user2.id,
             recipe_id=test_recipe.id,
             rating=5.0,
-            is_favorite=False,
+            is_bookmarked=False,
         )
 
         db_session.add_all([rating1, rating2])
@@ -1632,13 +1632,13 @@ class TestRecipeRatings:
 
     def test_get_aggregate_ratings_favorite_only(self, client, auth_headers, test_recipe, test_user, db_session):
         """Test aggregate ratings when user only favorited (no rating value)."""
-        from src.db.models.user_recipe import UserRecipeRating
-        rating = UserRecipeRating(
+        from src.db.models.user_recipe import UserRecipeRelation
+        rating = UserRecipeRelation(
             id=uuid4(),
             user_id=test_user.id,
             recipe_id=test_recipe.id,
             rating=None,  # No rating value
-            is_favorite=True,
+            is_bookmarked=True,
         )
         db_session.add(rating)
         db_session.commit()
@@ -1656,24 +1656,24 @@ class TestRecipeRatings:
 
     def test_get_aggregate_ratings_mixed_null_ratings(self, client, auth_headers, test_recipe, test_user, test_user2, db_session):
         """Test aggregate ratings with mix of null and numeric ratings."""
-        from src.db.models.user_recipe import UserRecipeRating
+        from src.db.models.user_recipe import UserRecipeRelation
 
         # User 1: numeric rating
-        rating1 = UserRecipeRating(
+        rating1 = UserRecipeRelation(
             id=uuid4(),
             user_id=test_user.id,
             recipe_id=test_recipe.id,
             rating=4.0,
-            is_favorite=False,
+            is_bookmarked=False,
         )
 
         # User 2: favorite only (no rating)
-        rating2 = UserRecipeRating(
+        rating2 = UserRecipeRelation(
             id=uuid4(),
             user_id=test_user2.id,
             recipe_id=test_recipe.id,
             rating=None,
-            is_favorite=True,
+            is_bookmarked=True,
         )
 
         db_session.add_all([rating1, rating2])
@@ -1709,13 +1709,13 @@ class TestRecipeRatings:
 
     def test_ratings_cross_user_isolation(self, client, auth_headers, auth_headers2, test_recipe, test_user, test_user2, db_session):
         """Test that each user has separate ratings for the same recipe."""
-        from src.db.models.user_recipe import UserRecipeRating
+        from src.db.models.user_recipe import UserRecipeRelation
 
         # User 1 creates rating
         rating_data = {
             "rating": 3.0,
-            "is_favorite": False,
-            "notes": "User 1 note",
+            "is_bookmarked": False,
+            "rating_comment": "User 1 note",
         }
         response = client.post(
             f"/recipes/{test_recipe.id}/rate",
@@ -1727,8 +1727,8 @@ class TestRecipeRatings:
         # User 2 creates different rating
         rating_data2 = {
             "rating": 5.0,
-            "is_favorite": True,
-            "notes": "User 2 note",
+            "is_bookmarked": True,
+            "rating_comment": "User 2 note",
         }
         response = client.post(
             f"/recipes/{test_recipe.id}/rate",
@@ -1745,7 +1745,7 @@ class TestRecipeRatings:
         assert response.status_code == 200
         data = response.json()
         assert data["rating"] == 3.0
-        assert data["notes"] == "User 1 note"
+        assert data["rating_comment"] == "User 1 note"
 
         # User 2 gets their rating
         response = client.get(
@@ -1755,11 +1755,11 @@ class TestRecipeRatings:
         assert response.status_code == 200
         data = response.json()
         assert data["rating"] == 5.0
-        assert data["notes"] == "User 2 note"
+        assert data["rating_comment"] == "User 2 note"
 
         # Verify two separate ratings exist in database
-        ratings = db_session.query(UserRecipeRating).filter(
-            UserRecipeRating.recipe_id == test_recipe.id
+        ratings = db_session.query(UserRecipeRelation).filter(
+            UserRecipeRelation.recipe_id == test_recipe.id
         ).all()
         assert len(ratings) == 2
 


### PR DESCRIPTION
## Work in Progress

Closes #480

[Phase 2.5D] Implement auto-generated menus

**Time Estimate**: 2hr

**Description**:
Implement auto-generated menu creation from behavioral patterns and filter rule evaluation. Menus auto-populate from user's saves matching filter rules.

**Claude Context**:
Files to Read:
- src/services/menu_service.py (CRUD from #13)
- src/services/feed_service.py (pattern detection from #12)
- docs/implementation-plan-recipe-engagement.md (Section 1.2 filter rule schema, Section 3.6)

Files to Modify:
- src/services/menu_service.py (add generation and evaluation functions)
- src/routers/menus.py (add generate endpoint)
- tests/routers/test_menus.py (add auto-generation tests)

Related Issues: #12 (reuse pattern detection), #13 (needs menu CRUD)

**Acceptance Criteria**:
- [ ] `POST /menus/generate` creates auto-generated menus from user's patterns (>=3 saves)
- [ ] Filter rule evaluation: supports tags (contains/not_contains), source_type (eq/in), cook_time_minutes (<=/>=/eq)
- [ ] Match logic: `all` = AND, `any` = OR across rules
- [ ] Auto menus populated with user's bookmarked+liked recipes matching rules
- [ ] Manual overrides respected: manually_added recipes stay, manually_removed recipes excluded
- [ ] Auto menu titles follow pattern: "Indian cuisine.", "Quick meals.", etc.
- [ ] `is_auto_generated=true` on created menus
- [ ] Tests: generate menus from patterns, filter evaluation, manual overrides

**Verification Commands**:
```bash
.venv/bin/python -m pytest tests/routers/test_menus.py::test_auto -x -q
```

**Done Definition**: Done when auto-generated menus are created from patterns and filter rules evaluate correctly.

**Scope Boundary**:
- DO: Implement generation, filter evaluation
- DO NOT: Implement homepage rotation (frontend concern)

**Dependencies**: After #12 (needs: pattern detection), After #13 (needs: menu CRUD)

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**21** files, **10** commits (+8 added, ~13 modified, -0 deleted)
- `A` alembic/versions/oi0jpexw8quw_add_is_persisted_to_recipes.py
- `A` alembic/versions/pj1kqfxy9rvw_rename_user_recipe_rating_to_relation.py
- `A` alembic/versions/qk2lrgyz0swx_create_menu_and_menu_recipe_tables.py
- `M` src/db/models/__init__.py
- `A` src/db/models/menu.py
- `M` src/db/models/recipe.py
- `M` src/db/models/user.py
- `M` src/db/models/user_recipe.py
- `M` src/main.py
- `M` src/routers/__init__.py
- `A` src/routers/menus.py
- `M` src/routers/recipes.py
- `A` src/schemas/menu.py
- `M` src/schemas/recipe.py
- `M` src/services/cleanup_service.py
- `M` src/services/feed_service.py
- `A` src/services/menu_service.py
- `M` tests/routers/test_feed.py
- `A` tests/routers/test_menus.py
- `M` tests/routers/test_recipes.py
- `M` tests/services/test_cleanup_service.py

### Commits
- 4f1822d feat: [Phase 2.5D] Implement auto-generated menus
- 29085b4 Merge branch 'feat/phase-25a-create-menu-and-menurecipe-models' into feat/phase-25d-implement-auto-generated-menus
- 5a692d6 fix: address remaining review MEDs from PR #482
- 87e31c0 chore: initialize work on #480 [Phase 2.5D] Implement auto-generated menus
- 20ffdd1 Merge branch 'main' into feat/phase-25a-create-menu-and-menurecipe-models
- 7345f38 fix: address review findings from PR automated review
- 6f20878 fix: address review findings from PR automated review
- c718105 fix: address review findings from PR automated review
- c61fc33 feat: [Phase 2.5A] Create Menu and MenuRecipe models
- 42fa78b chore: initialize work on #473 [Phase 2.5A] Create Menu and MenuRecipe models
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues
 Updated: #497  Updated: #497 
**From assessment on 2026-05-04T00:16:19Z:**
- Created: #497 
- Updated: none